### PR TITLE
fix(serialization): replace JsonCamelCaseStringEnumConverter with custom SwapStyleEnumConverter

### DIFF
--- a/src/Htmxor/Serialization/HtmxorJsonSerializerContext.cs
+++ b/src/Htmxor/Serialization/HtmxorJsonSerializerContext.cs
@@ -11,7 +11,7 @@ namespace Htmxor.Serialization;
 	GenerationMode = JsonSourceGenerationMode.Default,
 	Converters = [
 		typeof(TimespanMillisecondJsonConverter),
-		typeof(JsonCamelCaseStringEnumConverter<SwapStyle>),
+		typeof(SwapStyleEnumConverter),
 		typeof(JsonCamelCaseStringEnumConverter<ScrollBehavior>),
 	])]
 [JsonSerializable(typeof(HtmxConfig))]

--- a/src/Htmxor/Serialization/SwapStyleEnumConverter.cs
+++ b/src/Htmxor/Serialization/SwapStyleEnumConverter.cs
@@ -1,0 +1,35 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Htmxor.Serialization;
+
+public sealed class SwapStyleEnumConverter : JsonConverter<SwapStyle>
+{
+	public override SwapStyle Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+	{
+		var value = reader.GetString();
+
+		var style = value switch
+		{
+			null => SwapStyle.Default,
+			Constants.SwapStyles.Default => SwapStyle.Default,
+			Constants.SwapStyles.InnerHTML => SwapStyle.InnerHTML,
+			Constants.SwapStyles.OuterHTML => SwapStyle.OuterHTML,
+			Constants.SwapStyles.BeforeBegin => SwapStyle.BeforeBegin,
+			Constants.SwapStyles.AfterBegin => SwapStyle.AfterBegin,
+			Constants.SwapStyles.BeforeEnd => SwapStyle.BeforeEnd,
+			Constants.SwapStyles.AfterEnd => SwapStyle.AfterEnd,
+			Constants.SwapStyles.Delete => SwapStyle.Delete,
+			Constants.SwapStyles.None => SwapStyle.None,
+			_ => throw new SwitchExpressionException(value)
+		};
+
+		return style;
+	}
+
+	public override void Write(Utf8JsonWriter writer, SwapStyle value, JsonSerializerOptions options)
+	{
+		writer?.WriteStringValue(value.ToHtmxString());
+	}
+}

--- a/test/Htmxor.Tests/Configuration/HtmxHeadOutletTest.cs
+++ b/test/Htmxor.Tests/Configuration/HtmxHeadOutletTest.cs
@@ -60,7 +60,7 @@ public class HtmxHeadOutletTest : TestContext
                     "attr2"
                 ],
                 "defaultFocusScroll": true,
-                "defaultSwapStyle": "beforeBegin",
+                "defaultSwapStyle": "beforebegin",
                 "defaultSwapDelay": 60000,
                 "defaultSettleDelay": 3600000,
                 "disableSelector": "disable-selector",


### PR DESCRIPTION
Fixes #51 - This commit introduces a new `SwapStyleEnumConverter` to handle the serialization of the `SwapStyle` enum. This change also updates the test case in `HtmxHeadOutletTest.cs` to use correct serialized value.