### PR TITLE
feat: adds missing reswap modifier and adds reswap builder along with StopPolling

### DIFF
--- a/src/Htmxor/Http/HtmxResponse.cs
+++ b/src/Htmxor/Http/HtmxResponse.cs
@@ -140,9 +140,22 @@ public sealed class HtmxResponse(HttpContext context)
     /// <summary>
     /// Allows you to specify how the response will be swapped.
     /// </summary>
-    /// <param name="swapStyle"></param>
+    /// <param name="modifier">The hx-swap attributes supports modifiers for changing the behavior of the swap.</param>
     /// <returns>This <see cref="HtmxResponse"/> object instance.</returns>
-    public HtmxResponse Reswap(SwapStyle swapStyle)
+    public HtmxResponse Reswap(string modifier)
+    {
+        headers[HtmxResponseHeaderNames.Reswap] = modifier;
+
+        return this;
+    }
+
+    /// <summary>
+    /// Allows you to specify how the response will be swapped.
+    /// </summary>
+    /// <param name="swapStyle"></param>
+	/// <param name="modifier">The hx-swap attributes supports modifiers for changing the behavior of the swap.</param>
+    /// <returns>This <see cref="HtmxResponse"/> object instance.</returns>
+    public HtmxResponse Reswap(SwapStyle swapStyle, string? modifier = null)
     {
         AssertIsHtmxRequest();
 
@@ -159,9 +172,24 @@ public sealed class HtmxResponse(HttpContext context)
             _ => throw new SwitchExpressionException(swapStyle),
         };
 
-        headers[HtmxResponseHeaderNames.Reswap] = style;
+        var value = modifier != null ? $"{style} {modifier}" : style;
+
+        headers[HtmxResponseHeaderNames.Reswap] = value;
 
         return this;
+    }
+
+    /// <summary>
+    ///     Allows you to specify how the response will be swapped.
+    /// </summary>
+    /// <param></param>
+    /// <param name="swapStyle"></param>
+    /// <returns></returns>
+    public HtmxResponse Reswap(SwapStyleBuilder swapStyle)
+    {
+	    var (style, modifier) = swapStyle.Build();
+
+        return style is null ? Reswap(modifier) : Reswap((SwapStyle)style, modifier);
     }
 
     /// <summary>
@@ -190,6 +218,17 @@ public sealed class HtmxResponse(HttpContext context)
         headers[HtmxResponseHeaderNames.Reselect] = selector;
 
         return this;
+    }
+
+    /// <summary>
+    /// Sets response code to stop polling
+    /// </summary>
+    /// <returns></returns>
+    public HtmxResponse StopPolling()
+    {
+	    context.Response.StatusCode = HtmxStatusCodes.StopPolling;
+
+	    return this;
     }
 
     /// <summary>

--- a/src/Htmxor/Http/HtmxStatusCodes.cs
+++ b/src/Htmxor/Http/HtmxStatusCodes.cs
@@ -1,0 +1,6 @@
+﻿namespace Htmxor.Http;
+
+public static class HtmxStatusCodes
+{
+    public static readonly int StopPolling = 286;
+}

--- a/src/Htmxor/Http/SwapStyleBuilder.cs
+++ b/src/Htmxor/Http/SwapStyleBuilder.cs
@@ -189,4 +189,5 @@ public static class SwapStyleBuilderExtension
     public static SwapStyleBuilder FocusScroll(this SwapStyle style, bool scroll) => new SwapStyleBuilder(style).FocusScroll(scroll);
     public static SwapStyleBuilder ShowOn(this SwapStyle style, string selector, ScrollDirection direction) => new SwapStyleBuilder(style).ShowOn(selector, direction);
     public static SwapStyleBuilder ShowWindow(this SwapStyle style, ScrollDirection direction) => new SwapStyleBuilder(style).ShowWindow(direction);
+    public static SwapStyleBuilder ShowNone(this SwapStyle style) => new SwapStyleBuilder(style).ShowNone();
 }

--- a/src/Htmxor/Http/SwapStyleBuilder.cs
+++ b/src/Htmxor/Http/SwapStyleBuilder.cs
@@ -1,0 +1,192 @@
+﻿using System.Collections;
+using System.Collections.Specialized;
+
+namespace Htmxor.Http;
+
+/// <summary>
+/// A builder class for constructing a swap style command string for HTMX responses.
+/// </summary>
+public class SwapStyleBuilder
+{
+    private readonly SwapStyle? style;
+    private readonly OrderedDictionary modifiers = new();
+
+    /// <summary>
+    /// Initializes a new instance of the SwapStyleBuilder with a specified swap style.
+    /// </summary>
+    /// <param name="style">The initial swap style to be applied.</param>
+    public SwapStyleBuilder(SwapStyle? style = null)
+    {
+        this.style = style;
+    }
+
+    /// <summary>
+    /// Adds a delay to the swap operation.
+    /// </summary>
+    /// <param name="span">The time span to delay the swap.</param>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
+    public SwapStyleBuilder After(TimeSpan span)
+    {
+        AddModifier("swap", span.TotalMilliseconds < 1000 ? $"{span.TotalMilliseconds}ms" : $"{span.TotalSeconds}s");
+
+        return this;
+    }
+
+    /// <summary>
+    /// Specifies the direction to scroll the page after the swap.
+    /// </summary>
+    /// <param name="direction">The scroll direction.</param>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
+    public SwapStyleBuilder Scroll(ScrollDirection direction)
+    {
+        switch (direction)
+        {
+            case ScrollDirection.Top:
+                AddModifier("scroll", "top");
+                break;
+            case ScrollDirection.Bottom:
+                AddModifier("scroll", "bottom");
+                break;
+        }
+
+        return this;
+    }
+
+    /// <summary>
+    /// Determines whether to ignore the document title in the swap response.
+    /// </summary>
+    /// <param name="ignore">Whether to ignore the title.</param>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
+    public SwapStyleBuilder IgnoreTitle(bool ignore)
+    {
+        AddModifier("ignoreTitle", ignore);
+
+        return this;
+    }
+
+    /// <summary>
+    /// Enables or disables transition effects for the swap.
+    /// </summary>
+    /// <param name="show">Whether to show transition effects.</param>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
+    public SwapStyleBuilder Transition(bool show)
+    {
+        AddModifier("transition", show);
+
+        return this;
+    }
+
+    /// <summary>
+    /// Sets whether to focus and scroll to the swapped content.
+    /// </summary>
+    /// <param name="scroll">Whether to scroll to the focus element.</param>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
+    public SwapStyleBuilder FocusScroll(bool scroll)
+    {
+        AddModifier("focus-scroll", scroll);
+
+        return this;
+    }
+
+    /// <summary>
+    /// Specifies a CSS selector to dynamically target for the swap operation.
+    /// </summary>
+    /// <param name="selector">The CSS selector of the target element.</param>
+    /// <param name="direction">The scroll direction after swap.</param>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
+    public SwapStyleBuilder ShowOn(string selector, ScrollDirection direction)
+    {
+        switch (direction)
+        {
+            case ScrollDirection.Top:
+                AddModifier("show", $"{selector}:top");
+                break;
+            case ScrollDirection.Bottom:
+                AddModifier("show", $"{selector}:bottom");
+                break;
+        }
+
+        return this;
+    }
+
+    /// <summary>
+    /// Specifies that the swap should show in the window, with an optional scroll direction.
+    /// </summary>
+    /// <param name="direction">The direction to scroll the window after the swap.</param>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
+    public SwapStyleBuilder ShowWindow(ScrollDirection direction)
+    {
+        switch (direction)
+        {
+            case ScrollDirection.Top:
+                AddModifier("show", $"window:top");
+                break;
+            case ScrollDirection.Bottom:
+                AddModifier("show", $"window:bottom");
+                break;
+        }
+
+        return this;
+    }
+
+    /// <summary>
+    /// Turns off scrolling after swap
+    /// </summary>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
+    public SwapStyleBuilder ShowNone()
+    {
+        AddModifier("show", "none");
+
+        return this;
+    }
+
+    /// <summary>
+    /// Builds the swap style command string with all specified modifiers.
+    /// </summary>
+    /// <returns>A tuple containing the SwapStyle and the constructed command string.</returns>
+    internal (SwapStyle?, string) Build()
+    {
+        var value = string.Empty;
+
+        if (modifiers.Count > 0)
+        {
+            value = modifiers.Cast<DictionaryEntry>()
+                .Select(entry => $"{entry.Key}:{entry.Value}")
+                .Aggregate((current, next) => $"{current} {next}");
+        }
+
+        return (style, value);
+    }
+
+    /// <summary>
+    /// Adds a modifier to modifiers, overriding existing values if present
+    /// </summary>
+    /// <param name="modifier"></param>
+    /// <param name="options"></param>
+    private void AddModifier(string modifier, string options)
+    {
+        if (modifiers.Contains(modifier))
+            modifiers.Remove(modifier);
+
+        modifiers.Add(modifier, options);
+    }
+
+    private void AddModifier(string modifier, bool option) => AddModifier(modifier, option.ToString().ToLowerInvariant());
+}
+
+/// <summary>
+/// Extension methods for the SwapStyle enum to facilitate building swap style commands.
+/// </summary>
+public static class SwapStyleBuilderExtension
+{
+    // Each method below returns a SwapStyleBuilder instance initialized with the respective SwapStyle
+    // and applies the specified modifier to it. This allows for fluent configuration of swap style commands.
+
+    public static SwapStyleBuilder After(this SwapStyle style, TimeSpan span) => new SwapStyleBuilder(style).After(span);
+    public static SwapStyleBuilder Scroll(this SwapStyle style, ScrollDirection direction) => new SwapStyleBuilder(style).Scroll(direction);
+    public static SwapStyleBuilder IgnoreTitle(this SwapStyle style, bool ignore) => new SwapStyleBuilder(style).IgnoreTitle(ignore);
+    public static SwapStyleBuilder Transition(this SwapStyle style, bool show) => new SwapStyleBuilder(style).Transition(show);
+    public static SwapStyleBuilder FocusScroll(this SwapStyle style, bool scroll) => new SwapStyleBuilder(style).FocusScroll(scroll);
+    public static SwapStyleBuilder ShowOn(this SwapStyle style, string selector, ScrollDirection direction) => new SwapStyleBuilder(style).ShowOn(selector, direction);
+    public static SwapStyleBuilder ShowWindow(this SwapStyle style, ScrollDirection direction) => new SwapStyleBuilder(style).ShowWindow(direction);
+}

--- a/src/Htmxor/Http/SwapStyleBuilder.cs
+++ b/src/Htmxor/Http/SwapStyleBuilder.cs
@@ -6,7 +6,7 @@ namespace Htmxor.Http;
 /// <summary>
 /// A builder class for constructing a swap style command string for HTMX responses.
 /// </summary>
-public class SwapStyleBuilder
+public sealed class SwapStyleBuilder 
 {
     private readonly SwapStyle? style;
     private readonly OrderedDictionary modifiers = new();
@@ -21,21 +21,50 @@ public class SwapStyleBuilder
     }
 
     /// <summary>
-    /// Adds a delay to the swap operation.
+    /// Modifies the amount of time that htmx will wait after receiving a 
+    /// response to swap the content by including the modifier <c>swap:<paramref name="time"/></c>.
     /// </summary>
-    /// <param name="span">The time span to delay the swap.</param>
-    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
-    public SwapStyleBuilder After(TimeSpan span)
+    /// <remarks>
+    /// <paramref name="time"/> will be converted to milliseconds if less than 1000, otherwise seconds, 
+    /// meaning the resulting modifier will be <c>swap:500ms</c> for a <see cref="TimeSpan"/> of 500 milliseconds 
+    /// or <c>swap:2s</c> for a <see cref="TimeSpan"/> of 2 seconds..
+    /// </remarks>
+    /// <param name="style">The swap style.</param>
+    /// <param name="time">The amount of time htmx should wait after receiving a 
+    /// response to swap the content.</param>
+    public SwapStyleBuilder AfterSwapDelay(TimeSpan time)
     {
-        AddModifier("swap", span.TotalMilliseconds < 1000 ? $"{span.TotalMilliseconds}ms" : $"{span.TotalSeconds}s");
+        AddModifier("swap", time.TotalMilliseconds < 1000 ? $"{time.TotalMilliseconds}ms" : $"{time.TotalSeconds}s");
 
         return this;
     }
 
     /// <summary>
-    /// Specifies the direction to scroll the page after the swap.
+    /// Modifies the amount of time that htmx will wait between the swap 
+    /// and the settle logic by including the modifier <c>settle:<paramref name="time"/></c>.
     /// </summary>
