### PR TITLE
refactor: update serialization namespace

### DIFF
--- a/samples/HtmxBlazorSSR/Components/_Imports.razor
+++ b/samples/HtmxBlazorSSR/Components/_Imports.razor
@@ -9,5 +9,4 @@
 @using HtmxBlazorSSR.Components
 @using HtmxBlazorSSR.Components.FlashMessages
 @using Htmxor
-@using Htmxor.Configuration
 @using Htmxor.Components

--- a/src/Htmxor/Components/HtmxHeadOutlet.cs
+++ b/src/Htmxor/Components/HtmxHeadOutlet.cs
@@ -1,5 +1,5 @@
 ﻿using System.Text.Json;
-using Htmxor.Configuration.Serialization;
+using Htmxor.Serialization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/src/Htmxor/HtmxConfig.cs
+++ b/src/Htmxor/HtmxConfig.cs
@@ -2,7 +2,6 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
 using Htmxor.Antiforgery;
-using Htmxor.Configuration.Serialization;
 
 namespace Htmxor;
 

--- a/src/Htmxor/Http/HtmxResponse.cs
+++ b/src/Htmxor/Http/HtmxResponse.cs
@@ -2,7 +2,7 @@
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
-using Htmxor.Configuration.Serialization;
+using Htmxor.Serialization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Json;
 using Microsoft.AspNetCore.Routing;

--- a/src/Htmxor/Serialization/HtmxJsonSerializerContext.cs
+++ b/src/Htmxor/Serialization/HtmxJsonSerializerContext.cs
@@ -1,8 +1,7 @@
 ﻿using System.Text.Json.Serialization;
 using Htmxor.Http;
-using Htmxor.Serialization;
 
-namespace Htmxor.Configuration.Serialization;
+namespace Htmxor.Serialization;
 
 [JsonSourceGenerationOptions(
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,


### PR DESCRIPTION
Small fix with adjusting namespaces. The namespace for the serialization classes has been updated from `Htmxor.Configuration.Serialization` to `Htmxor.Serialization`. This change affects multiple files including `HtmxHeadOutlet.cs`, `HtmxResponse.cs`, and `HtmxJsonSerializerContext.cs`.
