### PR TITLE
feat: Add ability to utilize multiple htmx configurations

### DIFF
--- a/samples/HtmxBlazorSSR/Program.cs
+++ b/samples/HtmxBlazorSSR/Program.cs
@@ -14,15 +14,15 @@ builder.Services.AddScoped<ContactsRepository>();
 builder.Services.AddFlashMessages();
 
 builder.AddHtmxor()
-	.WithDefaultConfiguration(config =>
-	{
-		config.SelfRequestsOnly = true;
-	})
-	.WithNamedConfiguration("articles", config =>
-	{
-		config.SelfRequestsOnly = true;
-		config.GlobalViewTransitions = true;
-	});
+    .WithDefaultConfiguration(config =>
+    {
+        config.SelfRequestsOnly = true;
+    })
+    .WithNamedConfiguration("articles", config =>
+    {
+        config.SelfRequestsOnly = true;
+        config.GlobalViewTransitions = true;
+    });
 
 var app = builder.Build();
 

--- a/samples/HtmxBlazorSSR/Program.cs
+++ b/samples/HtmxBlazorSSR/Program.cs
@@ -13,7 +13,7 @@ builder.Services.AddScoped<DiskStorage>();
 builder.Services.AddScoped<ContactsRepository>();
 builder.Services.AddFlashMessages();
 