-    /// <param name="direction">The scroll direction.</param>
+    /// <remarks>
+    /// <paramref name="time"/> will be converted to milliseconds if less than 1000, otherwise seconds, 
+    /// meaning the resulting modifier will be <c>swap:500ms</c> for a <see cref="TimeSpan"/> of 500 milliseconds 
+    /// or <c>swap:2s</c> for a <see cref="TimeSpan"/> of 2 seconds..
+    /// </remarks>
+    /// <param name="time">The amount of time htmx should wait after receiving a 
+    /// response to swap the content.</param>
+    public SwapStyleBuilder AfterSettleDelay(TimeSpan time)
+    {
+	    AddModifier("settle", time.TotalMilliseconds < 1000 ? $"{time.TotalMilliseconds}ms" : $"{time.TotalSeconds}s");
+
+	    return this;
+    }
+
+    /// <summary>
+    /// Specifies the direction to scroll the page after the swap and appends the modifier <c>scroll:{direction}</c>.
+    /// </summary>
+    /// <remarks>
+    /// Sets the scroll direction on the page after swapping. For instance, using <see cref="ScrollDirection.Top"/>
+    /// will add the modifier <c>scroll:top</c> which instructs the page to scroll to the top after the swap.
+    /// </remarks>
+    /// <param name="direction">The scroll direction after the swap.</param>
     /// <returns>The SwapStyleBuilder instance for chaining.</returns>
     public SwapStyleBuilder Scroll(ScrollDirection direction)
     {
@@ -53,11 +82,37 @@ public class SwapStyleBuilder
     }
 
     /// <summary>
-    /// Determines whether to ignore the document title in the swap response.
+    /// Automatically scrolls to the top of the page after a swap.
     /// </summary>
+    /// <remarks>
+    /// This method adds the modifier <c>scroll:top</c> to the swap commands, instructing the page to scroll to
+    /// the top after content is swapped.
+    /// </remarks>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
+    public SwapStyleBuilder ScrollTop() => Scroll(ScrollDirection.Top);
+
+    /// <summary>
+    /// Automatically scrolls to the bottom of the page after a swap.
+    /// </summary>
+    /// <remarks>
+    /// This method adds the modifier <c>scroll:bottom</c> to the swap commands, instructing the page to scroll to
+    /// the bottom after content is swapped.
+    /// </remarks>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
+    public SwapStyleBuilder ScrollBottom() => Scroll(ScrollDirection.Bottom);
+
+    /// <summary>
+    /// Determines whether to ignore the document title in the swap response by appending the modifier
+    /// <c>ignoreTitle:{ignore}</c>.
+    /// </summary>
+    /// <remarks>
+    /// When set to true, the document title in the swap response will be ignored by adding the modifier
+    /// <c>ignoreTitle:true</c>.
+    /// This keeps the current title unchanged regardless of the incoming swap content's title tag.
+    /// </remarks>
     /// <param name="ignore">Whether to ignore the title.</param>
     /// <returns>The SwapStyleBuilder instance for chaining.</returns>
-    public SwapStyleBuilder IgnoreTitle(bool ignore)
+    public SwapStyleBuilder IgnoreTitle(bool ignore = true)
     {
         AddModifier("ignoreTitle", ignore);
 
@@ -65,8 +120,22 @@ public class SwapStyleBuilder
     }
 
     /// <summary>
-    /// Enables or disables transition effects for the swap.
+    /// Includes the document title from the swap response in the current page.
     /// </summary>
+    /// <remarks>
+    /// This method ensures the title of the document is updated according to the swap response by removing any
+    /// ignoreTitle modifiers, effectively setting <c>ignoreTitle:false</c>.
+    /// </remarks>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
+    public SwapStyleBuilder IncludeTitle() => IgnoreTitle(false);
+
+    /// <summary>
+    /// Enables or disables transition effects for the swap by appending the modifier <c>transition:{show}</c>.
+    /// </summary>
+    /// <remarks>
+    /// Controls the display of transition effects during the swap. For example, setting <paramref name="show"/> to true
+    /// will add the modifier <c>transition:true</c> to enable smooth transitions.
+    /// </remarks>
     /// <param name="show">Whether to show transition effects.</param>
     /// <returns>The SwapStyleBuilder instance for chaining.</returns>
     public SwapStyleBuilder Transition(bool show)
@@ -77,20 +146,49 @@ public class SwapStyleBuilder
     }
 
     /// <summary>
-    /// Sets whether to focus and scroll to the swapped content.
+    /// Explicitly includes transition effects for the swap.
     /// </summary>
+    /// <remarks>
+    /// By calling this method, transition effects are enabled for the swap, adding the modifier <c>transition:true</c>.
+    /// </remarks>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
+    public SwapStyleBuilder IncludeTransition() => Transition(true);
+
+    /// <summary>
+    /// Explicitly ignores transition effects for the swap.
+    /// </summary>
+    /// <remarks>
+    /// This method disables transition effects by adding the modifier <c>transition:false</c> to the swap commands.
+    /// </remarks>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
+    public SwapStyleBuilder IgnoreTransition() => Transition(false);
+
+    /// <summary>
+    /// htmx preserves focus between requests for inputs that have a defined id attribute. By
+    /// default htmx prevents auto-scrolling to focused inputs between requests which can be
+    /// unwanted behavior on longer requests when the user has already scrolled away. 
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="scroll"/> when true will be <c>focus-scroll:true</c>, otherwise when false
+    /// will be <c>focus-scroll:false</c>
+    /// </remarks>
     /// <param name="scroll">Whether to scroll to the focus element.</param>
     /// <returns>The SwapStyleBuilder instance for chaining.</returns>
-    public SwapStyleBuilder FocusScroll(bool scroll)
+    public SwapStyleBuilder ScrollFocus(bool scroll = true)
     {
         AddModifier("focus-scroll", scroll);
 
         return this;
     }
 
+    public SwapStyleBuilder PreserveFocus() => ScrollFocus(false);
+
     /// <summary>
-    /// Specifies a CSS selector to dynamically target for the swap operation.
+    /// Specifies a CSS selector to dynamically target for the swap operation, with an optional scroll direction after the swap.
     /// </summary>
+    /// <remarks>
+    /// Adds a show modifier with the specified CSS selector and scroll direction. For example, if <paramref name="selector"/> is ".item" and <paramref name="direction"/> is <see cref="ScrollDirection.Top"/>, the modifier <c>show:.item:top</c> is added.
+    /// </remarks>
     /// <param name="selector">The CSS selector of the target element.</param>
     /// <param name="direction">The scroll direction after swap.</param>
     /// <returns>The SwapStyleBuilder instance for chaining.</returns>
@@ -110,11 +208,34 @@ public class SwapStyleBuilder
     }
 
     /// <summary>
+    /// Specifies that the swap should show the element matching the CSS selector at the top of the window.
+    /// </summary>
+    /// <remarks>
+    /// This method adds the modifier <c>show:{selector}:top</c>, directing the swap to display the specified element at the top of the window.
+    /// </remarks>
+    /// <param name="selector">The CSS selector of the target element.</param>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
+    public SwapStyleBuilder ShowOnTop(string selector) => ShowOn(selector, ScrollDirection.Top);
+
+    /// <summary>
+    /// Specifies that the swap should show the element matching the CSS selector at the bottom of the window.
+    /// </summary>
+    /// <remarks>
+    /// This method adds the modifier <c>show:{selector}:bottom</c>, directing the swap to display the specified element at the bottom of the window.
+    /// </remarks>
+    /// <param name="selector">The CSS selector of the target element.</param>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
+    public SwapStyleBuilder ShowOnBottom(string selector) => ShowOn(selector, ScrollDirection.Bottom);
+
+    /// <summary>
     /// Specifies that the swap should show in the window, with an optional scroll direction.
     /// </summary>
     /// <param name="direction">The direction to scroll the window after the swap.</param>
+    /// <remarks>
+    /// This method adds the modifier <c>show:window:{direction}</c>, directing the swap to display the specified element at the bottom of the window.
+    /// </remarks>
     /// <returns>The SwapStyleBuilder instance for chaining.</returns>
-    public SwapStyleBuilder ShowWindow(ScrollDirection direction)
+    public SwapStyleBuilder ShowOnWindow(ScrollDirection direction)
     {
         switch (direction)
         {
@@ -130,8 +251,34 @@ public class SwapStyleBuilder
     }
 
     /// <summary>
-    /// Turns off scrolling after swap
+    /// Specifies that the swap should show content at the top of the window.
     /// </summary>
+    /// <remarks>
+    /// This method adds the modifier <c>show:window:top</c>, instructing the content to be displayed
+    /// at the top of the window following a swap. This can be useful for ensuring that important content or
+    /// notifications are immediately visible to the user after a swap operation.
+    /// </remarks>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
+    public SwapStyleBuilder ShowOnWindowTop() => ShowOnWindow(ScrollDirection.Top);
+
+    /// <summary>
+    /// Specifies that the swap should show content at the bottom of the window.
+    /// </summary>
+    /// <remarks>
+    /// This method adds the modifier <c>show:window:bottom</c>, instructing the content to be displayed
+    /// at the bottom of the window following a swap. This positioning can be used for infinite scrolling, footers or
+    /// lower-priority information that should not immediately distract from other content.
+    /// </remarks>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
+    public SwapStyleBuilder ShowOnWindowBottom() => ShowOnWindow(ScrollDirection.Bottom);
+
+    /// <summary>
+    /// Turns off scrolling after swap.
+    /// </summary>
+    /// <remarks>
+    /// This method disables automatic scrolling by setting the modifier <c>show:none</c>, ensuring the page
+    /// position remains unchanged after the swap.
+    /// </remarks>
     /// <returns>The SwapStyleBuilder instance for chaining.</returns>
     public SwapStyleBuilder ShowNone()
     {
@@ -167,11 +314,11 @@ public class SwapStyleBuilder
     {
         if (modifiers.Contains(modifier))
             modifiers.Remove(modifier);
-
+        
         modifiers.Add(modifier, options);
     }
 
-    private void AddModifier(string modifier, bool option) => AddModifier(modifier, option.ToString().ToLowerInvariant());
+    private void AddModifier(string modifier, bool option) => AddModifier(modifier, option ? "true" : "false");
 }
 
 /// <summary>
@@ -182,12 +329,23 @@ public static class SwapStyleBuilderExtension
     // Each method below returns a SwapStyleBuilder instance initialized with the respective SwapStyle
     // and applies the specified modifier to it. This allows for fluent configuration of swap style commands.
 
-    public static SwapStyleBuilder After(this SwapStyle style, TimeSpan span) => new SwapStyleBuilder(style).After(span);
+    public static SwapStyleBuilder AfterSwapDelay(this SwapStyle style, TimeSpan time) => new SwapStyleBuilder(style).AfterSwapDelay(time);
+    public static SwapStyleBuilder AfterSettleDelay(this SwapStyle style, TimeSpan time) => new SwapStyleBuilder(style).AfterSettleDelay(time);
     public static SwapStyleBuilder Scroll(this SwapStyle style, ScrollDirection direction) => new SwapStyleBuilder(style).Scroll(direction);
-    public static SwapStyleBuilder IgnoreTitle(this SwapStyle style, bool ignore) => new SwapStyleBuilder(style).IgnoreTitle(ignore);
+    public static SwapStyleBuilder ScrollTop(this SwapStyle style) => new SwapStyleBuilder(style).ScrollTop();
+    public static SwapStyleBuilder ScrollBottom(this SwapStyle style) => new SwapStyleBuilder(style).ScrollBottom();
+    public static SwapStyleBuilder IgnoreTitle(this SwapStyle style, bool ignore = true) => new SwapStyleBuilder(style).IgnoreTitle(ignore);
+    public static SwapStyleBuilder IncludeTitle(this SwapStyle style) => new SwapStyleBuilder(style).IncludeTitle();
     public static SwapStyleBuilder Transition(this SwapStyle style, bool show) => new SwapStyleBuilder(style).Transition(show);
-    public static SwapStyleBuilder FocusScroll(this SwapStyle style, bool scroll) => new SwapStyleBuilder(style).FocusScroll(scroll);
+    public static SwapStyleBuilder IncludeTransition(this SwapStyle style) => new SwapStyleBuilder(style).IncludeTransition();
+    public static SwapStyleBuilder IgnoreTransition(this SwapStyle style) => new SwapStyleBuilder(style).IgnoreTransition();
+    public static SwapStyleBuilder ScrollFocus(this SwapStyle style, bool scroll = true) => new SwapStyleBuilder(style).ScrollFocus(scroll);
+    public static SwapStyleBuilder PreserveFocus(this SwapStyle style, bool scroll = true) => new SwapStyleBuilder(style).PreserveFocus();
     public static SwapStyleBuilder ShowOn(this SwapStyle style, string selector, ScrollDirection direction) => new SwapStyleBuilder(style).ShowOn(selector, direction);
-    public static SwapStyleBuilder ShowWindow(this SwapStyle style, ScrollDirection direction) => new SwapStyleBuilder(style).ShowWindow(direction);
+    public static SwapStyleBuilder ShowOnTop(this SwapStyle style, string selector) => new SwapStyleBuilder(style).ShowOnTop(selector);
+    public static SwapStyleBuilder ShowOnBottom(this SwapStyle style, string selector) => new SwapStyleBuilder(style).ShowOnBottom(selector);
+    public static SwapStyleBuilder ShowOnWindow(this SwapStyle style, ScrollDirection direction) => new SwapStyleBuilder(style).ShowOnWindow(direction);
+    public static SwapStyleBuilder ShowOnWindowTop(this SwapStyle style) => new SwapStyleBuilder(style).ShowOnWindowTop();
+    public static SwapStyleBuilder ShowOnWindowBottom(this SwapStyle style) => new SwapStyleBuilder(style).ShowOnWindowBottom();
     public static SwapStyleBuilder ShowNone(this SwapStyle style) => new SwapStyleBuilder(style).ShowNone();
 }

