### PR TITLE
Conditional writing of markup to output

### DIFF
--- a/src/Htmxor/Builder/HtmxorComponentEndpointDataSource.cs
+++ b/src/Htmxor/Builder/HtmxorComponentEndpointDataSource.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using Htmxor.Components;
 using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Components.Endpoints;
 using Microsoft.AspNetCore.Http;
@@ -52,6 +53,10 @@ internal class HtmxorComponentEndpointDataSource : EndpointDataSource
                 if (componentInfo.ComponentLayoutType is not null)
                 {
                     builder.Metadata.Add(new HtmxorLayoutComponentMetadata(componentInfo.ComponentLayoutType));
+                }
+                else
+                {
+                    builder.Metadata.Add(new HtmxorLayoutComponentMetadata(typeof(HtmxorLayoutComponentBase)));
                 }
 
                 builder.RequestDelegate = static httpContext =>

--- a/src/Htmxor/Components/FragmentBase.cs
+++ b/src/Htmxor/Components/FragmentBase.cs
@@ -1,9 +1,0 @@
-﻿using Microsoft.AspNetCore.Components;
-
-namespace Htmxor.Components;
-
-public abstract class FragmentBase : ComponentBase
-{
-    internal bool WillRender() => ShouldRender();
-}
-

--- a/src/Htmxor/Components/HtmxPartial.cs
+++ b/src/Htmxor/Components/HtmxPartial.cs
@@ -1,17 +1,18 @@
-using System.Diagnostics.CodeAnalysis;
-using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Rendering;
+﻿using Microsoft.AspNetCore.Components;
 
 namespace Htmxor.Components;
 
-public sealed class HtmxPartial : FragmentBase
+public sealed class HtmxPartial : IComponent, IConditionalOutputComponent
 {
+    private RenderHandle renderHandle;
+
     [Parameter, EditorRequired]
     public required RenderFragment ChildContent { get; set; }
 
     [Parameter] public bool Condition { get; set; } = true;
 
-    public override Task SetParametersAsync(ParameterView parameters)
+
+    public Task SetParametersAsync(ParameterView parameters)
     {
         if (!parameters.TryGetValue<RenderFragment>(nameof(ChildContent), out var childContent))
         {
@@ -20,12 +21,15 @@ public sealed class HtmxPartial : FragmentBase
 
         ChildContent = childContent;
         Condition = parameters.GetValueOrDefault(nameof(Condition), true);
-        return base.SetParametersAsync(parameters);
+        renderHandle.Render(ChildContent);
+        return Task.CompletedTask;
     }
 
-    protected override void BuildRenderTree([NotNull] RenderTreeBuilder builder)
-        => builder.AddContent(0, ChildContent);
+    void IComponent.Attach(RenderHandle renderHandle)
+    {
+        this.renderHandle = renderHandle;
+    }
 
-    protected override bool ShouldRender() => Condition;
+    bool IConditionalOutputComponent.ShouldOutput(int _) => Condition;
 }
 

--- a/src/Htmxor/Components/HtmxorLayoutComponentBase.cs
+++ b/src/Htmxor/Components/HtmxorLayoutComponentBase.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Htmxor.Components;
+
+public class HtmxorLayoutComponentBase : LayoutComponentBase, IConditionalOutputComponent
+{
+	public bool ShouldOutput(int conditionalChildren)
+		=> conditionalChildren == 0;
+
+	protected override void BuildRenderTree([NotNull] RenderTreeBuilder builder)
+		=> builder.AddContent(0, Body);
+}

--- a/src/Htmxor/Components/IConditionalOutput.cs
+++ b/src/Htmxor/Components/IConditionalOutput.cs
@@ -1,0 +1,15 @@
+﻿namespace Htmxor.Components;
+
+/// <summary>
+/// Represents a component that can conditionally produce markup.
+/// </summary>
+public interface IConditionalOutputComponent
+{
+    /// <summary>
+    /// Determine whether this component should produce any markup during a request.
+    /// </summary>
+    /// <param name="conditionalChildren">The number of children that implements <see cref="IConditionalOutputComponent"/>.</param>
+    /// <returns><see langword="true"/> if the component should produce markup, <see langword="false"/> otherwise.</returns>
+    bool ShouldOutput(int conditionalChildren);
+}
+

--- a/src/Htmxor/HtmxorComponentEndpointInvoker.cs
+++ b/src/Htmxor/HtmxorComponentEndpointInvoker.cs
@@ -32,7 +32,8 @@ internal partial class HtmxorComponentEndpointInvoker : IHtmxorComponentEndpoint
 		this.logger = logger;
 	}
 