-builder.AddHtmx()
+builder.AddHtmxor()
 	.WithDefaultConfiguration(config =>
 	{
 		config.SelfRequestsOnly = true;

--- a/samples/HtmxBlazorSSR/Program.cs
+++ b/samples/HtmxBlazorSSR/Program.cs
@@ -13,10 +13,16 @@ builder.Services.AddScoped<DiskStorage>();
 builder.Services.AddScoped<ContactsRepository>();
 builder.Services.AddFlashMessages();
 
-builder.AddHtmx(config =>
-{
-    config.SelfRequestsOnly = true;
-});
+builder.AddHtmx()
+	.WithDefaultConfiguration(config =>
+	{
+		config.SelfRequestsOnly = true;
+	})
+	.WithNamedConfiguration("articles", config =>
+	{
+		config.SelfRequestsOnly = true;
+		config.GlobalViewTransitions = true;
+	});
 
 var app = builder.Build();
 

--- a/src/Htmxor/Antiforgery/HtmxAntiforgeryMiddleware.cs
+++ b/src/Htmxor/Antiforgery/HtmxAntiforgeryMiddleware.cs
@@ -1,13 +1,14 @@
 ﻿using Htmxor.Configuration;
 using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 
 namespace Htmxor.Antiforgery;
 
 /// <summary>
 /// This will add a HX-XSRF-TOKEN to each response, no matter if it was initiated by HTMX or not.
 /// </summary>
-public sealed class HtmxAntiforgeryMiddleware(IAntiforgery antiforgery, HtmxConfig htmxConfig, RequestDelegate next)
+public sealed class HtmxAntiforgeryMiddleware(IAntiforgery antiforgery, IOptions<HtmxAntiforgeryOptions> antiforgeryConfig, RequestDelegate next)
 {
     private static readonly CookieOptions cookieOptions = new CookieOptions
     {
@@ -18,10 +19,10 @@ public sealed class HtmxAntiforgeryMiddleware(IAntiforgery antiforgery, HtmxConf
 
     public async Task Invoke(HttpContext context)
     {
-        if (htmxConfig.Antiforgery is not null)
+        if (antiforgeryConfig.Value.IncludeAntiForgery)
         {
             var tokens = antiforgery.GetAndStoreTokens(context);
-            context.Response.Cookies.Append(htmxConfig.Antiforgery.CookieName, tokens.RequestToken!, cookieOptions);
+            context.Response.Cookies.Append(antiforgeryConfig.Value.CookieName, tokens.RequestToken!, cookieOptions);
             await next.Invoke(context);
         }
     }

--- a/src/Htmxor/Antiforgery/HtmxAntiforgeryOptions.cs
+++ b/src/Htmxor/Antiforgery/HtmxAntiforgeryOptions.cs
@@ -5,8 +5,8 @@ namespace Htmxor.Antiforgery;
 
 public class HtmxAntiforgeryOptions
 {
-	public bool IncludeAntiForgery { get; set; }
-    public string FormFieldName { get; set; } 
-	public string? HeaderName { get; set; }
+    public bool IncludeAntiForgery { get; set; }
+    public string FormFieldName { get; set; }
+    public string? HeaderName { get; set; }
     public string CookieName { get; set; }
 }

--- a/src/Htmxor/Antiforgery/HtmxAntiforgeryOptions.cs
+++ b/src/Htmxor/Antiforgery/HtmxAntiforgeryOptions.cs
@@ -3,11 +3,10 @@ using Microsoft.Extensions.Options;
 
 namespace Htmxor.Antiforgery;
 
-public class HtmxAntiforgeryOptions(IOptions<AntiforgeryOptions> antiforgeryOptions)
+public class HtmxAntiforgeryOptions
 {
-    public string FormFieldName { get; } = antiforgeryOptions.Value.FormFieldName;
-
-    public string? HeaderName { get; } = antiforgeryOptions.Value.HeaderName;
-
-    public string CookieName { get; } = "HX-XSRF-TOKEN";
+	public bool IncludeAntiForgery { get; set; }
+    public string FormFieldName { get; set; } 
+	public string? HeaderName { get; set; }
+    public string CookieName { get; set; }
 }

--- a/src/Htmxor/Configuration/HtmxConfig.cs
+++ b/src/Htmxor/Configuration/HtmxConfig.cs
@@ -221,5 +221,5 @@ public record class HtmxConfig
     public bool? ScrollIntoViewOnBoost { get; set; }
 
     [JsonInclude]
-    internal HtmxAntiforgeryOptions? Antiforgery { get; init; }
+    internal HtmxAntiforgeryOptions? Antiforgery { get; set; }
 }

--- a/src/Htmxor/Configuration/HtmxConfigHeadOutlet.cs
+++ b/src/Htmxor/Configuration/HtmxConfigHeadOutlet.cs
@@ -6,7 +6,7 @@ namespace Htmxor.Configuration;
 
 public class HtmxConfigHeadOutlet : IComponent
 {
-	private string _jsonConfig = string.Empty;
+    private string _jsonConfig = string.Empty;
 
     [Inject] private IOptionsSnapshot<HtmxConfig> Options { get; set; } = default!;
 
@@ -25,13 +25,13 @@ public class HtmxConfigHeadOutlet : IComponent
 
     public Task SetParametersAsync(ParameterView parameters)
     {
-	    Configuration = parameters.GetValueOrDefault<string?>("Configuration");
+        Configuration = parameters.GetValueOrDefault<string?>("Configuration");
 
-	    var config = string.IsNullOrEmpty(Configuration) ? 
-		    Options.Value : Options.Get(Configuration);
+        var config = string.IsNullOrEmpty(Configuration) ?
+            Options.Value : Options.Get(Configuration);
 
-	    _jsonConfig = JsonSerializer.Serialize(config, HtmxConfig.SerializerOptions);
+        _jsonConfig = JsonSerializer.Serialize(config, HtmxConfig.SerializerOptions);
 
         return Task.CompletedTask;
-	}
+    }
 }

--- a/src/Htmxor/Configuration/HtmxConfigHeadOutlet.cs
+++ b/src/Htmxor/Configuration/HtmxConfigHeadOutlet.cs
@@ -1,20 +1,37 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Options;
 using System.Text.Json;
 
 namespace Htmxor.Configuration;
 
 public class HtmxConfigHeadOutlet : IComponent
 {
-    [Inject] private HtmxConfig Config { get; set; } = default!;
+	private string _jsonConfig = string.Empty;
+
+    [Inject] private IOptionsSnapshot<HtmxConfig> Options { get; set; } = default!;
+
+    /// <summary>
+    /// Specify a named configuration to use a non-default configuration
+    /// </summary>
+    [Parameter] public string? Configuration { get; set; } = default!;
 
     public void Attach(RenderHandle renderHandle)
     {
-        var json = JsonSerializer.Serialize(Config, HtmxConfig.SerializerOptions);
         renderHandle.Render(builder =>
         {
-            builder.AddMarkupContent(0, @$"<meta name=""htmx-config"" content='{json}'>");
+            builder.AddMarkupContent(0, @$"<meta name=""htmx-config"" content='{_jsonConfig}'>");
         });
     }
 
-    public Task SetParametersAsync(ParameterView parameters) => Task.CompletedTask;
+    public Task SetParametersAsync(ParameterView parameters)
+    {
+	    Configuration = parameters.GetValueOrDefault<string?>("Configuration");
+
+	    var config = string.IsNullOrEmpty(Configuration) ? 
+		    Options.Value : Options.Get(Configuration);
+
+	    _jsonConfig = JsonSerializer.Serialize(config, HtmxConfig.SerializerOptions);
+
+        return Task.CompletedTask;
+	}
 }

--- a/src/Htmxor/Configuration/HtmxorConfigBuilder.cs
+++ b/src/Htmxor/Configuration/HtmxorConfigBuilder.cs
@@ -1,0 +1,96 @@
+﻿using Htmxor.Antiforgery;
+using Microsoft.AspNetCore.Antiforgery;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Htmxor.Http;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Htmxor.Configuration;
+
+public class HtmxorConfigBuilder
+{
+	private readonly string _defaultCookieName = "HX-XSRF-TOKEN";
+	private readonly IHostApplicationBuilder _builder;
+
+	/// <summary>
+	/// Configures HtmxConfig options to include the antiforgery configuration
+	/// </summary>
+	public class ConfigureHtmxSettings : IConfigureOptions<HtmxConfig>, IConfigureNamedOptions<HtmxConfig>
+	{
+		private HtmxAntiforgeryOptions _antiforgeryOptions = default!;
+		public ConfigureHtmxSettings(IOptions<HtmxAntiforgeryOptions> antiforgeryOptions)
+		{
+			_antiforgeryOptions = antiforgeryOptions.Value;
+		}
+		public void Configure(string name, HtmxConfig options)
+		{
+			options.Antiforgery = _antiforgeryOptions;
+		}
+		public void Configure(HtmxConfig options) => Configure(Options.DefaultName, options);
+	}
+
+	/// <summary>
+	/// Sets up default services for Htmxor
+	/// </summary>
+	/// <param name="builder"></param>
+	public HtmxorConfigBuilder(IHostApplicationBuilder builder)
+	{
+		_builder = builder;
+
+		AddHtmxAntiForgery();
+
+		// Make sure all HtmxConfig instances get properly configured
+		_builder.Services.AddSingleton<IConfigureOptions<HtmxConfig>, ConfigureHtmxSettings>();
+		_builder.Services.AddSingleton<IConfigureNamedOptions<HtmxConfig>, ConfigureHtmxSettings>();
+
+		// Configure a default htmx configuration
+		_builder.Services.Configure<HtmxConfig>(config => { });
+
+		_builder.Services.AddScoped(srv => srv.GetRequiredService<IHttpContextAccessor>().HttpContext!.GetHtmxContext());
+	}
+
+	/// <summary>
+	/// Adds a default configuration for use inside an HtmxConfigHeadOutlet
+	/// </summary>
+	/// <param name="configBuilder"></param>
+	/// <returns></returns>
+	public HtmxorConfigBuilder WithDefaultConfiguration(Action<HtmxConfig> configBuilder)
+	{
+		_builder.Services.Configure<HtmxConfig>(configBuilder);
+
+		return this;
+	}
+
+	/// <summary>
+	/// Adds a named configuration for use inside an HtmxConfigHeadOutlet
+	/// </summary>
+	/// <param name="configBuilder"></param>
+	/// <returns></returns>
+	public HtmxorConfigBuilder WithNamedConfiguration(string name, Action<HtmxConfig> configBuilder)
+	{
+		_builder.Services.Configure<HtmxConfig>(name, configBuilder);
+
+		return this;
+	}
+
+	private void AddHtmxAntiForgery()
+	{
+		var provider = _builder.Services.BuildServiceProvider();
+		var antiforgeryOptions = provider.GetRequiredService<IOptions<AntiforgeryOptions>>();
+
+		_builder.Services.Configure<HtmxAntiforgeryOptions>(opt =>
+		{
+			// Default to true, can be configured again after adding htmx if necessary
+			opt.IncludeAntiForgery = true;
+			opt.FormFieldName = antiforgeryOptions.Value.FormFieldName;
+			opt.HeaderName = antiforgeryOptions.Value.HeaderName;
+			opt.CookieName = _defaultCookieName;
+		});
+	}
+}

--- a/src/Htmxor/Configuration/HtmxorConfigBuilder.cs
+++ b/src/Htmxor/Configuration/HtmxorConfigBuilder.cs
@@ -15,82 +15,82 @@ namespace Htmxor.Configuration;
 
 public class HtmxorConfigBuilder
 {
-	private readonly string _defaultCookieName = "HX-XSRF-TOKEN";
-	private readonly IHostApplicationBuilder _builder;
+    private readonly string _defaultCookieName = "HX-XSRF-TOKEN";
+    private readonly IHostApplicationBuilder _builder;
 
-	/// <summary>
-	/// Configures HtmxConfig options to include the antiforgery configuration
-	/// </summary>
-	public class ConfigureHtmxSettings : IConfigureOptions<HtmxConfig>, IConfigureNamedOptions<HtmxConfig>
-	{
-		private HtmxAntiforgeryOptions _antiforgeryOptions = default!;
-		public ConfigureHtmxSettings(IOptions<HtmxAntiforgeryOptions> antiforgeryOptions)
-		{
-			_antiforgeryOptions = antiforgeryOptions.Value;
-		}
-		public void Configure(string name, HtmxConfig options)
-		{
-			options.Antiforgery = _antiforgeryOptions;
-		}
-		public void Configure(HtmxConfig options) => Configure(Options.DefaultName, options);
-	}
+    /// <summary>
+    /// Configures HtmxConfig options to include the antiforgery configuration
+    /// </summary>
+    public class ConfigureHtmxSettings : IConfigureOptions<HtmxConfig>, IConfigureNamedOptions<HtmxConfig>
+    {
+        private HtmxAntiforgeryOptions _antiforgeryOptions = default!;
+        public ConfigureHtmxSettings(IOptions<HtmxAntiforgeryOptions> antiforgeryOptions)
+        {
+            _antiforgeryOptions = antiforgeryOptions.Value;
+        }
+        public void Configure(string name, HtmxConfig options)
+        {
+            options.Antiforgery = _antiforgeryOptions;
+        }
+        public void Configure(HtmxConfig options) => Configure(Options.DefaultName, options);
+    }
 
-	/// <summary>
-	/// Sets up default services for Htmxor
-	/// </summary>
-	/// <param name="builder"></param>
-	public HtmxorConfigBuilder(IHostApplicationBuilder builder)
-	{
-		_builder = builder;
+    /// <summary>
+    /// Sets up default services for Htmxor
+    /// </summary>
+    /// <param name="builder"></param>
+    public HtmxorConfigBuilder(IHostApplicationBuilder builder)
+    {
+        _builder = builder;
 
-		AddHtmxAntiForgery();
+        AddHtmxAntiForgery();
 
-		// Make sure all HtmxConfig instances get properly configured
-		_builder.Services.AddSingleton<IConfigureOptions<HtmxConfig>, ConfigureHtmxSettings>();
-		_builder.Services.AddSingleton<IConfigureNamedOptions<HtmxConfig>, ConfigureHtmxSettings>();
+        // Make sure all HtmxConfig instances get properly configured
+        _builder.Services.AddSingleton<IConfigureOptions<HtmxConfig>, ConfigureHtmxSettings>();
+        _builder.Services.AddSingleton<IConfigureNamedOptions<HtmxConfig>, ConfigureHtmxSettings>();
 
-		// Configure a default htmx configuration
-		_builder.Services.Configure<HtmxConfig>(config => { });
+        // Configure a default htmx configuration
+        _builder.Services.Configure<HtmxConfig>(config => { });
 
-		_builder.Services.AddScoped(srv => srv.GetRequiredService<IHttpContextAccessor>().HttpContext!.GetHtmxContext());
-	}
+        _builder.Services.AddScoped(srv => srv.GetRequiredService<IHttpContextAccessor>().HttpContext!.GetHtmxContext());
+    }
 
-	/// <summary>
-	/// Adds a default configuration for use inside an HtmxConfigHeadOutlet
-	/// </summary>
-	/// <param name="configBuilder"></param>
-	/// <returns></returns>
-	public HtmxorConfigBuilder WithDefaultConfiguration(Action<HtmxConfig> configBuilder)
-	{
-		_builder.Services.Configure<HtmxConfig>(configBuilder);
+    /// <summary>
+    /// Adds a default configuration for use inside an HtmxConfigHeadOutlet
+    /// </summary>
+    /// <param name="configBuilder"></param>
+    /// <returns></returns>
+    public HtmxorConfigBuilder WithDefaultConfiguration(Action<HtmxConfig> configBuilder)
+    {
+        _builder.Services.Configure<HtmxConfig>(configBuilder);
 
-		return this;
-	}
+        return this;
+    }
 
-	/// <summary>
-	/// Adds a named configuration for use inside an HtmxConfigHeadOutlet
-	/// </summary>
-	/// <param name="configBuilder"></param>
-	/// <returns></returns>
-	public HtmxorConfigBuilder WithNamedConfiguration(string name, Action<HtmxConfig> configBuilder)
-	{
-		_builder.Services.Configure<HtmxConfig>(name, configBuilder);
+    /// <summary>
+    /// Adds a named configuration for use inside an HtmxConfigHeadOutlet
+    /// </summary>
+    /// <param name="configBuilder"></param>
+    /// <returns></returns>
+    public HtmxorConfigBuilder WithNamedConfiguration(string name, Action<HtmxConfig> configBuilder)
+    {
+        _builder.Services.Configure<HtmxConfig>(name, configBuilder);
 
-		return this;
-	}
+        return this;
+    }
 
-	private void AddHtmxAntiForgery()
-	{
-		var provider = _builder.Services.BuildServiceProvider();
-		var antiforgeryOptions = provider.GetRequiredService<IOptions<AntiforgeryOptions>>();
+    private void AddHtmxAntiForgery()
+    {
+        var provider = _builder.Services.BuildServiceProvider();
+        var antiforgeryOptions = provider.GetRequiredService<IOptions<AntiforgeryOptions>>();
 
-		_builder.Services.Configure<HtmxAntiforgeryOptions>(opt =>
-		{
-			// Default to true, can be configured again after adding htmx if necessary
-			opt.IncludeAntiForgery = true;
-			opt.FormFieldName = antiforgeryOptions.Value.FormFieldName;
-			opt.HeaderName = antiforgeryOptions.Value.HeaderName;
-			opt.CookieName = _defaultCookieName;
-		});
-	}
+        _builder.Services.Configure<HtmxAntiforgeryOptions>(opt =>
+        {
+            // Default to true, can be configured again after adding htmx if necessary
+            opt.IncludeAntiForgery = true;
+            opt.FormFieldName = antiforgeryOptions.Value.FormFieldName;
+            opt.HeaderName = antiforgeryOptions.Value.HeaderName;
+            opt.CookieName = _defaultCookieName;
+        });
+    }
 }

--- a/src/Htmxor/WebApplicationBuilderExtensions.cs
+++ b/src/Htmxor/WebApplicationBuilderExtensions.cs
@@ -14,7 +14,7 @@ namespace Htmxor;
 
 public static class WebApplicationBuilderExtensions
 {
-	public static HtmxorConfigBuilder AddHtmx(this IHostApplicationBuilder builder) =>
+	public static HtmxorConfigBuilder AddHtmxor(this IHostApplicationBuilder builder) =>
 		new HtmxorConfigBuilder(builder);
 
 }

--- a/src/Htmxor/WebApplicationBuilderExtensions.cs
+++ b/src/Htmxor/WebApplicationBuilderExtensions.cs
@@ -1,4 +1,6 @@
-﻿using Htmxor.Antiforgery;
+﻿using System.Reflection.Metadata.Ecma335;
+using System.Xml.Linq;
+using Htmxor.Antiforgery;
 using Htmxor.Configuration;
 using Htmxor.Http;
 using Microsoft.AspNetCore.Antiforgery;
@@ -6,23 +8,13 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
+using static Htmxor.WebApplicationBuilderExtensions;
 
 namespace Htmxor;
 
 public static class WebApplicationBuilderExtensions
 {
-    public static void AddHtmx(this IHostApplicationBuilder builder, Action<HtmxConfig>? configBuilder = null)
-    {
-        builder.Services.AddSingleton<HtmxConfig>(x =>
-        {
-            var config = new HtmxConfig
-            {
-                Antiforgery = new HtmxAntiforgeryOptions(x.GetRequiredService<IOptions<AntiforgeryOptions>>()),
-            };
-            configBuilder?.Invoke(config);
-            return config;
-        });
+	public static HtmxorConfigBuilder AddHtmx(this IHostApplicationBuilder builder) =>
+		new HtmxorConfigBuilder(builder);
 
-        builder.Services.AddScoped(srv => srv.GetRequiredService<IHttpContextAccessor>().HttpContext!.GetHtmxContext());
-    }
 }

--- a/src/Htmxor/WebApplicationBuilderExtensions.cs
+++ b/src/Htmxor/WebApplicationBuilderExtensions.cs
@@ -14,7 +14,7 @@ namespace Htmxor;
 
 public static class WebApplicationBuilderExtensions
 {
-	public static HtmxorConfigBuilder AddHtmxor(this IHostApplicationBuilder builder) =>
-		new HtmxorConfigBuilder(builder);
+    public static HtmxorConfigBuilder AddHtmxor(this IHostApplicationBuilder builder) =>
+        new HtmxorConfigBuilder(builder);
 
 }


### PR DESCRIPTION
Based on conversation regarding configuration on startup I realized that it isn't unreasonable to have different configurations for different pages.  While a single config per-site might work I think a better approach would be to also allow for named configurations along with a default configuration.  Htmx could potentially have different configurations across different pages, since the configs are page-level.  

Adding a specific configuration for a page could just involve configuring the HtmxConfigHeadOutlet as follows:

```html
<HtmxConfigHeadOutlet Configuration="articles"/>

or leave Configuration off to use the default configuration
```

Then implement a config we can create a config builder that works like the following:
```csharp
builder.AddHtmxor()
	.WithDefaultConfiguration(config =>
	{
		config.SelfRequestsOnly = true;
	})
	.WithNamedConfiguration("articles", config =>
	{
		config.SelfRequestsOnly = true;
		config.GlobalViewTransitions = true;
	});
```

Side Effects
HtmxAntiforgeryOptions will need to be configured globally for the site on startup instead since there is no reasonable way to know which config should be used per-request