--- a/src/Htmxor/Http/SwapStyleBuilder.cs
+++ b/src/Htmxor/Http/SwapStyleBuilder.cs
@@ -44,8 +44,8 @@ public sealed class SwapStyleBuilder
     /// </summary>
     /// <remarks>
     /// <paramref name="time"/> will be converted to milliseconds if less than 1000, otherwise seconds, 
-    /// meaning the resulting modifier will be <c>swap:500ms</c> for a <see cref="TimeSpan"/> of 500 milliseconds 
-    /// or <c>swap:2s</c> for a <see cref="TimeSpan"/> of 2 seconds..
+    /// meaning the resulting modifier will be <c>settle:500ms</c> for a <see cref="TimeSpan"/> of 500 milliseconds 
+    /// or <c>settle:2s</c> for a <see cref="TimeSpan"/> of 2 seconds..
     /// </remarks>
     /// <param name="time">The amount of time htmx should wait after receiving a 
     /// response to swap the content.</param>
@@ -57,11 +57,11 @@ public sealed class SwapStyleBuilder
     }
 
     /// <summary>
-    /// Specifies the direction to scroll the page after the swap and appends the modifier <c>scroll:{direction}</c>.
+    /// Specifies how to set the current window scrollbar after the swap and appends the modifier <c>scroll:<paramref name="direction"/></c>.
     /// </summary>
     /// <remarks>
-    /// Sets the scroll direction on the page after swapping. For instance, using <see cref="ScrollDirection.Top"/>
-    /// will add the modifier <c>scroll:top</c> which instructs the page to scroll to the top after the swap.
+    /// Sets the window scrollbar position after swapping immediately (without animation). For instance, using <see cref="ScrollDirection.Top"/>
+    /// will add the modifier <c>scroll:top</c> which instructs the window to set the scrollbar position to the top of swap content after the swap.
     /// </remarks>
     /// <param name="direction">The scroll direction after the swap.</param>
     /// <returns>The SwapStyleBuilder instance for chaining.</returns>
@@ -81,28 +81,28 @@ public sealed class SwapStyleBuilder
     }
 
     /// <summary>
-    /// Automatically scrolls to the top of the page after a swap.
+    /// Sets the window scrollbar position to the top of the swapped content after a swap.
     /// </summary>
     /// <remarks>
     /// This method adds the modifier <c>scroll:top</c> to the swap commands, instructing the page to scroll to
-    /// the top after content is swapped.
+    /// the top after content is swapped immediately and without animation.
     /// </remarks>
     /// <returns>The SwapStyleBuilder instance for chaining.</returns>
     public SwapStyleBuilder ScrollTop() => Scroll(ScrollDirection.Top);
 
     /// <summary>
-    /// Automatically scrolls to the bottom of the page after a swap.
+    /// Sets the window scrollbar position to the bottom of the swapped content after a swap.
     /// </summary>
     /// <remarks>
     /// This method adds the modifier <c>scroll:bottom</c> to the swap commands, instructing the page to scroll to
-    /// the bottom after content is swapped.
+    /// the bottom after content is swapped immediately and without animation.
     /// </remarks>
     /// <returns>The SwapStyleBuilder instance for chaining.</returns>
     public SwapStyleBuilder ScrollBottom() => Scroll(ScrollDirection.Bottom);
 
     /// <summary>
     /// Determines whether to ignore the document title in the swap response by appending the modifier
-    /// <c>ignoreTitle:{ignore}</c>.
+    /// <c>ignoreTitle:<paramref name="ignore"/></c>.
     /// </summary>
     /// <remarks>
     /// When set to true, the document title in the swap response will be ignored by adding the modifier
@@ -129,7 +129,7 @@ public sealed class SwapStyleBuilder
     public SwapStyleBuilder IncludeTitle() => IgnoreTitle(false);
 
     /// <summary>
-    /// Enables or disables transition effects for the swap by appending the modifier <c>transition:{show}</c>.
+    /// Enables or disables transition effects for the swap by appending the modifier <c>transition:<paramref name="show"/></c>.
     /// </summary>
     /// <remarks>
     /// Controls the display of transition effects during the swap. For example, setting <paramref name="show"/> to true
@@ -192,7 +192,7 @@ public sealed class SwapStyleBuilder
     public SwapStyleBuilder PreserveFocus() => ScrollFocus(false);
 
     /// <summary>
-    /// Positions viewport at top of swap target after swap is completed
+    /// Smoothly animates the scrollbar position to top or bottom of swap target after swap is completed
     /// </summary>
     /// <remarks>
     /// Adds a show modifier with the specified scroll direction.
@@ -218,7 +218,7 @@ public sealed class SwapStyleBuilder
     }
 
     /// <summary>
-    /// Positions viewport at top of swap target after swap is completed
+    /// Smoothly animates the scrollbar position to top of swap target after swap is completed
     /// </summary>
     /// <remarks>
     /// Adds a show modifier <c>show:top</c>
@@ -227,7 +227,7 @@ public sealed class SwapStyleBuilder
     public SwapStyleBuilder ShowOnTop() => ShowOn(ScrollDirection.Top);
 
     /// <summary>
-    /// Positions viewport at top of swap target after swap is completed
+    /// Smoothly animates the scrollbar position to bottom of swap target after swap is completed
     /// </summary>
     /// <remarks>
     /// Adds a show modifier with the specified scroll direction.
@@ -237,10 +237,13 @@ public sealed class SwapStyleBuilder
     public SwapStyleBuilder ShowOnBottom() => ShowOn(ScrollDirection.Bottom);
 
     /// <summary>
-    /// Specifies a CSS selector to dynamically target for the swap operation, with a scroll direction after the swap.
+    /// Specifies a CSS selector to target for the swap operation, smoothly animating the scrollbar position to either the
+    /// top or the bottom of the target element after the swap.
     /// </summary>
     /// <remarks>
-    /// Adds a show modifier with the specified CSS selector and scroll direction. For example, if <paramref name="selector"/> is ".item" and <paramref name="direction"/> is <see cref="ScrollDirection.Top"/>, the modifier <c>show:.item:top</c> is added.
+    /// Adds a show modifier with the specified CSS selector and scroll direction. For example, if <paramref name="selector"/>
+    /// is ".item" and <paramref name="direction"/> is <see cref="ScrollDirection.Top"/>, the modifier <c>show:.item:top</c>
+    /// is added.
     /// </remarks>
     /// <param name="selector">The CSS selector of the target element.</param>
     /// <param name="direction">The scroll direction after swap.</param>
@@ -261,31 +264,34 @@ public sealed class SwapStyleBuilder
     }
 
     /// <summary>
-    /// Specifies that the swap should show the element matching the CSS selector at the top of the window.
+    /// Specifies that the swap should show the top of the element matching the CSS selector.
     /// </summary>
     /// <remarks>
-    /// This method adds the modifier <c>show:{selector}:top</c>, directing the swap to display the specified element at the top of the window.
+    /// This method adds the modifier <c>show:<param name="selector"/>:top</c>, smoothly scrolling to the top of the element identified by
+    /// <param name="selector"/>.
     /// </remarks>
     /// <param name="selector">The CSS selector of the target element.</param>
     /// <returns>The SwapStyleBuilder instance for chaining.</returns>
     public SwapStyleBuilder ShowOnTop(string selector) => ShowOn(selector, ScrollDirection.Top);
 
     /// <summary>
-    /// Specifies that the swap should show the element matching the CSS selector at the bottom of the window.
+    /// Specifies that the swap should show the bottom of the element matching the CSS selector.
     /// </summary>
     /// <remarks>
-    /// This method adds the modifier <c>show:{selector}:bottom</c>, directing the swap to display the specified element at the bottom of the window.
+    /// This method adds the modifier <c>show:<param name="selector">:bottom</c>, smoothly scrolling to the bottom of the element identified by
+    /// <param name="selector"/>.
     /// </remarks>
     /// <param name="selector">The CSS selector of the target element.</param>
     /// <returns>The SwapStyleBuilder instance for chaining.</returns>
     public SwapStyleBuilder ShowOnBottom(string selector) => ShowOn(selector, ScrollDirection.Bottom);
 
     /// <summary>
-    /// Specifies that the swap should show in the window, with an optional scroll direction.
+    /// Specifies that the swap should show in the window by smoothly scrolling to either the top or bottom of the window.
     /// </summary>
     /// <param name="direction">The direction to scroll the window after the swap.</param>
     /// <remarks>
-    /// This method adds the modifier <c>show:window:{direction}</c>, directing the swap to display the specified element at the bottom of the window.
+    /// This method adds the modifier <c>show:window:<param name="direction"/></c>, directing the swap to display the specified
+    /// element at the bottom of the window.
     /// </remarks>
     /// <returns>The SwapStyleBuilder instance for chaining.</returns>
     public SwapStyleBuilder ShowWindow(ScrollDirection direction)
@@ -304,23 +310,24 @@ public sealed class SwapStyleBuilder
     }
 
     /// <summary>
-    /// Specifies that the swap should show content at the top of the window.
+    /// Specifies that the swap should smoothly scroll to the top of the window.
     /// </summary>
     /// <remarks>
     /// This method adds the modifier <c>show:window:top</c>, instructing the content to be displayed
-    /// at the top of the window following a swap. This can be useful for ensuring that important content or
-    /// notifications at the top of the page are immediately visible to the user after a swap operation.
+    /// at the top of the window following a swap by smoothly animating the scrollbar position. This can be useful
+    /// for ensuring that important content or notifications at the top of the page are immediately visible to
+    /// the user after a swap operation.
     /// </remarks>
     /// <returns>The SwapStyleBuilder instance for chaining.</returns>
     public SwapStyleBuilder ShowWindowTop() => ShowWindow(ScrollDirection.Top);
 
     /// <summary>
-    /// Specifies that the swap should show content at the bottom of the window.
+    /// Specifies that the swap should smoothly scroll to the bottom of the window.
     /// </summary>
     /// <remarks>
     /// This method adds the modifier <c>show:window:bottom</c>, instructing the content to be displayed
-    /// at the bottom of the window following a swap. This positioning can be used for infinite scrolling, footers or
-    /// lower-priority information that should not immediately distract from other content.
+    /// at the bottom of the window following a swap by smoothly animating the scrollbar position. This positioning
+    /// can be used for infinite scrolling, footers, or information appended at the end of the page.
     /// </remarks>
     /// <returns>The SwapStyleBuilder instance for chaining.</returns>
     public SwapStyleBuilder ShowWindowBottom() => ShowWindow(ScrollDirection.Bottom);
@@ -404,8 +411,8 @@ public static class SwapStyleBuilderExtension
     /// </summary>
     /// <remarks>
     /// <paramref name="time"/> will be converted to milliseconds if less than 1000, otherwise seconds, 
-    /// meaning the resulting modifier will be <c>swap:500ms</c> for a <see cref="TimeSpan"/> of 500 milliseconds 
-    /// or <c>swap:2s</c> for a <see cref="TimeSpan"/> of 2 seconds..
+    /// meaning the resulting modifier will be <c>settle:500ms</c> for a <see cref="TimeSpan"/> of 500 milliseconds 
+    /// or <c>settle:2s</c> for a <see cref="TimeSpan"/> of 2 seconds..
     /// </remarks>
     /// <param name="style">The swap style.</param>
     /// <param name="time">The amount of time htmx should wait after receiving a 
@@ -413,11 +420,11 @@ public static class SwapStyleBuilderExtension
     public static SwapStyleBuilder AfterSettleDelay(this SwapStyle style, TimeSpan time) => new SwapStyleBuilder(style).AfterSettleDelay(time);
 
     /// <summary>
-    /// Specifies the direction to scroll the page after the swap and appends the modifier <c>scroll:{direction}</c>.
+    /// Specifies how to set the current window scrollbar after the swap and appends the modifier <c>scroll:<paramref name="direction"/></c>.
     /// </summary>
     /// <remarks>