-	public Task Render(HttpContext context) => renderer.Dispatcher.InvokeAsync(() => RenderComponentCore(context));
+    public Task Render(HttpContext context)
+        => renderer.Dispatcher.InvokeAsync(() => RenderComponentCore(context));
 
 	private async Task RenderComponentCore(HttpContext context)
 	{
@@ -129,10 +130,10 @@ internal partial class HtmxorComponentEndpointInvoker : IHtmxorComponentEndpoint
 			return;
 		}
 
-		// Matches MVC's MemoryPoolHttpResponseStreamWriterFactory.DefaultBufferSize
-		var defaultBufferSize = 16 * 1024;
-		await using var writer = new HttpResponseStreamWriter(context.Response.Body, Encoding.UTF8, defaultBufferSize, ArrayPool<byte>.Shared, ArrayPool<char>.Shared);
-		using var bufferWriter = new BufferedTextWriter(writer);
+        // Matches MVC's MemoryPoolHttpResponseStreamWriterFactory.DefaultBufferSize
+        var defaultBufferSize = 16 * 1024;
+        await using var writer = new HttpResponseStreamWriter(context.Response.Body, Encoding.UTF8, defaultBufferSize, ArrayPool<byte>.Shared, ArrayPool<char>.Shared);
+        using var bufferWriter = new ConditionalBufferedTextWriter(writer);
 
 		// Importantly, we must not yield this thread (which holds exclusive access to the renderer sync context)
 		// in between the first call to htmlContent.WriteTo and the point where we start listening for subsequent

--- a/src/Htmxor/Rendering/Buffering/ConditionalBufferedTextWriter.cs
+++ b/src/Htmxor/Rendering/Buffering/ConditionalBufferedTextWriter.cs
@@ -1,0 +1,45 @@
+﻿namespace Htmxor.Rendering.Buffering;
+
+/// <summary>
+/// A text writer that will only output when its <see cref="ShouldWrite"/> returns true.
+/// </summary>
+internal sealed class ConditionalBufferedTextWriter : BufferedTextWriter
+{
+    internal bool ShouldWrite { get; set; } = true;
+
+    public ConditionalBufferedTextWriter(TextWriter underlying) : base(underlying)
+    {
+    }
+
+    public override void Write(char value)
+    {
+        if (ShouldWrite)
+        {
+            base.Write(value);
+        }
+    }
+
+    public override void Write(char[] buffer, int index, int count)
+    {
+        if (ShouldWrite)
+        {
+            base.Write(buffer, index, count);
+        }
+    }
+
+    public override void Write(string? value)
+    {
+        if (ShouldWrite)
+        {
+            base.Write(value);
+        }
+    }
+
+    public override void Write(int value)
+    {
+        if (ShouldWrite)
+        {
+            base.Write(value);
+        }
+    }
+}

--- a/src/Htmxor/Rendering/HtmxorComponentState.cs
+++ b/src/Htmxor/Rendering/HtmxorComponentState.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.AspNetCore.Components.RenderTree;
+
+namespace Htmxor.Rendering;
+
+internal class HtmxorComponentState : ComponentState
+{
+    public HtmxorComponentState(Renderer renderer, int componentId, IComponent component, HtmxorComponentState? parentComponentState)
+        : base(renderer, componentId, component, parentComponentState)
+    {
+    }
+
+    public override ValueTask DisposeAsync()
+    {
+        return base.DisposeAsync();
+    }
+
+    internal bool HasPartialFragments()
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Htmxor/Rendering/HtmxorComponentState.cs
+++ b/src/Htmxor/Rendering/HtmxorComponentState.cs
@@ -1,23 +1,56 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿using System.Diagnostics;
+using Htmxor.Components;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
-using Microsoft.AspNetCore.Components.RenderTree;
 
 namespace Htmxor.Rendering;
 
 internal class HtmxorComponentState : ComponentState
 {
-    public HtmxorComponentState(Renderer renderer, int componentId, IComponent component, HtmxorComponentState? parentComponentState)
+    private readonly HtmxorComponentState? parentComponentState;
+    private int conditionalChildrenCount;
+    private IConditionalOutputComponent? conditionalOutput;
+    private bool isDisposed;
+
+    public HtmxorComponentState(HtmxorRenderer renderer, int componentId, IComponent component, HtmxorComponentState? parentComponentState)
         : base(renderer, componentId, component, parentComponentState)
     {
+        if (component is IConditionalOutputComponent conditionalOutput)
+        {
+            this.conditionalOutput = conditionalOutput;
+            parentComponentState?.ConditionalChildAdded();
+        }
+
+        this.parentComponentState = parentComponentState;
     }
 
     public override ValueTask DisposeAsync()
     {
+        if (parentComponentState is not null && conditionalOutput is not null && !isDisposed)
+        {
+            parentComponentState.ConditionalChildDisposed();
+        }
+
+        isDisposed = true;
+
         return base.DisposeAsync();
     }
 
-    internal bool HasPartialFragments()
+    private void ConditionalChildAdded()
     {
-        throw new NotImplementedException();
+        conditionalChildrenCount++;
+        parentComponentState?.ConditionalChildAdded();
     }
+
+    private void ConditionalChildDisposed()
+    {
+        conditionalChildrenCount--;
+        parentComponentState?.ConditionalChildDisposed();
+        Debug.Assert(conditionalChildrenCount >= 0, "conditionalChildrenCount should never be able to be less than zero");
+    }
+
+    internal bool ShouldGenerateMarkup()
+        => conditionalOutput?.ShouldOutput(conditionalChildrenCount)
+        ?? parentComponentState?.ShouldGenerateMarkup()
+        ?? true;
 }

--- a/src/Htmxor/Rendering/HtmxorRenderer.HtmlWriting.cs
+++ b/src/Htmxor/Rendering/HtmxorRenderer.HtmlWriting.cs
@@ -7,7 +7,6 @@ using System.Globalization;
 using System.Reflection;
 using System.Text;
 using System.Text.Encodings.Web;
-using Htmxor.Components;
 using Htmxor.Http;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Forms;
@@ -31,94 +30,91 @@ internal partial class HtmxorRenderer
 			args: [new CascadingParameterAttribute(), string.Empty, typeof(FormMappingContext)],
 			culture: CultureInfo.InvariantCulture)!;
 
-	private readonly TextEncoder javaScriptEncoder;
-	private TextEncoder htmlEncoder;
-	private string? closestSelectValueAsString;
+    private readonly TextEncoder _javaScriptEncoder;
+    private TextEncoder _htmlEncoder;
+    private string? _closestSelectValueAsString;
+    private bool writeFromCompleteRenderTree;
 
-	/// <summary>
-	/// Renders the specified component as HTML to the output.
-	/// </summary>
-	/// <param name="componentId">The ID of the component whose current HTML state is to be rendered.</param>
-	/// <param name="output">The output destination.</param>
-	private void WriteComponent(int componentId, TextWriter output)
-	{
-		// We're about to walk over some buffers inside the renderer that can be mutated during rendering.
-		// So, we require exclusive access to the renderer during this synchronous process.
-		Dispatcher.AssertAccess();
+    private void WriteRootComponent(HtmxorComponentState rootComponentState, TextWriter output)
+    {
+        // We're about to walk over some buffers inside the renderer that can be mutated during rendering.
+        // So, we require exclusive access to the renderer during this synchronous process.
+        Dispatcher.AssertAccess();
 
-		var frames = GetCurrentRenderTreeFrames(componentId);
-		RenderFrames(componentId, output, frames, 0, frames.Count);
-	}
+        WriteComponent(rootComponentState, output);
+    }
 