-    /// Sets the scroll direction on the page after swapping. For instance, using <see cref="ScrollDirection.Top"/>
-    /// will add the modifier <c>scroll:top</c> which instructs the page to scroll to the top after the swap.
+    /// Sets the window scrollbar position after swapping immediately (without animation). For instance, using <see cref="ScrollDirection.Top"/>
+    /// will add the modifier <c>scroll:top</c> which instructs the window to set the scrollbar position to the top of swap content after the swap.
     /// </remarks>
     /// <param name="style">The swap style.</param>
     /// <param name="direction">The scroll direction after the swap.</param>
@@ -425,22 +432,22 @@ public static class SwapStyleBuilderExtension
     public static SwapStyleBuilder Scroll(this SwapStyle style, ScrollDirection direction) => new SwapStyleBuilder(style).Scroll(direction);
 
     /// <summary>
-    /// Automatically scrolls to the top of the page after a swap.
+    /// Sets the window scrollbar position to the top of the swapped content after a swap.
     /// </summary>
     /// <remarks>
     /// This method adds the modifier <c>scroll:top</c> to the swap commands, instructing the page to scroll to
-    /// the top after content is swapped.
+    /// the top after content is swapped immediately and without animation.
     /// </remarks>
     /// <param name="style">The swap style.</param>
     /// <returns>The SwapStyleBuilder instance for chaining.</returns>
     public static SwapStyleBuilder ScrollTop(this SwapStyle style) => new SwapStyleBuilder(style).ScrollTop();
 
     /// <summary>
-    /// Automatically scrolls to the bottom of the page after a swap.
+    /// Sets the window scrollbar position to the bottom of the swapped content after a swap.
     /// </summary>
     /// <remarks>
     /// This method adds the modifier <c>scroll:bottom</c> to the swap commands, instructing the page to scroll to
-    /// the bottom after content is swapped.
+    /// the bottom after content is swapped immediately and without animation.
     /// </remarks>
     /// <param name="style">The swap style.</param>
     /// <returns>The SwapStyleBuilder instance for chaining.</returns>
@@ -448,7 +455,7 @@ public static class SwapStyleBuilderExtension
 
     /// <summary>
     /// Determines whether to ignore the document title in the swap response by appending the modifier
-    /// <c>ignoreTitle:{ignore}</c>.
+    /// <c>ignoreTitle:<paramref name="ignore"/></c>.
     /// </summary>
     /// <remarks>
     /// When set to true, the document title in the swap response will be ignored by adding the modifier
@@ -504,10 +511,10 @@ public static class SwapStyleBuilderExtension
     public static SwapStyleBuilder IgnoreTransition(this SwapStyle style) => new SwapStyleBuilder(style).IgnoreTransition();
 
     /// <summary>
+    /// Allows you to specify that htmx should scroll to the focused element when a request completes.
     /// htmx preserves focus between requests for inputs that have a defined id attribute. By
     /// default htmx prevents auto-scrolling to focused inputs between requests which can be
-    /// unwanted behavior on longer requests when the user has already scrolled away. Allows you
-    /// to specify that htmx should scroll to the focused element when a request completes
+    /// unwanted behavior on longer requests when the user has already scrolled away. 
     /// </summary>
     /// <remarks>
     /// <paramref name="scroll"/> when true will be <c>focus-scroll:true</c>, otherwise when false
@@ -531,20 +538,20 @@ public static class SwapStyleBuilderExtension
     public static SwapStyleBuilder PreserveFocus(this SwapStyle style, bool scroll = true) => new SwapStyleBuilder(style).PreserveFocus();
 
     /// <summary>
-    /// Positions viewport at top of swap target after swap is completed
+    /// Smoothly animates the scrollbar position to top of swap target after swap is completed
     /// </summary>
     /// <remarks>
     /// Adds a show modifier <c>show:top</c>
     /// </remarks>
     /// <param name="style">The swap style.</param>
-    /// <param name="direction">The scroll direction after swap.</param>
     /// <returns>The SwapStyleBuilder instance for chaining.</returns>
-    public static SwapStyleBuilder ShowOnTop(this SwapStyle style, ScrollDirection direction) => new SwapStyleBuilder(style).ShowOn(ScrollDirection.Top);
+    public static SwapStyleBuilder ShowOnTop(this SwapStyle style) => new SwapStyleBuilder(style).ShowOnTop();
 
     /// <summary>
-    /// Positions viewport at top of swap target after swap is completed
+    /// Smoothly animates the scrollbar position to bottom of swap target after swap is completed
     /// </summary>
     /// <remarks>
+    /// Adds a show modifier with the specified scroll direction.
     /// Adds a show modifier <c>show:bottom</c>
     /// </remarks>
     /// <param name="style">The swap style.</param>
@@ -552,10 +559,26 @@ public static class SwapStyleBuilderExtension
     public static SwapStyleBuilder ShowOnBottom(this SwapStyle style) => new SwapStyleBuilder(style).ShowOn(ScrollDirection.Bottom);
 
     /// <summary>
+    /// Smoothly animates the scrollbar position to top or bottom of swap target after swap is completed
+    /// </summary>
+    /// <remarks>
+    /// Adds a show modifier with the specified scroll direction.
+    /// If <paramref name="direction"/> is <see cref="ScrollDirection.Top"/>,
+    /// the modifier <c>show:top</c> is added.  Otherwise, <c>show:bottom</c>
+    /// is added
+    /// </remarks>
+    /// <param name="style">The swap style.</param>
+    /// <param name="direction">The scroll direction after swap.</param>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
+    public static SwapStyleBuilder ShowOn(this SwapStyle style, ScrollDirection direction) => new SwapStyleBuilder(style).ShowOn(direction);
+
+    /// <summary>
     /// Specifies a CSS selector to dynamically target for the swap operation, with a scroll direction after the swap.
     /// </summary>
     /// <remarks>
-    /// Adds a show modifier with the specified CSS selector and scroll direction. For example, if <paramref name="selector"/> is ".item" and <paramref name="direction"/> is <see cref="ScrollDirection.Top"/>, the modifier <c>show:.item:top</c> is added.
+    /// Adds a show modifier with the specified CSS selector and scroll direction. For example, if <paramref name="selector"/>
+    /// is ".item" and <paramref name="direction"/> is <see cref="ScrollDirection.Top"/>, the modifier <c>show:.item:top</c>
+    /// is added.
     /// </remarks>
     /// <param name="style">The swap style.</param>
     /// <param name="selector">The CSS selector of the target element.</param>
@@ -586,35 +609,37 @@ public static class SwapStyleBuilderExtension
     public static SwapStyleBuilder ShowOnBottom(this SwapStyle style, string selector) => new SwapStyleBuilder(style).ShowOnBottom(selector);
 
     /// <summary>
-    /// Specifies that the swap should show in the window, with an optional scroll direction.
+    /// Specifies that the swap should show in the window by smoothly scrolling to either the top or bottom of the window.
     /// </summary>
     /// <param name="direction">The direction to scroll the window after the swap.</param>
     /// <remarks>
-    /// This method adds the modifier <c>show:window:{direction}</c>, directing the swap to display the specified element at the bottom of the window.
+    /// This method adds the modifier <c>show:window:<param name="direction"/></c>, directing the swap to display the specified
+    /// element at the bottom of the window.
     /// </remarks>
     /// <param name="style">The swap style.</param>
     /// <returns>The SwapStyleBuilder instance for chaining.</returns>
     public static SwapStyleBuilder ShowWindow(this SwapStyle style, ScrollDirection direction) => new SwapStyleBuilder(style).ShowWindow(direction);
 
     /// <summary>
-    /// Specifies that the swap should show content at the top of the window.
+    /// Specifies that the swap should smoothly scroll to the top of the window.
     /// </summary>
     /// <remarks>
     /// This method adds the modifier <c>show:window:top</c>, instructing the content to be displayed
-    /// at the top of the window following a swap. This can be useful for ensuring that important content or
-    /// notifications at the top of the page are immediately visible to the user after a swap operation.
+    /// at the top of the window following a swap by smoothly animating the scrollbar position. This can be useful
+    /// for ensuring that important content or notifications at the top of the page are immediately visible to
+    /// the user after a swap operation.
     /// </remarks>
     /// <param name="style">The swap style.</param>
     /// <returns>The SwapStyleBuilder instance for chaining.</returns>
     public static SwapStyleBuilder ShowWindowTop(this SwapStyle style) => new SwapStyleBuilder(style).ShowWindowTop();
 
     /// <summary>
-    /// Specifies that the swap should show content at the bottom of the window.
+    /// Specifies that the swap should smoothly scroll to the bottom of the window.
     /// </summary>
     /// <remarks>
     /// This method adds the modifier <c>show:window:bottom</c>, instructing the content to be displayed
-    /// at the bottom of the window following a swap. This positioning can be used for infinite scrolling, footers or
-    /// lower-priority information that should not immediately distract from other content.
+    /// at the bottom of the window following a swap by smoothly animating the scrollbar position. This positioning
+    /// can be used for infinite scrolling, footers, or information appended at the end of the page.
     /// </remarks>
     /// <param name="style">The swap style.</param>
     /// <returns>The SwapStyleBuilder instance for chaining.</returns>

--- a/src/Htmxor/Http/SwapStyleBuilder.cs
+++ b/src/Htmxor/Http/SwapStyleBuilder.cs
@@ -29,7 +29,6 @@ public sealed class SwapStyleBuilder
     /// meaning the resulting modifier will be <c>swap:500ms</c> for a <see cref="TimeSpan"/> of 500 milliseconds 
     /// or <c>swap:2s</c> for a <see cref="TimeSpan"/> of 2 seconds..
     /// </remarks>
-    /// <param name="style">The swap style.</param>
     /// <param name="time">The amount of time htmx should wait after receiving a 
     /// response to swap the content.</param>
     public SwapStyleBuilder AfterSwapDelay(TimeSpan time)
@@ -164,6 +163,7 @@ public sealed class SwapStyleBuilder
     public SwapStyleBuilder IgnoreTransition() => Transition(false);
 
     /// <summary>
+    /// Allows you to specify that htmx should scroll to the focused element when a request completes.
     /// htmx preserves focus between requests for inputs that have a defined id attribute. By
     /// default htmx prevents auto-scrolling to focused inputs between requests which can be
     /// unwanted behavior on longer requests when the user has already scrolled away. 
@@ -181,10 +181,63 @@ public sealed class SwapStyleBuilder
         return this;
     }
 
+    /// <summary>
+    /// Explicitly preserves focus between requests for inputs that have a defined id attribute without
+    /// scrolling.
+    /// </summary>
+    /// <remarks>
+    /// Adds a modifier of <c>focus-scroll:false</c>
+    /// </remarks>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
     public SwapStyleBuilder PreserveFocus() => ScrollFocus(false);
 
     /// <summary>
-    /// Specifies a CSS selector to dynamically target for the swap operation, with an optional scroll direction after the swap.
+    /// Positions viewport at top of swap target after swap is completed
+    /// </summary>
+    /// <remarks>
+    /// Adds a show modifier with the specified scroll direction.
+    /// If <paramref name="direction"/> is <see cref="ScrollDirection.Top"/>,
+    /// the modifier <c>show:top</c> is added.  Otherwise, <c>show:bottom</c>
+    /// is added
+    /// </remarks>
+    /// <param name="direction">The scroll direction after swap.</param>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
+    public SwapStyleBuilder ShowOn(ScrollDirection direction)
+    {
+	    switch (direction)
+	    {
+		    case ScrollDirection.Top:
+			    AddModifier("show", $"top");
+			    break;
+		    case ScrollDirection.Bottom:
+			    AddModifier("show", $"bottom");
+			    break;
+	    }
+
+	    return this;
+    }
+
+    /// <summary>
+    /// Positions viewport at top of swap target after swap is completed
+    /// </summary>
+    /// <remarks>
+    /// Adds a show modifier <c>show:top</c>
+    /// </remarks>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
+    public SwapStyleBuilder ShowOnTop() => ShowOn(ScrollDirection.Top);
+
+    /// <summary>
+    /// Positions viewport at top of swap target after swap is completed
+    /// </summary>
+    /// <remarks>
+    /// Adds a show modifier with the specified scroll direction.
+    /// Adds a show modifier <c>show:bottom</c>
+    /// </remarks>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
+    public SwapStyleBuilder ShowOnBottom() => ShowOn(ScrollDirection.Bottom);
+
+    /// <summary>
+    /// Specifies a CSS selector to dynamically target for the swap operation, with a scroll direction after the swap.
     /// </summary>
     /// <remarks>
     /// Adds a show modifier with the specified CSS selector and scroll direction. For example, if <paramref name="selector"/> is ".item" and <paramref name="direction"/> is <see cref="ScrollDirection.Top"/>, the modifier <c>show:.item:top</c> is added.
@@ -235,15 +288,15 @@ public sealed class SwapStyleBuilder
     /// This method adds the modifier <c>show:window:{direction}</c>, directing the swap to display the specified element at the bottom of the window.
     /// </remarks>
     /// <returns>The SwapStyleBuilder instance for chaining.</returns>
-    public SwapStyleBuilder ShowOnWindow(ScrollDirection direction)
+    public SwapStyleBuilder ShowWindow(ScrollDirection direction)
     {
         switch (direction)
         {
             case ScrollDirection.Top:
-                AddModifier("show", $"window:top");
+                AddModifier("show", "window:top");
                 break;
             case ScrollDirection.Bottom:
-                AddModifier("show", $"window:bottom");
+                AddModifier("show", "window:bottom");
                 break;
         }
 
@@ -256,10 +309,10 @@ public sealed class SwapStyleBuilder
     /// <remarks>
     /// This method adds the modifier <c>show:window:top</c>, instructing the content to be displayed
     /// at the top of the window following a swap. This can be useful for ensuring that important content or
-    /// notifications are immediately visible to the user after a swap operation.
+    /// notifications at the top of the page are immediately visible to the user after a swap operation.
     /// </remarks>
     /// <returns>The SwapStyleBuilder instance for chaining.</returns>
-    public SwapStyleBuilder ShowOnWindowTop() => ShowOnWindow(ScrollDirection.Top);
+    public SwapStyleBuilder ShowWindowTop() => ShowWindow(ScrollDirection.Top);
 
     /// <summary>
     /// Specifies that the swap should show content at the bottom of the window.
@@ -270,7 +323,7 @@ public sealed class SwapStyleBuilder
     /// lower-priority information that should not immediately distract from other content.
     /// </remarks>
     /// <returns>The SwapStyleBuilder instance for chaining.</returns>
-    public SwapStyleBuilder ShowOnWindowBottom() => ShowOnWindow(ScrollDirection.Bottom);
+    public SwapStyleBuilder ShowWindowBottom() => ShowWindow(ScrollDirection.Bottom);
 
     /// <summary>
     /// Turns off scrolling after swap.
@@ -318,6 +371,11 @@ public sealed class SwapStyleBuilder
         modifiers.Add(modifier, options);
     }
 
+    /// <summary>
+    /// Adds a boolean modifier to modifiers
+    /// </summary>
+    /// <param name="modifier"></param>
+    /// <param name="option"></param>
     private void AddModifier(string modifier, bool option) => AddModifier(modifier, option ? "true" : "false");
 }
 
@@ -326,26 +384,250 @@ public sealed class SwapStyleBuilder
 /// </summary>
 public static class SwapStyleBuilderExtension
 {
-    // Each method below returns a SwapStyleBuilder instance initialized with the respective SwapStyle
-    // and applies the specified modifier to it. This allows for fluent configuration of swap style commands.
-
+    /// <summary>
+    /// Modifies the amount of time that htmx will wait after receiving a 
+    /// response to swap the content by including the modifier <c>swap:<paramref name="time"/></c>.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="time"/> will be converted to milliseconds if less than 1000, otherwise seconds, 
+    /// meaning the resulting modifier will be <c>swap:500ms</c> for a <see cref="TimeSpan"/> of 500 milliseconds 
+    /// or <c>swap:2s</c> for a <see cref="TimeSpan"/> of 2 seconds..
+    /// </remarks>
+    /// <param name="style">The swap style.</param>
+    /// <param name="time">The amount of time htmx should wait after receiving a 
+    /// response to swap the content.</param>
     public static SwapStyleBuilder AfterSwapDelay(this SwapStyle style, TimeSpan time) => new SwapStyleBuilder(style).AfterSwapDelay(time);
+
+    /// <summary>
+    /// Modifies the amount of time that htmx will wait between the swap 
+    /// and the settle logic by including the modifier <c>settle:<paramref name="time"/></c>.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="time"/> will be converted to milliseconds if less than 1000, otherwise seconds, 
+    /// meaning the resulting modifier will be <c>swap:500ms</c> for a <see cref="TimeSpan"/> of 500 milliseconds 
+    /// or <c>swap:2s</c> for a <see cref="TimeSpan"/> of 2 seconds..
+    /// </remarks>
+    /// <param name="style">The swap style.</param>
+    /// <param name="time">The amount of time htmx should wait after receiving a 
+    /// response to swap the content.</param>
     public static SwapStyleBuilder AfterSettleDelay(this SwapStyle style, TimeSpan time) => new SwapStyleBuilder(style).AfterSettleDelay(time);
+
+    /// <summary>
+    /// Specifies the direction to scroll the page after the swap and appends the modifier <c>scroll:{direction}</c>.
+    /// </summary>
+    /// <remarks>
+    /// Sets the scroll direction on the page after swapping. For instance, using <see cref="ScrollDirection.Top"/>
+    /// will add the modifier <c>scroll:top</c> which instructs the page to scroll to the top after the swap.
+    /// </remarks>
+    /// <param name="style">The swap style.</param>
+    /// <param name="direction">The scroll direction after the swap.</param>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
     public static SwapStyleBuilder Scroll(this SwapStyle style, ScrollDirection direction) => new SwapStyleBuilder(style).Scroll(direction);
+
+    /// <summary>
+    /// Automatically scrolls to the top of the page after a swap.
+    /// </summary>
+    /// <remarks>
+    /// This method adds the modifier <c>scroll:top</c> to the swap commands, instructing the page to scroll to
+    /// the top after content is swapped.
+    /// </remarks>
+    /// <param name="style">The swap style.</param>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
     public static SwapStyleBuilder ScrollTop(this SwapStyle style) => new SwapStyleBuilder(style).ScrollTop();
+
+    /// <summary>
+    /// Automatically scrolls to the bottom of the page after a swap.
+    /// </summary>
+    /// <remarks>
+    /// This method adds the modifier <c>scroll:bottom</c> to the swap commands, instructing the page to scroll to
+    /// the bottom after content is swapped.
+    /// </remarks>
+    /// <param name="style">The swap style.</param>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
     public static SwapStyleBuilder ScrollBottom(this SwapStyle style) => new SwapStyleBuilder(style).ScrollBottom();
+
+    /// <summary>
+    /// Determines whether to ignore the document title in the swap response by appending the modifier
+    /// <c>ignoreTitle:{ignore}</c>.
+    /// </summary>
+    /// <remarks>
+    /// When set to true, the document title in the swap response will be ignored by adding the modifier
+    /// <c>ignoreTitle:true</c>.
+    /// This keeps the current title unchanged regardless of the incoming swap content's title tag.
+    /// </remarks>
+    /// <param name="style">The swap style.</param>
+    /// <param name="ignore">Whether to ignore the title.</param>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
     public static SwapStyleBuilder IgnoreTitle(this SwapStyle style, bool ignore = true) => new SwapStyleBuilder(style).IgnoreTitle(ignore);
+
+    /// <summary>
+    /// Includes the document title from the swap response in the current page.
+    /// </summary>
+    /// <remarks>
+    /// This method ensures the title of the document is updated according to the swap response by removing any
+    /// ignoreTitle modifiers, effectively setting <c>ignoreTitle:false</c>.
+    /// </remarks>
+    /// <param name="style">The swap style.</param>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
     public static SwapStyleBuilder IncludeTitle(this SwapStyle style) => new SwapStyleBuilder(style).IncludeTitle();
+
+    /// <summary>
+    /// Enables or disables transition effects for the swap by appending the modifier <c>transition:{show}</c>.
+    /// </summary>
+    /// <remarks>
+    /// Controls the display of transition effects during the swap. For example, setting <paramref name="show"/> to true
+    /// will add the modifier <c>transition:true</c> to enable smooth transitions.
+    /// </remarks>
+    /// <param name="style">The swap style.</param>
+    /// <param name="show">Whether to show transition effects.</param>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
     public static SwapStyleBuilder Transition(this SwapStyle style, bool show) => new SwapStyleBuilder(style).Transition(show);
+
+    /// <summary>
+    /// Explicitly includes transition effects for the swap.
+    /// </summary>
+    /// <remarks>
+    /// By calling this method, transition effects are enabled for the swap, adding the modifier <c>transition:true</c>.
+    /// </remarks>
+    /// <param name="style">The swap style.</param>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
     public static SwapStyleBuilder IncludeTransition(this SwapStyle style) => new SwapStyleBuilder(style).IncludeTransition();
+
+    /// <summary>
+    /// Explicitly ignores transition effects for the swap.
+    /// </summary>
+    /// <remarks>
+    /// This method disables transition effects by adding the modifier <c>transition:false</c> to the swap commands.
+    /// </remarks>
+    /// <param name="style">The swap style.</param>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
     public static SwapStyleBuilder IgnoreTransition(this SwapStyle style) => new SwapStyleBuilder(style).IgnoreTransition();
+
+    /// <summary>
+    /// htmx preserves focus between requests for inputs that have a defined id attribute. By
+    /// default htmx prevents auto-scrolling to focused inputs between requests which can be
+    /// unwanted behavior on longer requests when the user has already scrolled away. Allows you
+    /// to specify that htmx should scroll to the focused element when a request completes
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="scroll"/> when true will be <c>focus-scroll:true</c>, otherwise when false
+    /// will be <c>focus-scroll:false</c>
+    /// </remarks>
+    /// <param name="style">The swap style.</param>
+    /// <param name="scroll">Whether to scroll to the focus element.</param>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
     public static SwapStyleBuilder ScrollFocus(this SwapStyle style, bool scroll = true) => new SwapStyleBuilder(style).ScrollFocus(scroll);
+
+    /// <summary>
+    /// Explicitly preserves focus between requests for inputs that have a defined id attribute without
+    /// scrolling.
+    /// </summary>
+    /// <remarks>
+    /// Adds a modifier of <c>focus-scroll:false</c>
+    /// </remarks>
+    /// <param name="style">The swap style.</param>
+    /// <param name="scroll">Whether to scroll to current focus or preserve focus</param>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
     public static SwapStyleBuilder PreserveFocus(this SwapStyle style, bool scroll = true) => new SwapStyleBuilder(style).PreserveFocus();
+
+    /// <summary>
+    /// Positions viewport at top of swap target after swap is completed
+    /// </summary>
+    /// <remarks>
+    /// Adds a show modifier <c>show:top</c>
+    /// </remarks>
+    /// <param name="style">The swap style.</param>
+    /// <param name="direction">The scroll direction after swap.</param>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
+    public static SwapStyleBuilder ShowOnTop(this SwapStyle style, ScrollDirection direction) => new SwapStyleBuilder(style).ShowOn(ScrollDirection.Top);
+
+    /// <summary>
+    /// Positions viewport at top of swap target after swap is completed
+    /// </summary>
+    /// <remarks>
+    /// Adds a show modifier <c>show:bottom</c>
+    /// </remarks>
+    /// <param name="style">The swap style.</param>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
+    public static SwapStyleBuilder ShowOnBottom(this SwapStyle style) => new SwapStyleBuilder(style).ShowOn(ScrollDirection.Bottom);
+
+    /// <summary>
+    /// Specifies a CSS selector to dynamically target for the swap operation, with a scroll direction after the swap.
+    /// </summary>
+    /// <remarks>
+    /// Adds a show modifier with the specified CSS selector and scroll direction. For example, if <paramref name="selector"/> is ".item" and <paramref name="direction"/> is <see cref="ScrollDirection.Top"/>, the modifier <c>show:.item:top</c> is added.
+    /// </remarks>
+    /// <param name="style">The swap style.</param>
+    /// <param name="selector">The CSS selector of the target element.</param>
+    /// <param name="direction">The scroll direction after swap.</param>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
     public static SwapStyleBuilder ShowOn(this SwapStyle style, string selector, ScrollDirection direction) => new SwapStyleBuilder(style).ShowOn(selector, direction);
+
+    /// <summary>
+    /// Specifies that the swap should show the element matching the CSS selector at the top of the window.
+    /// </summary>
+    /// <remarks>
+    /// This method adds the modifier <c>show:{selector}:top</c>, directing the swap to display the specified element at the top of the window.
+    /// </remarks>
+    /// <param name="style">The swap style.</param>
+    /// <param name="selector">The CSS selector of the target element.</param>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
     public static SwapStyleBuilder ShowOnTop(this SwapStyle style, string selector) => new SwapStyleBuilder(style).ShowOnTop(selector);
+
+    /// <summary>
+    /// Specifies that the swap should show the element matching the CSS selector at the bottom of the window.
+    /// </summary>
+    /// <remarks>
+    /// This method adds the modifier <c>show:{selector}:bottom</c>, directing the swap to display the specified element at the bottom of the window.
+    /// </remarks>
+    /// <param name="style">The swap style.</param>
+    /// <param name="selector">The CSS selector of the target element.</param>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
     public static SwapStyleBuilder ShowOnBottom(this SwapStyle style, string selector) => new SwapStyleBuilder(style).ShowOnBottom(selector);
-    public static SwapStyleBuilder ShowOnWindow(this SwapStyle style, ScrollDirection direction) => new SwapStyleBuilder(style).ShowOnWindow(direction);
-    public static SwapStyleBuilder ShowOnWindowTop(this SwapStyle style) => new SwapStyleBuilder(style).ShowOnWindowTop();
-    public static SwapStyleBuilder ShowOnWindowBottom(this SwapStyle style) => new SwapStyleBuilder(style).ShowOnWindowBottom();
+
+    /// <summary>
+    /// Specifies that the swap should show in the window, with an optional scroll direction.
+    /// </summary>
+    /// <param name="direction">The direction to scroll the window after the swap.</param>
+    /// <remarks>
+    /// This method adds the modifier <c>show:window:{direction}</c>, directing the swap to display the specified element at the bottom of the window.
+    /// </remarks>
+    /// <param name="style">The swap style.</param>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
+    public static SwapStyleBuilder ShowWindow(this SwapStyle style, ScrollDirection direction) => new SwapStyleBuilder(style).ShowWindow(direction);
+
+    /// <summary>
+    /// Specifies that the swap should show content at the top of the window.
+    /// </summary>
+    /// <remarks>
+    /// This method adds the modifier <c>show:window:top</c>, instructing the content to be displayed
+    /// at the top of the window following a swap. This can be useful for ensuring that important content or
+    /// notifications at the top of the page are immediately visible to the user after a swap operation.
+    /// </remarks>
+    /// <param name="style">The swap style.</param>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
+    public static SwapStyleBuilder ShowWindowTop(this SwapStyle style) => new SwapStyleBuilder(style).ShowWindowTop();
+
+    /// <summary>
+    /// Specifies that the swap should show content at the bottom of the window.
+    /// </summary>
+    /// <remarks>
+    /// This method adds the modifier <c>show:window:bottom</c>, instructing the content to be displayed
+    /// at the bottom of the window following a swap. This positioning can be used for infinite scrolling, footers or
+    /// lower-priority information that should not immediately distract from other content.
+    /// </remarks>
+    /// <param name="style">The swap style.</param>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
+    public static SwapStyleBuilder ShowWindowBottom(this SwapStyle style) => new SwapStyleBuilder(style).ShowWindowBottom();
+
+    /// <summary>
+    /// Turns off scrolling after swap.
+    /// </summary>
+    /// <remarks>
+    /// This method disables automatic scrolling by setting the modifier <c>show:none</c>, ensuring the page
+    /// position remains unchanged after the swap.
+    /// </remarks>
+    /// <param name="style">The swap style.</param>
+    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
     public static SwapStyleBuilder ShowNone(this SwapStyle style) => new SwapStyleBuilder(style).ShowNone();
 }