-	/// <summary>
-	/// Renders the specified component frame as HTML to the output.
-	/// </summary>
-	/// <param name="output">The output destination.</param>
-	/// <param name="componentFrame">The <see cref="RenderTreeFrame"/> representing the component to be rendered.</param>
-	private void RenderChildComponent(TextWriter output, ref RenderTreeFrame componentFrame)
-	{
-		WriteComponent(componentFrame.ComponentId, output);
-	}
+    private void WriteComponent(HtmxorComponentState componentState, TextWriter output)
+    {
+        var frames = GetCurrentRenderTreeFrames(componentState.ComponentId);
+        RenderFrames(componentState, output, frames, 0, frames.Count);
+    }
 
-	private int RenderFrames(int componentId, TextWriter output, ArrayRange<RenderTreeFrame> frames, int position, int maxElements)
-	{
-		var nextPosition = position;
-		var endPosition = position + maxElements;
-		while (position < endPosition)
-		{
-			nextPosition = RenderCore(componentId, output, frames, position);
-			if (position == nextPosition)
-			{
-				throw new InvalidOperationException("We didn't consume any input.");
-			}
-			position = nextPosition;
-		}
+    private void RenderChildComponent(TextWriter output, ref RenderTreeFrame componentFrame)
+    {
+        var copmonentState = (HtmxorComponentState)GetComponentState(componentFrame.Component);
+        WriteComponent(copmonentState, output);
+    }
+
+    private int RenderFrames(HtmxorComponentState componentState, TextWriter output, ArrayRange<RenderTreeFrame> frames, int position, int maxElements)
+    {
+        var nextPosition = position;
+        var endPosition = position + maxElements;
+        while (position < endPosition)
+        {
+            nextPosition = RenderCore(componentState, output, frames, position);
+            if (position == nextPosition)
+            {
+                throw new InvalidOperationException("We didn't consume any input.");
+            }
+            position = nextPosition;
+        }
 
 		return nextPosition;
 	}
 
-	private int RenderCore(
-		int componentId,
-		TextWriter output,
-		ArrayRange<RenderTreeFrame> frames,
-		int position)
-	{
-		ref var frame = ref frames.Array[position];
-		switch (frame.FrameType)
-		{
-			case RenderTreeFrameType.Element:
-				return RenderElement(componentId, output, frames, position);
-			case RenderTreeFrameType.Attribute:
-				throw new InvalidOperationException($"Attributes should only be encountered within {nameof(RenderElement)}");
-			case RenderTreeFrameType.Text:
-				htmlEncoder.Encode(output, frame.TextContent);
-				return ++position;
-			case RenderTreeFrameType.Markup:
-				output.Write(frame.MarkupContent);
-				return ++position;
-			case RenderTreeFrameType.Component:
-				return RenderChildComponent(output, frames, position);
-			case RenderTreeFrameType.Region:
-				return RenderFrames(componentId, output, frames, position + 1, frame.RegionSubtreeLength - 1);
-			case RenderTreeFrameType.ElementReferenceCapture:
-			case RenderTreeFrameType.ComponentReferenceCapture:
-				return ++position;
-			case RenderTreeFrameType.NamedEvent:
-				RenderHiddenFieldForNamedSubmitEvent(componentId, output, frames, position);
-				return ++position;
-			default:
-				throw new InvalidOperationException($"Invalid element frame type '{frame.FrameType}'.");
-		}
-	}
+    private int RenderCore(
+        HtmxorComponentState componentState,
+        TextWriter output,
+        ArrayRange<RenderTreeFrame> frames,
+        int position)
+    {
+        ref var frame = ref frames.Array[position];
+        switch (frame.FrameType)
+        {
+            case RenderTreeFrameType.Element:
+                return RenderElement(componentState, output, frames, position);
+            case RenderTreeFrameType.Attribute:
+                throw new InvalidOperationException($"Attributes should only be encountered within {nameof(RenderElement)}");
+            case RenderTreeFrameType.Text:
+                _htmlEncoder.Encode(output, frame.TextContent);
+                return ++position;
+            case RenderTreeFrameType.Markup:
+                output.Write(frame.MarkupContent);
+                return ++position;
+            case RenderTreeFrameType.Component:
+                return RenderChildComponent(output, frames, position);
+            case RenderTreeFrameType.Region:
+                return RenderFrames(componentState, output, frames, position + 1, frame.RegionSubtreeLength - 1);
+            case RenderTreeFrameType.ElementReferenceCapture:
+            case RenderTreeFrameType.ComponentReferenceCapture:
+                return ++position;
+            case RenderTreeFrameType.NamedEvent:
+                RenderHiddenFieldForNamedSubmitEvent(componentState, output, frames, position);
+                return ++position;
+            default:
+                throw new InvalidOperationException($"Invalid element frame type '{frame.FrameType}'.");
+        }
+    }
 
-	private int RenderElement(int componentId, TextWriter output, ArrayRange<RenderTreeFrame> frames, int position)
-	{
-		ref var frame = ref frames.Array[position];
-		output.Write('<');
-		output.Write(frame.ElementName);
-		int afterElement;
-		var isTextArea = string.Equals(frame.ElementName, "textarea", StringComparison.OrdinalIgnoreCase);
-		var isForm = string.Equals(frame.ElementName, "form", StringComparison.OrdinalIgnoreCase);
+    private int RenderElement(HtmxorComponentState componentState, TextWriter output, ArrayRange<RenderTreeFrame> frames, int position)
+    {
+        ref var frame = ref frames.Array[position];
+        output.Write('<');
+        output.Write(frame.ElementName);
+        int afterElement;
+        var isTextArea = string.Equals(frame.ElementName, "textarea", StringComparison.OrdinalIgnoreCase);
+        var isForm = string.Equals(frame.ElementName, "form", StringComparison.OrdinalIgnoreCase);
 
 		// We don't want to include value attribute of textarea element.
 		var afterAttributes = RenderAttributes(output, frames, position + 1, frame.ElementSubtreeLength - 1, !isTextArea, isForm: isForm, out var capturedValueAttribute);
@@ -144,21 +140,21 @@ internal partial class HtmxorRenderer
 				closestSelectValueAsString = capturedValueAttribute;
 			}
 
-			if (isTextArea && !string.IsNullOrEmpty(capturedValueAttribute))
-			{
-				// Textarea is a special type of form field where the value is given as text content instead of a 'value' attribute
-				// So, if we captured a value attribute, use that instead of any child content
-				htmlEncoder.Encode(output, capturedValueAttribute);
-				afterElement = position + frame.ElementSubtreeLength; // Skip descendants
-			}
-			else if (string.Equals(frame.ElementName, "script", StringComparison.OrdinalIgnoreCase))
-			{
-				afterElement = RenderScriptElementChildren(componentId, output, frames, afterAttributes, remainingElements);
-			}
-			else
-			{
-				afterElement = RenderChildren(componentId, output, frames, afterAttributes, remainingElements);
-			}
+            if (isTextArea && !string.IsNullOrEmpty(capturedValueAttribute))
+            {
+                // Textarea is a special type of form field where the value is given as text content instead of a 'value' attribute
+                // So, if we captured a value attribute, use that instead of any child content
+                _htmlEncoder.Encode(output, capturedValueAttribute);
+                afterElement = position + frame.ElementSubtreeLength; // Skip descendants
+            }
+            else if (string.Equals(frame.ElementName, "script", StringComparison.OrdinalIgnoreCase))
+            {
+                afterElement = RenderScriptElementChildren(componentState, output, frames, afterAttributes, remainingElements);
+            }
+            else
+            {
+                afterElement = RenderChildren(componentState, output, frames, afterAttributes, remainingElements);
+            }
 
 			if (isSelect)
 			{
@@ -190,45 +186,45 @@ internal partial class HtmxorRenderer
 		}
 	}
 
-	private int RenderScriptElementChildren(int componentId, TextWriter output, ArrayRange<RenderTreeFrame> frames, int position, int maxElements)
-	{
-		// Inside a <script> context, AddContent calls should result in the text being
-		// JavaScript encoded rather than HTML encoded. It's not that we recommend inserting
-		// user-supplied content inside a <script> block, but that if someone does, we
-		// want the encoding style to match the context for correctness and safety. This is
-		// also consistent with .cshtml's treatment of <script>.
-		var originalEncoder = htmlEncoder;
-		try
-		{
-			htmlEncoder = javaScriptEncoder;
-			return RenderChildren(componentId, output, frames, position, maxElements);
-		}
-		finally
-		{
-			htmlEncoder = originalEncoder;
-		}
-	}
+    private int RenderScriptElementChildren(HtmxorComponentState componentState, TextWriter output, ArrayRange<RenderTreeFrame> frames, int position, int maxElements)
+    {
+        // Inside a <script> context, AddContent calls should result in the text being
+        // JavaScript encoded rather than HTML encoded. It's not that we recommend inserting
+        // user-supplied content inside a <script> block, but that if someone does, we
+        // want the encoding style to match the context for correctness and safety. This is
+        // also consistent with .cshtml's treatment of <script>.
+        var originalEncoder = _htmlEncoder;
+        try
+        {
+            _htmlEncoder = _javaScriptEncoder;
+            return RenderChildren(componentState, output, frames, position, maxElements);
+        }
+        finally
+        {
+            _htmlEncoder = originalEncoder;
+        }
+    }
 
-	private void RenderHiddenFieldForNamedSubmitEvent(int componentId, TextWriter output, ArrayRange<RenderTreeFrame> frames, int namedEventFramePosition)
-	{
-		// Strictly speaking we could just emit the hidden input unconditionally, but since we currently
-		// only intend to support this for "form submit" events, validate that's the case
-		ref var namedEventFrame = ref frames.Array[namedEventFramePosition];
-		if (string.Equals(namedEventFrame.NamedEventType, "onsubmit", StringComparison.Ordinal)
-			&& TryFindEnclosingElementFrame(frames, namedEventFramePosition, out var enclosingElementFrameIndex))
-		{
-			ref var enclosingElementFrame = ref frames.Array[enclosingElementFrameIndex];
-			if (string.Equals(enclosingElementFrame.ElementName, "form", StringComparison.OrdinalIgnoreCase))
-			{
-				if (TryCreateScopeQualifiedEventName(componentId, namedEventFrame.NamedEventAssignedName, out var combinedFormName))
-				{
-					output.Write("<input type=\"hidden\" name=\"_handler\" value=\"");
-					htmlEncoder.Encode(output, combinedFormName);
-					output.Write("\" />");
-				}
-			}
-		}
-	}
+    private void RenderHiddenFieldForNamedSubmitEvent(HtmxorComponentState componentState, TextWriter output, ArrayRange<RenderTreeFrame> frames, int namedEventFramePosition)
+    {
+        // Strictly speaking we could just emit the hidden input unconditionally, but since we currently
+        // only intend to support this for "form submit" events, validate that's the case
+        ref var namedEventFrame = ref frames.Array[namedEventFramePosition];
+        if (string.Equals(namedEventFrame.NamedEventType, "onsubmit", StringComparison.Ordinal)
+            && TryFindEnclosingElementFrame(frames, namedEventFramePosition, out var enclosingElementFrameIndex))
+        {
+            ref var enclosingElementFrame = ref frames.Array[enclosingElementFrameIndex];
+            if (string.Equals(enclosingElementFrame.ElementName, "form", StringComparison.OrdinalIgnoreCase))
+            {
+                if (TryCreateScopeQualifiedEventName(componentState.ComponentId, namedEventFrame.NamedEventAssignedName, out var combinedFormName))
+                {
+                    output.Write("<input type=\"hidden\" name=\"_handler\" value=\"");
+                    _htmlEncoder.Encode(output, combinedFormName);
+                    output.Write("\" />");
+                }
+            }
+        }
+    }
 
 	/// <summary>
 	/// Creates the fully scope-qualified name for a named event, if the component is within
@@ -501,15 +497,15 @@ internal partial class HtmxorRenderer
 		return new Uri(navigationManager.Uri, UriKind.Absolute).PathAndQuery;
 	}
 