--- a/src/Htmxor/Http/SwapStyleBuilder.cs
+++ b/src/Htmxor/Http/SwapStyleBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Specialized;
+using System.Numerics;
 
 namespace Htmxor.Http;
 
@@ -57,23 +58,25 @@ public sealed class SwapStyleBuilder
     }
 
     /// <summary>
-    /// Specifies how to set the current window scrollbar after the swap and appends the modifier <c>scroll:<paramref name="direction"/></c>.
+    /// Specifies how to set the content scrollbar position after the swap and appends the modifier <c>scroll:<paramref name="direction"/></c>.
     /// </summary>
     /// <remarks>
-    /// Sets the window scrollbar position after swapping immediately (without animation). For instance, using <see cref="ScrollDirection.Top"/>
-    /// will add the modifier <c>scroll:top</c> which instructs the window to set the scrollbar position to the top of swap content after the swap.
+    /// Sets the swapped content scrollbar position after swapping immediately (without animation). For instance, using <see cref="ScrollDirection.Top"/>
+    /// will add the modifier <c>scroll:top</c> which sets the scrollbar position to the top of swap content after the swap.
+    /// If css <paramref name="selector"/> is present then the page is scrolled to the <paramref name="direction"/> of the content identified by the css selector.
     /// </remarks>
     /// <param name="direction">The scroll direction after the swap.</param>
+    /// <param name="selector">Optional CSS selector of the target element.</param>
     /// <returns>The SwapStyleBuilder instance for chaining.</returns>
-    public SwapStyleBuilder Scroll(ScrollDirection direction)
+    public SwapStyleBuilder Scroll(ScrollDirection direction, string? selector = null)
     {
         switch (direction)
         {
             case ScrollDirection.Top:
-                AddModifier("scroll", "top");
+                AddModifier("scroll", selector is null ? "top" : $"{selector}:top");
                 break;
             case ScrollDirection.Bottom:
-                AddModifier("scroll", "bottom");
+                AddModifier("scroll", selector is null ? "bottom" : $"{selector}:bottom");
                 break;
         }
 
@@ -81,25 +84,29 @@ public sealed class SwapStyleBuilder
     }
 
     /// <summary>
-    /// Sets the window scrollbar position to the top of the swapped content after a swap.
+    /// Sets the content scrollbar position to the top of the swapped content after a swap.
     /// </summary>
     /// <remarks>
     /// This method adds the modifier <c>scroll:top</c> to the swap commands, instructing the page to scroll to
-    /// the top after content is swapped immediately and without animation.
+    /// the top of the content after content is swapped immediately and without animation. If css <paramref name="selector"/>
+    /// is present then the page is scrolled to the top of the content identified by the css selector.
     /// </remarks>
+    /// <param name="selector">Optional CSS selector of the target element.</param>
     /// <returns>The SwapStyleBuilder instance for chaining.</returns>
-    public SwapStyleBuilder ScrollTop() => Scroll(ScrollDirection.Top);
+    public SwapStyleBuilder ScrollTop(string? selector = null) => Scroll(ScrollDirection.Top, selector);
 
     /// <summary>
-    /// Sets the window scrollbar position to the bottom of the swapped content after a swap.
+    /// Sets the content scrollbar position to the bottom of the swapped content after a swap.
     /// </summary>
     /// <remarks>
     /// This method adds the modifier <c>scroll:bottom</c> to the swap commands, instructing the page to scroll to
-    /// the bottom after content is swapped immediately and without animation.
+    /// the bottom of the content after content is swapped immediately and without animation. If css <paramref name="selector"/>
+    /// is present then the page is scrolled to the bottom of the content identified by the css selector.
     /// </remarks>
+    /// <param name="selector">Optional CSS selector of the target element.</param>
     /// <returns>The SwapStyleBuilder instance for chaining.</returns>
-    public SwapStyleBuilder ScrollBottom() => Scroll(ScrollDirection.Bottom);
-
+    public SwapStyleBuilder ScrollBottom(string? selector = null) => Scroll(ScrollDirection.Bottom, selector);
+    
     /// <summary>
     /// Determines whether to ignore the document title in the swap response by appending the modifier
     /// <c>ignoreTitle:<paramref name="ignore"/></c>.
@@ -192,51 +199,6 @@ public sealed class SwapStyleBuilder
     public SwapStyleBuilder PreserveFocus() => ScrollFocus(false);
 
     /// <summary>
-    /// Smoothly animates the scrollbar position to top or bottom of swap target after swap is completed
-    /// </summary>
-    /// <remarks>
-    /// Adds a show modifier with the specified scroll direction.
-    /// If <paramref name="direction"/> is <see cref="ScrollDirection.Top"/>,
-    /// the modifier <c>show:top</c> is added.  Otherwise, <c>show:bottom</c>
-    /// is added
-    /// </remarks>
-    /// <param name="direction">The scroll direction after swap.</param>
-    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
-    public SwapStyleBuilder ShowOn(ScrollDirection direction)
-    {
-	    switch (direction)
-	    {
-		    case ScrollDirection.Top:
-			    AddModifier("show", $"top");
-			    break;
-		    case ScrollDirection.Bottom:
-			    AddModifier("show", $"bottom");
-			    break;
-	    }
-
-	    return this;
-    }
-
-    /// <summary>
-    /// Smoothly animates the scrollbar position to top of swap target after swap is completed
-    /// </summary>
-    /// <remarks>
-    /// Adds a show modifier <c>show:top</c>
-    /// </remarks>
-    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
-    public SwapStyleBuilder ShowOnTop() => ShowOn(ScrollDirection.Top);
-
-    /// <summary>
-    /// Smoothly animates the scrollbar position to bottom of swap target after swap is completed
-    /// </summary>
-    /// <remarks>
-    /// Adds a show modifier with the specified scroll direction.
-    /// Adds a show modifier <c>show:bottom</c>
-    /// </remarks>
-    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
-    public SwapStyleBuilder ShowOnBottom() => ShowOn(ScrollDirection.Bottom);
-
-    /// <summary>
     /// Specifies a CSS selector to target for the swap operation, smoothly animating the scrollbar position to either the
     /// top or the bottom of the target element after the swap.
     /// </summary>
@@ -245,18 +207,18 @@ public sealed class SwapStyleBuilder
     /// is ".item" and <paramref name="direction"/> is <see cref="ScrollDirection.Top"/>, the modifier <c>show:.item:top</c>
     /// is added.
     /// </remarks>
-    /// <param name="selector">The CSS selector of the target element.</param>
     /// <param name="direction">The scroll direction after swap.</param>
+    /// <param name="selector">Optional CSS selector of the target element.</param>
     /// <returns>The SwapStyleBuilder instance for chaining.</returns>
-    public SwapStyleBuilder ShowOn(string selector, ScrollDirection direction)
+    public SwapStyleBuilder ShowOn(ScrollDirection direction, string? selector = null)
     {
         switch (direction)
         {
             case ScrollDirection.Top:
-                AddModifier("show", $"{selector}:top");
+                AddModifier("show", selector is null ? "top" : $"{selector}:top");
                 break;
             case ScrollDirection.Bottom:
-                AddModifier("show", $"{selector}:bottom");
+                AddModifier("show", selector is null ? "bottom" : $"{selector}:bottom");
                 break;
         }
 
@@ -267,30 +229,30 @@ public sealed class SwapStyleBuilder
     /// Specifies that the swap should show the top of the element matching the CSS selector.
     /// </summary>
     /// <remarks>
-    /// This method adds the modifier <c>show:<param name="selector"/>:top</c>, smoothly scrolling to the top of the element identified by
-    /// <param name="selector"/>.
+    /// This method adds the modifier <c>show:<paramref name="selector"/>:top</c>, smoothly scrolling to the top of the element identified by
+    /// <paramref name="selector"/>.
     /// </remarks>
-    /// <param name="selector">The CSS selector of the target element.</param>
+    /// <param name="selector">Optional CSS selector of the target element.</param>
     /// <returns>The SwapStyleBuilder instance for chaining.</returns>
-    public SwapStyleBuilder ShowOnTop(string selector) => ShowOn(selector, ScrollDirection.Top);
+    public SwapStyleBuilder ShowOnTop(string? selector = null) => ShowOn(ScrollDirection.Top, selector);
 
     /// <summary>
     /// Specifies that the swap should show the bottom of the element matching the CSS selector.
     /// </summary>
     /// <remarks>
-    /// This method adds the modifier <c>show:<param name="selector">:bottom</c>, smoothly scrolling to the bottom of the element identified by
-    /// <param name="selector"/>.
+    /// This method adds the modifier <c>show:<paramref name="selector"/>:bottom</c>, smoothly scrolling to the bottom of the element identified by
+    /// <paramref name="selector"/>.
     /// </remarks>
-    /// <param name="selector">The CSS selector of the target element.</param>
+    /// <param name="selector">Optional CSS selector of the target element.</param>
     /// <returns>The SwapStyleBuilder instance for chaining.</returns>
-    public SwapStyleBuilder ShowOnBottom(string selector) => ShowOn(selector, ScrollDirection.Bottom);
+    public SwapStyleBuilder ShowOnBottom(string? selector = null) => ShowOn(ScrollDirection.Bottom, selector);
 
     /// <summary>
     /// Specifies that the swap should show in the window by smoothly scrolling to either the top or bottom of the window.
     /// </summary>
     /// <param name="direction">The direction to scroll the window after the swap.</param>
     /// <remarks>
-    /// This method adds the modifier <c>show:window:<param name="direction"/></c>, directing the swap to display the specified
+    /// This method adds the modifier <c>show:window:<paramref name="direction"/></c>, directing the swap to display the specified
     /// element at the bottom of the window.
     /// </remarks>
     /// <returns>The SwapStyleBuilder instance for chaining.</returns>
@@ -420,38 +382,44 @@ public static class SwapStyleBuilderExtension
     public static SwapStyleBuilder AfterSettleDelay(this SwapStyle style, TimeSpan time) => new SwapStyleBuilder(style).AfterSettleDelay(time);
 
     /// <summary>
-    /// Specifies how to set the current window scrollbar after the swap and appends the modifier <c>scroll:<paramref name="direction"/></c>.
+    /// Specifies how to set the content scrollbar position after the swap and appends the modifier <c>scroll:<paramref name="direction"/></c>.
     /// </summary>
     /// <remarks>
-    /// Sets the window scrollbar position after swapping immediately (without animation). For instance, using <see cref="ScrollDirection.Top"/>
-    /// will add the modifier <c>scroll:top</c> which instructs the window to set the scrollbar position to the top of swap content after the swap.
+    /// Sets the swapped content scrollbar position after swapping immediately (without animation). For instance, using <see cref="ScrollDirection.Top"/>
+    /// will add the modifier <c>scroll:top</c> which sets the scrollbar position to the top of swap content after the swap.
+    /// If css <paramref name="selector"/> is present then the page is scrolled to the <paramref name="direction"/> of the content identified by the css selector.
     /// </remarks>
     /// <param name="style">The swap style.</param>
     /// <param name="direction">The scroll direction after the swap.</param>
+    /// <param name="selector">Optional CSS selector of the target element.</param>
     /// <returns>The SwapStyleBuilder instance for chaining.</returns>
-    public static SwapStyleBuilder Scroll(this SwapStyle style, ScrollDirection direction) => new SwapStyleBuilder(style).Scroll(direction);
+    public static SwapStyleBuilder Scroll(this SwapStyle style, ScrollDirection direction, string? selector) => new SwapStyleBuilder(style).Scroll(direction, selector);
 
     /// <summary>
-    /// Sets the window scrollbar position to the top of the swapped content after a swap.
+    /// Sets the content scrollbar position to the top of the swapped content after a swap.
     /// </summary>
     /// <remarks>
     /// This method adds the modifier <c>scroll:top</c> to the swap commands, instructing the page to scroll to
-    /// the top after content is swapped immediately and without animation.
+    /// the top of the content after content is swapped immediately and without animation. If css <paramref name="selector"/>
+    /// is present then the page is scrolled to the top of the content identified by the css selector.
     /// </remarks>
+    /// <param name="selector">Optional CSS selector of the target element.</param>
     /// <param name="style">The swap style.</param>
     /// <returns>The SwapStyleBuilder instance for chaining.</returns>
-    public static SwapStyleBuilder ScrollTop(this SwapStyle style) => new SwapStyleBuilder(style).ScrollTop();
+    public static SwapStyleBuilder ScrollTop(this SwapStyle style, string? selector) => new SwapStyleBuilder(style).ScrollTop(selector);
 
     /// <summary>
-    /// Sets the window scrollbar position to the bottom of the swapped content after a swap.
+    /// Sets the content scrollbar position to the bottom of the swapped content after a swap.
     /// </summary>
     /// <remarks>
     /// This method adds the modifier <c>scroll:bottom</c> to the swap commands, instructing the page to scroll to
-    /// the bottom after content is swapped immediately and without animation.
+    /// the bottom of the content after content is swapped immediately and without animation. If css <paramref name="selector"/>
+    /// is present then the page is scrolled to the bottom of the content identified by the css selector.
     /// </remarks>
+    /// <param name="selector">Optional CSS selector of the target element.</param>
     /// <param name="style">The swap style.</param>
     /// <returns>The SwapStyleBuilder instance for chaining.</returns>
-    public static SwapStyleBuilder ScrollBottom(this SwapStyle style) => new SwapStyleBuilder(style).ScrollBottom();
+    public static SwapStyleBuilder ScrollBottom(this SwapStyle style, string? selector) => new SwapStyleBuilder(style).ScrollBottom(selector);
 
     /// <summary>
     /// Determines whether to ignore the document title in the swap response by appending the modifier
@@ -538,41 +506,6 @@ public static class SwapStyleBuilderExtension
     public static SwapStyleBuilder PreserveFocus(this SwapStyle style, bool scroll = true) => new SwapStyleBuilder(style).PreserveFocus();
 
     /// <summary>
-    /// Smoothly animates the scrollbar position to top of swap target after swap is completed
-    /// </summary>
-    /// <remarks>
-    /// Adds a show modifier <c>show:top</c>
-    /// </remarks>
-    /// <param name="style">The swap style.</param>
-    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
-    public static SwapStyleBuilder ShowOnTop(this SwapStyle style) => new SwapStyleBuilder(style).ShowOnTop();
-
-    /// <summary>
-    /// Smoothly animates the scrollbar position to bottom of swap target after swap is completed
-    /// </summary>
-    /// <remarks>
-    /// Adds a show modifier with the specified scroll direction.
-    /// Adds a show modifier <c>show:bottom</c>
-    /// </remarks>
-    /// <param name="style">The swap style.</param>
-    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
-    public static SwapStyleBuilder ShowOnBottom(this SwapStyle style) => new SwapStyleBuilder(style).ShowOn(ScrollDirection.Bottom);
-
-    /// <summary>
-    /// Smoothly animates the scrollbar position to top or bottom of swap target after swap is completed
-    /// </summary>
-    /// <remarks>
-    /// Adds a show modifier with the specified scroll direction.
-    /// If <paramref name="direction"/> is <see cref="ScrollDirection.Top"/>,
-    /// the modifier <c>show:top</c> is added.  Otherwise, <c>show:bottom</c>
-    /// is added
-    /// </remarks>
-    /// <param name="style">The swap style.</param>
-    /// <param name="direction">The scroll direction after swap.</param>
-    /// <returns>The SwapStyleBuilder instance for chaining.</returns>
-    public static SwapStyleBuilder ShowOn(this SwapStyle style, ScrollDirection direction) => new SwapStyleBuilder(style).ShowOn(direction);
-
-    /// <summary>
     /// Specifies a CSS selector to dynamically target for the swap operation, with a scroll direction after the swap.
     /// </summary>
     /// <remarks>
@@ -581,10 +514,10 @@ public static class SwapStyleBuilderExtension
     /// is added.
     /// </remarks>
     /// <param name="style">The swap style.</param>
-    /// <param name="selector">The CSS selector of the target element.</param>
+    /// <param name="selector">Optional CSS selector of the target element.</param>
     /// <param name="direction">The scroll direction after swap.</param>
     /// <returns>The SwapStyleBuilder instance for chaining.</returns>
-    public static SwapStyleBuilder ShowOn(this SwapStyle style, string selector, ScrollDirection direction) => new SwapStyleBuilder(style).ShowOn(selector, direction);
+    public static SwapStyleBuilder ShowOn(this SwapStyle style, ScrollDirection direction, string? selector = null) => new SwapStyleBuilder(style).ShowOn(direction, selector);
 
     /// <summary>
     /// Specifies that the swap should show the element matching the CSS selector at the top of the window.
@@ -593,9 +526,9 @@ public static class SwapStyleBuilderExtension
     /// This method adds the modifier <c>show:{selector}:top</c>, directing the swap to display the specified element at the top of the window.
     /// </remarks>
     /// <param name="style">The swap style.</param>
-    /// <param name="selector">The CSS selector of the target element.</param>
+    /// <param name="selector">Optional CSS selector of the target element.</param>
     /// <returns>The SwapStyleBuilder instance for chaining.</returns>
-    public static SwapStyleBuilder ShowOnTop(this SwapStyle style, string selector) => new SwapStyleBuilder(style).ShowOnTop(selector);
+    public static SwapStyleBuilder ShowOnTop(this SwapStyle style, string? selector = null) => new SwapStyleBuilder(style).ShowOnTop(selector);
 
     /// <summary>
     /// Specifies that the swap should show the element matching the CSS selector at the bottom of the window.
@@ -606,14 +539,14 @@ public static class SwapStyleBuilderExtension
     /// <param name="style">The swap style.</param>
     /// <param name="selector">The CSS selector of the target element.</param>
     /// <returns>The SwapStyleBuilder instance for chaining.</returns>
-    public static SwapStyleBuilder ShowOnBottom(this SwapStyle style, string selector) => new SwapStyleBuilder(style).ShowOnBottom(selector);
+    public static SwapStyleBuilder ShowOnBottom(this SwapStyle style, string? selector = null) => new SwapStyleBuilder(style).ShowOnBottom(selector);
 
     /// <summary>
     /// Specifies that the swap should show in the window by smoothly scrolling to either the top or bottom of the window.
     /// </summary>
     /// <param name="direction">The direction to scroll the window after the swap.</param>
     /// <remarks>
-    /// This method adds the modifier <c>show:window:<param name="direction"/></c>, directing the swap to display the specified
+    /// This method adds the modifier <c>show:window:<paramref name="direction"/></c>, directing the swap to display the specified
     /// element at the bottom of the window.
     /// </remarks>
     /// <param name="style">The swap style.</param>

--- a/src/Htmxor/ScrollDirection.cs
+++ b/src/Htmxor/ScrollDirection.cs
@@ -1,0 +1,10 @@
+﻿namespace Htmxor;
+
+/// <summary>
+/// Direction values for scroll and show modifier methods
+/// </summary>
+public enum ScrollDirection
+{
+    Top,
+    Bottom
+}

--- a/test/Htmxor.Tests/Http/SwapStyleBuilderTests.cs
+++ b/test/Htmxor.Tests/Http/SwapStyleBuilderTests.cs
@@ -20,21 +20,34 @@ public class SwapStyleBuilderTests : TestContext
         var (resultStyle, modifiers) = builder.Build();
 
         // Assert
-        Assert.Equal(swapStyle, resultStyle);
-        Assert.Empty(modifiers);  // Expect no modifiers if none are added
+        resultStyle.Should().Be(swapStyle);
+        modifiers.Should().BeEmpty();  // Expect no modifiers if none are added
     }
 
     [Fact]
-    public void SwapStyleBuilder_After_AddsCorrectDelay()
+    public void SwapStyleBuilder_AfterSwap_AddsCorrectDelay()
     {
         // Arrange
         var builder = new SwapStyleBuilder(SwapStyle.InnerHTML);
 
         // Act
-        var (_, modifiers) = builder.After(TimeSpan.FromSeconds(1)).Build();
+        var (_, modifiers) = builder.AfterSwapDelay(TimeSpan.FromSeconds(1)).Build();
 
         // Assert
-        Assert.Equal("swap:1s", modifiers);
+        modifiers.Should().Be("swap:1s");
+    }
+
+    [Fact]
+    public void SwapStyleBuilder_AfterSettle_AddsCorrectDelay()
+    {
+	    // Arrange
+	    var builder = new SwapStyleBuilder(SwapStyle.InnerHTML);
+
+	    // Act
+	    var (_, modifiers) = builder.AfterSettleDelay(TimeSpan.FromSeconds(1)).Build();
+
+	    // Assert
+	    modifiers.Should().Be("settle:1s");
     }
 
     [Fact]
@@ -47,7 +60,7 @@ public class SwapStyleBuilderTests : TestContext
         var (_, modifiers) = builder.Scroll(ScrollDirection.Bottom).Build();
 
         // Assert
-        Assert.Equal("scroll:bottom", modifiers);
+        modifiers.Should().Be("scroll:bottom");
     }
 
     [Fact]
@@ -60,7 +73,7 @@ public class SwapStyleBuilderTests : TestContext
         var (_, modifiers) = builder.IgnoreTitle(true).Build();
 
         // Assert
-        Assert.Equal("ignoreTitle:true", modifiers);
+        modifiers.Should().Be("ignoreTitle:true");
     }
 
     [Fact]
@@ -73,20 +86,20 @@ public class SwapStyleBuilderTests : TestContext
         var (_, modifiers) = builder.Transition(true).Build();
 
         // Assert
-        Assert.Equal("transition:true", modifiers);
+        modifiers.Should().Be("transition:true");
     }
 
     [Fact]
-    public void SwapStyleBuilder_FocusScroll_AddsCorrectFlag()
+    public void SwapStyleBuilder_ScrollFocus_AddsCorrectFlag()
     {
         // Arrange
         var builder = new SwapStyleBuilder(SwapStyle.InnerHTML);
 
         // Act
-        var (_, modifiers) = builder.FocusScroll(true).Build();
+        var (_, modifiers) = builder.ScrollFocus(true).Build();
 
         // Assert
-        Assert.Equal("focus-scroll:true", modifiers);
+        modifiers.Should().Be("focus-scroll:true");
     }
 
     [Fact]
@@ -100,7 +113,7 @@ public class SwapStyleBuilderTests : TestContext
         var (_, modifiers) = builder.ShowOn(selector, ScrollDirection.Top).Build();
 
         // Assert
-        Assert.Equal("show:#dynamic-area:top", modifiers);
+        modifiers.Should().Be("show:#dynamic-area:top");
     }
 
     [Fact]
@@ -113,7 +126,7 @@ public class SwapStyleBuilderTests : TestContext
         var (_, modifiers) = builder.ShowWindow(ScrollDirection.Top).Build();
 
         // Assert