-	private int RenderChildren(int componentId, TextWriter output, ArrayRange<RenderTreeFrame> frames, int position, int maxElements)
-	{
-		if (maxElements == 0)
-		{
-			return position;
-		}
+    private int RenderChildren(HtmxorComponentState componentState, TextWriter output, ArrayRange<RenderTreeFrame> frames, int position, int maxElements)
+    {
+        if (maxElements == 0)
+        {
+            return position;
+        }
 
-		return RenderFrames(componentId, output, frames, position, maxElements);
-	}
+        return RenderFrames(componentState, output, frames, position, maxElements);
+    }
 
 	private int RenderChildComponent(TextWriter output, ArrayRange<RenderTreeFrame> frames, int position)
 	{

--- a/src/Htmxor/Rendering/HtmxorRenderer.Rendering.cs
+++ b/src/Htmxor/Rendering/HtmxorRenderer.Rendering.cs
@@ -10,20 +10,6 @@ namespace Htmxor.Rendering;
 
 internal partial class HtmxorRenderer
 {
-	private HttpContext httpContext = default!; // Always set at the start of an inbound call
-
-	private void SetHttpContext(HttpContext httpContext)
-	{
-		if (this.httpContext is null)
-		{
-			this.httpContext = httpContext;
-		}
-		else if (this.httpContext != httpContext)
-		{
-			throw new InvalidOperationException("The HttpContext cannot change value once assigned.");
-		}
-	}
-
 	internal async ValueTask<RenderedComponentHtmlContent> RenderEndpointComponent(
 		HttpContext httpContext,
 		[DynamicallyAccessedMembers(Component)] Type rootComponentType,

--- a/src/Htmxor/Rendering/HtmxorRenderer.cs
+++ b/src/Htmxor/Rendering/HtmxorRenderer.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.Endpoints;
 using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.AspNetCore.Components.RenderTree;
 using Microsoft.AspNetCore.Components.Routing;
 using Microsoft.AspNetCore.Http;
@@ -146,13 +147,14 @@ internal partial class HtmxorRenderer : Renderer
         var htmxContext = httpContext.GetHtmxContext();
         if (htmxContext.Request.IsFullPageRequest)
         {
-            WriteComponent(componentId, output);
+            var componentState = (HtmxorComponentState)GetComponentState(componentId);
+            WriteComponent(componentState, output);
         }
         else
         {
             var matchingPartialComponentId = FindPartialComponentMatchingRequest(componentId);
             WriteComponent(
-                matchingPartialComponentId.HasValue ? matchingPartialComponentId.Value : componentId,
+                (HtmxorComponentState)GetComponentState(matchingPartialComponentId.HasValue ? matchingPartialComponentId.Value : componentId),
                 output);
         }
     }

--- a/src/Htmxor/Rendering/HtmxorRenderer.cs
+++ b/src/Htmxor/Rendering/HtmxorRenderer.cs
@@ -138,6 +138,9 @@ internal partial class HtmxorRenderer : Renderer
         }
     }
 
+    protected override HtmxorComponentState CreateComponentState(int componentId, IComponent component, ComponentState? parentComponentState)
+        => new HtmxorComponentState(this, componentId, component, parentComponentState as HtmxorComponentState);
+
     internal void WriteComponentHtml(int componentId, TextWriter output)
     {
         var htmxContext = httpContext.GetHtmxContext();


### PR DESCRIPTION
This PR adds the `IConditionalOutputComponent` type, which influences how the renderer will generate/write markup to the output during a request.

Here are the rules:

1. If a component does NOT implement `IConditionalOutputComponent`, nor any of its parents, it will always generate markup.
2. If a component does NOT implement `IConditionalOutputComponent`, but a parent component does, then it's closest parent decides whether or not to generate markup.
3. If a component implements `IConditionalOutputComponent`, it decides whether or not it should generate markup. It may also decide this for it's children, if they do not implement `IConditionalOutputComponent`.

This PR also includes a few changes to the default behavior of Htmxor:

1. If a component does not include a `@attribute [HxLayout(typeof(MyOwnHxLayout)]`, then it will be assigned the `HtmxorLayoutComponentBase` by default. This component does NOT generate any markup IF it has one or more children that has implements `IConditionalOutputComponent`.