-        Assert.Equal("show:window:top", modifiers);
+        modifiers.Should().Be("show:window:top");
     }
 
     [Fact]
@@ -124,14 +137,14 @@ public class SwapStyleBuilderTests : TestContext
 
         // Act
         var (_, modifiers) = builder
-            .After(TimeSpan.FromSeconds(1))
+            .AfterSwapDelay(TimeSpan.FromSeconds(1))
             .Scroll(ScrollDirection.Top)
             .Transition(true)
             .IgnoreTitle(false)
             .Build();
 
         // Assert
-        Assert.Equal("swap:1s scroll:top transition:true ignoreTitle:false", modifiers);
+        modifiers.Should().Be("swap:1s scroll:top transition:true ignoreTitle:false");
     }
 
     [Fact]
@@ -141,10 +154,10 @@ public class SwapStyleBuilderTests : TestContext
         var builder = new SwapStyleBuilder(SwapStyle.InnerHTML);
 
         // Act
-        var (_, modifiers) = builder.After(TimeSpan.FromMilliseconds(250)).Build();
+        var (_, modifiers) = builder.AfterSwapDelay(TimeSpan.FromMilliseconds(250)).Build();
 
         // Assert
-        Assert.Equal("swap:250ms", modifiers);
+        modifiers.Should().Be("swap:250ms");
     }
 
     [Fact]
@@ -158,7 +171,7 @@ public class SwapStyleBuilderTests : TestContext
         var (_, modifiers) = builder.ShowOn(selector, ScrollDirection.Bottom).Build();
 
         // Assert
-        Assert.Equal("show:#element-id:bottom", modifiers);
+        modifiers.Should().Be("show:#element-id:bottom");
     }
 
     [Fact]
@@ -171,7 +184,7 @@ public class SwapStyleBuilderTests : TestContext
         var (_, modifiers) = builder.ShowWindow(ScrollDirection.Bottom).Build();
 
         // Assert
-        Assert.Equal("show:window:bottom", modifiers);
+        modifiers.Should().Be("show:window:bottom");
     }
 
     [Fact]
@@ -182,7 +195,7 @@ public class SwapStyleBuilderTests : TestContext
         var (style, _) = builder.Build();
 
         // Assert
-        Assert.Null(style);
+        style.Should().BeNull();
     }
 
     [Fact]
@@ -195,6 +208,6 @@ public class SwapStyleBuilderTests : TestContext
         var (_, modifiers) = builder.ShowNone().Build();
 
         // Assert
-        Assert.Equal("show:none", modifiers);
+        modifiers.Should().Be("show:none");
     }
 }

--- a/test/Htmxor.Tests/Http/SwapStyleBuilderTests.cs
+++ b/test/Htmxor.Tests/Http/SwapStyleBuilderTests.cs
@@ -110,7 +110,7 @@ public class SwapStyleBuilderTests
         var selector = "#dynamic-area";
 
         // Act
-        var (_, modifiers) = builder.ShowOn(selector, ScrollDirection.Top).Build();
+        var (_, modifiers) = builder.ShowOn(ScrollDirection.Top, selector).Build();
 
         // Assert
         modifiers.Should().Be("show:#dynamic-area:top");
@@ -168,7 +168,7 @@ public class SwapStyleBuilderTests
         var selector = "#element-id";
 
         // Act
-        var (_, modifiers) = builder.ShowOn(selector, ScrollDirection.Bottom).Build();
+        var (_, modifiers) = builder.ShowOn(ScrollDirection.Bottom, selector).Build();
 
         // Assert
         modifiers.Should().Be("show:#element-id:bottom");

--- a/test/Htmxor.Tests/Http/SwapStyleBuilderTests.cs
+++ b/test/Htmxor.Tests/Http/SwapStyleBuilderTests.cs
@@ -1,0 +1,200 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Bunit;
+
+namespace Htmxor.Http;
+
+public class SwapStyleBuilderTests : TestContext
+{
+    [Fact]
+    public void SwapStyleBuilder_InitializeAndBuild_ReturnsCorrectValues()
+    {
+        // Arrange
+        var swapStyle = SwapStyle.InnerHTML;
+
+        // Act
+        var builder = new SwapStyleBuilder(swapStyle);
+        var (resultStyle, modifiers) = builder.Build();
+
+        // Assert
+        Assert.Equal(swapStyle, resultStyle);
+        Assert.Empty(modifiers);  // Expect no modifiers if none are added
+    }
+
+    [Fact]
+    public void SwapStyleBuilder_After_AddsCorrectDelay()
+    {
+        // Arrange
+        var builder = new SwapStyleBuilder(SwapStyle.InnerHTML);
+
+        // Act
+        var (_, modifiers) = builder.After(TimeSpan.FromSeconds(1)).Build();
+
+        // Assert
+        Assert.Equal("swap:1s", modifiers);
+    }
+
+    [Fact]
+    public void SwapStyleBuilder_Scroll_AddsCorrectDirection()
+    {
+        // Arrange
+        var builder = new SwapStyleBuilder(SwapStyle.InnerHTML);
+
+        // Act
+        var (_, modifiers) = builder.Scroll(ScrollDirection.Bottom).Build();
+
+        // Assert
+        Assert.Equal("scroll:bottom", modifiers);
+    }
+
+    [Fact]
+    public void SwapStyleBuilder_IgnoreTitle_AddsCorrectFlag()
+    {
+        // Arrange
+        var builder = new SwapStyleBuilder(SwapStyle.InnerHTML);
+
+        // Act
+        var (_, modifiers) = builder.IgnoreTitle(true).Build();
+
+        // Assert
+        Assert.Equal("ignoreTitle:true", modifiers);
+    }
+
+    [Fact]
+    public void SwapStyleBuilder_Transition_AddsCorrectFlag()
+    {
+        // Arrange
+        var builder = new SwapStyleBuilder(SwapStyle.InnerHTML);
+
+        // Act
+        var (_, modifiers) = builder.Transition(true).Build();
+
+        // Assert
+        Assert.Equal("transition:true", modifiers);
+    }
+
+    [Fact]
+    public void SwapStyleBuilder_FocusScroll_AddsCorrectFlag()
+    {
+        // Arrange
+        var builder = new SwapStyleBuilder(SwapStyle.InnerHTML);
+
+        // Act
+        var (_, modifiers) = builder.FocusScroll(true).Build();
+
+        // Assert
+        Assert.Equal("focus-scroll:true", modifiers);
+    }
+
+    [Fact]
+    public void SwapStyleBuilder_ShowOn_AddsCorrectSelectorAndDirection()
+    {
+        // Arrange
+        var builder = new SwapStyleBuilder(SwapStyle.InnerHTML);
+        var selector = "#dynamic-area";
+
+        // Act
+        var (_, modifiers) = builder.ShowOn(selector, ScrollDirection.Top).Build();
+
+        // Assert
+        Assert.Equal("show:#dynamic-area:top", modifiers);
+    }
+
+    [Fact]
+    public void SwapStyleBuilder_ShowWindow_AddsCorrectWindowAndDirection()
+    {
+        // Arrange
+        var builder = new SwapStyleBuilder(SwapStyle.InnerHTML);
+
+        // Act
+        var (_, modifiers) = builder.ShowWindow(ScrollDirection.Top).Build();
+
+        // Assert
+        Assert.Equal("show:window:top", modifiers);
+    }
+
+    [Fact]
+    public void SwapStyleBuilder_ChainedOperations_AddsCorrectModifiers()
+    {
+        // Arrange
+        var builder = new SwapStyleBuilder(SwapStyle.InnerHTML);
+
+        // Act
+        var (_, modifiers) = builder
+            .After(TimeSpan.FromSeconds(1))
+            .Scroll(ScrollDirection.Top)
+            .Transition(true)
+            .IgnoreTitle(false)
+            .Build();
+
+        // Assert
+        Assert.Equal("swap:1s scroll:top transition:true ignoreTitle:false", modifiers);
+    }
+
+    [Fact]
+    public void SwapStyleBuilder_After_With250Milliseconds_AddsCorrectDelay()
+    {
+        // Arrange
+        var builder = new SwapStyleBuilder(SwapStyle.InnerHTML);
+
+        // Act
+        var (_, modifiers) = builder.After(TimeSpan.FromMilliseconds(250)).Build();
+
+        // Assert
+        Assert.Equal("swap:250ms", modifiers);
+    }
+
+    [Fact]
+    public void SwapStyleBuilder_ShowOn_BottomDirection_AddsCorrectModifier()
+    {
+        // Arrange
+        var builder = new SwapStyleBuilder(SwapStyle.InnerHTML);
+        var selector = "#element-id";
+
+        // Act
+        var (_, modifiers) = builder.ShowOn(selector, ScrollDirection.Bottom).Build();
+
+        // Assert
+        Assert.Equal("show:#element-id:bottom", modifiers);
+    }
+
+    [Fact]
+    public void SwapStyleBuilder_ShowWindow_BottomDirection_AddsCorrectModifier()
+    {
+        // Arrange
+        var builder = new SwapStyleBuilder(SwapStyle.InnerHTML);
+
+        // Act
+        var (_, modifiers) = builder.ShowWindow(ScrollDirection.Bottom).Build();
+
+        // Assert
+        Assert.Equal("show:window:bottom", modifiers);
+    }
+
+    [Fact]
+    public void SwapStyleBuilder_NullSwapStyle_ReturnsNullStyle()
+    {
+        // Arrange & Act
+        var builder = new SwapStyleBuilder(null);
+        var (style, _) = builder.Build();
+
+        // Assert
+        Assert.Null(style);
+    }
+
+    [Fact]
+    public void SwapStyleBuilder_ShowNone_ReturnsCorrectValue()
+    {
+        // Arrange
+        var builder = new SwapStyleBuilder(SwapStyle.InnerHTML);
+
+        // Act
+        var (_, modifiers) = builder.ShowNone().Build();
+
+        // Assert
+        Assert.Equal("show:none", modifiers);
+    }
+}

--- a/test/Htmxor.Tests/Http/SwapStyleBuilderTests.cs
+++ b/test/Htmxor.Tests/Http/SwapStyleBuilderTests.cs
@@ -7,7 +7,7 @@ using Bunit;
 
 namespace Htmxor.Http;
 
-public class SwapStyleBuilderTests : TestContext
+public class SwapStyleBuilderTests 
 {
     [Fact]
     public void SwapStyleBuilder_InitializeAndBuild_ReturnsCorrectValues()
@@ -209,5 +209,44 @@ public class SwapStyleBuilderTests : TestContext
 
         // Assert
         modifiers.Should().Be("show:none");
+    }
+
+    [Fact]
+    public void SwapStyleBuilder_ShowOnTop_ReturnsCorrectValue()
+    {
+	    // Arrange
+	    var builder = new SwapStyleBuilder(SwapStyle.InnerHTML);
+
+	    // Act
+	    var (_, modifiers) = builder.ShowOnTop().Build();
+
+	    // Assert
+	    modifiers.Should().Be("show:top");
+    }
+
+    [Fact]
+    public void SwapStyleBuilder_ShowOnBottom_ReturnsCorrectValue()
+    {
+	    // Arrange
+	    var builder = new SwapStyleBuilder(SwapStyle.InnerHTML);
+
+	    // Act
+	    var (_, modifiers) = builder.ShowOnBottom().Build();
+
+	    // Assert
+	    modifiers.Should().Be("show:bottom");
+    }
+
+    [Fact]
+    public void SwapStyleBuilder_MixedShowOverrides_ReturnsCorrectValue()
+    {
+	    // Arrange
+	    var builder = new SwapStyleBuilder(SwapStyle.InnerHTML);
+
+	    // Act
+	    var (_, modifiers) = builder.ShowOnTop().AfterSettleDelay(TimeSpan.FromMilliseconds(250)).ShowWindowTop().ShowOnBottom().Build();
+
+	    // Assert
+	    modifiers.Should().Be("settle:250ms show:bottom");
     }
 }


### PR DESCRIPTION
This commit introduces several enhancements to the `HtmxResponse` class. It adds a new optional parameter `modifier` to the `Reswap` method, allowing for more flexible response swapping. A new overload of the `Reswap` method is also added that takes a `SwapStyleBuilder` object as an argument to allow for fluent modifiers.

See Reswap fluent modifiers docs: [https://jalexsocial.github.io/rizzy.docs/docs/htmx/response/#applying-fluent-modifiers](https://jalexsocial.github.io/rizzy.docs/docs/htmx/response/#applying-fluent-modifiers)

A new method, `StopPolling`, has been introduced which sets the response code to stop polling.

Two new classes, `HtmxStatusCodes` and `SwapStyleBuilder`, have been created. The former provides status codes specific to HTMX responses while the latter aids in constructing reswap commands.

Additionally, a new enum called `ScrollDirection` has been added for specifying scroll direction values for reswaps.
