### PR TITLE
refactor: Change casing on SwapStyle (and other htmx enums) for correct serialization

### DIFF
--- a/src/Htmxor/HtmxConfig.cs
+++ b/src/Htmxor/HtmxConfig.cs
@@ -160,7 +160,7 @@ public partial record class HtmxConfig
 	public TimeSpan? Timeout { get; set; }
 
 	/// <summary>
-	/// Defaults to <see cref="Htmxor.ScrollBehavior.smooth" /> if this property is null.
+	/// Defaults to <see cref="ScrollBehavior.smooth" /> if this property is null.
 	/// The behavior for a boosted link on page transitions. 
 	/// Smooth will smooth scroll to the top of the page while auto will behave like a vanilla link.
 	/// </summary>

--- a/src/Htmxor/HtmxConfig.cs
+++ b/src/Htmxor/HtmxConfig.cs
@@ -32,7 +32,7 @@ public partial record class HtmxConfig
 	public bool? RefreshOnHistoryMiss { get; set; }
 
 	/// <summary>
-	/// Defaults to <see cref="SwapStyle.InnerHTML"/> if this property is null.
+	/// Defaults to <see cref="SwapStyle.innerHTML"/> if this property is null.
 	/// </summary>
 	[JsonPropertyName("defaultSwapStyle")]
 	public SwapStyle? DefaultSwapStyle

--- a/src/Htmxor/HtmxConfig.cs
+++ b/src/Htmxor/HtmxConfig.cs
@@ -160,7 +160,7 @@ public partial record class HtmxConfig
 	public TimeSpan? Timeout { get; set; }
 
 	/// <summary>
-	/// Defaults to <see cref="ScrollBehavior.Smooth" /> if this property is null.
+	/// Defaults to <see cref="Htmxor.ScrollBehavior.smooth" /> if this property is null.
 	/// The behavior for a boosted link on page transitions. 
 	/// Smooth will smooth scroll to the top of the page while auto will behave like a vanilla link.
 	/// </summary>

--- a/src/Htmxor/ScrollBehavior.cs
+++ b/src/Htmxor/ScrollBehavior.cs
@@ -4,6 +4,9 @@ namespace Htmxor;
 /// <summary>
 /// The behavior for a boosted link on page transitions.
 /// </summary>
+/// <remarks>
+/// The casing on each of these values matches htmx attributes so that they can be used directly in markup
+/// </remarks>
 public enum ScrollBehavior
 {
 	/// <summary>

--- a/src/Htmxor/ScrollBehavior.cs
+++ b/src/Htmxor/ScrollBehavior.cs
@@ -1,4 +1,5 @@
-﻿namespace Htmxor;
+// ReSharper disable InconsistentNaming
+namespace Htmxor;
 
 /// <summary>
 /// The behavior for a boosted link on page transitions.
@@ -8,10 +9,11 @@ public enum ScrollBehavior
 	/// <summary>
 	/// Smooth will smooth-scroll to the top of the page.
 	/// </summary>
-	Smooth,
+	smooth,
+
 	/// <summary>
 	/// Auto will behave like a vanilla link.
 	/// </summary>
-	Auto,
+	auto,
 }
 

--- a/src/Htmxor/ScrollDirection.cs
+++ b/src/Htmxor/ScrollDirection.cs
@@ -1,10 +1,11 @@
-﻿namespace Htmxor;
+// ReSharper disable InconsistentNaming
+namespace Htmxor;
 
 /// <summary>
 /// Direction values for scroll and show modifier methods
 /// </summary>
 public enum ScrollDirection
 {
-	Top,
-	Bottom
+	top,
+	bottom
 }

--- a/src/Htmxor/ScrollDirection.cs
+++ b/src/Htmxor/ScrollDirection.cs
@@ -4,6 +4,9 @@ namespace Htmxor;
 /// <summary>
 /// Direction values for scroll and show modifier methods
 /// </summary>
+/// <remarks>
+/// The casing on each of these values matches htmx attributes so that they can be used directly in markup
+/// </remarks>
 public enum ScrollDirection
 {
 	top,

--- a/src/Htmxor/Serialization/SwapStyleEnumConverter.cs
+++ b/src/Htmxor/Serialization/SwapStyleEnumConverter.cs
@@ -14,14 +14,14 @@ internal sealed class SwapStyleEnumConverter : JsonConverter<SwapStyle>
 		{
 			null => SwapStyle.Default,
 			Constants.SwapStyles.Default => SwapStyle.Default,
-			Constants.SwapStyles.InnerHTML => SwapStyle.InnerHTML,
-			Constants.SwapStyles.OuterHTML => SwapStyle.OuterHTML,
-			Constants.SwapStyles.BeforeBegin => SwapStyle.BeforeBegin,
-			Constants.SwapStyles.AfterBegin => SwapStyle.AfterBegin,
-			Constants.SwapStyles.BeforeEnd => SwapStyle.BeforeEnd,
-			Constants.SwapStyles.AfterEnd => SwapStyle.AfterEnd,
-			Constants.SwapStyles.Delete => SwapStyle.Delete,
-			Constants.SwapStyles.None => SwapStyle.None,
+			Constants.SwapStyles.InnerHTML => SwapStyle.innerHTML,
+			Constants.SwapStyles.OuterHTML => SwapStyle.outerHTML,
+			Constants.SwapStyles.BeforeBegin => SwapStyle.beforebegin,
+			Constants.SwapStyles.AfterBegin => SwapStyle.afterbegin,
+			Constants.SwapStyles.BeforeEnd => SwapStyle.beforeend,
+			Constants.SwapStyles.AfterEnd => SwapStyle.afterend,
+			Constants.SwapStyles.Delete => SwapStyle.delete,
+			Constants.SwapStyles.None => SwapStyle.none,
 			_ => throw new SwitchExpressionException(value)
 		};
 

--- a/src/Htmxor/SwapStyle.cs
+++ b/src/Htmxor/SwapStyle.cs
@@ -4,12 +4,18 @@ namespace Htmxor;
 /// <summary>
 /// How to swap the response into the target element.
 /// </summary>
+/// <remarks>
+/// The casing on each of these values matches htmx attributes so that they can be used directly in markup
+/// </remarks>
 public enum SwapStyle
 {
 	/// <summary>
 	/// Default style is what is specified in <see cref="HtmxConfig.DefaultSwapStyle"/> for the application
 	/// or htmx's default, which is <see cref="innerHTML"/>.
 	/// </summary>
+	/// <remarks>
+	/// This SwapStyle cannot be used directly in markup
+	/// </remarks>
 	Default,
 
 	/// <summary>

--- a/src/Htmxor/SwapStyle.cs
+++ b/src/Htmxor/SwapStyle.cs
@@ -1,4 +1,5 @@
-﻿namespace Htmxor;
+// ReSharper disable InconsistentNaming
+namespace Htmxor;
 
 /// <summary>
 /// How to swap the response into the target element.
@@ -7,48 +8,48 @@ public enum SwapStyle
 {
 	/// <summary>
 	/// Default style is what is specified in <see cref="HtmxConfig.DefaultSwapStyle"/> for the application
-	/// or htmx's default, which is <see cref="InnerHTML"/>.
+	/// or htmx's default, which is <see cref="innerHTML"/>.
 	/// </summary>
 	Default,
 
 	/// <summary>
 	/// Replace the inner html of the target element.
 	/// </summary>
-	InnerHTML,
+	innerHTML,
 
 	/// <summary>
 	/// Replace the entire target element with the response.
 	/// </summary>
-	OuterHTML,
+	outerHTML,
 
 	/// <summary>
 	/// Insert the response before the target element.
 	/// </summary>
-	BeforeBegin,
+	beforebegin,
 
 	/// <summary>
 	/// Insert the response before the first child of the target element.
 	/// </summary>
-	AfterBegin,
+	afterbegin,
 
 	/// <summary>
 	/// Insert the response after the last child of the target element.
 	/// </summary>
-	BeforeEnd,
+	beforeend,
 
 	/// <summary>
 	/// Insert the response after the target element.
 	/// </summary>
-	AfterEnd,
+	afterend,
 
 	/// <summary>
 	/// Deletes the target element regardless of the response.
 	/// </summary>
-	Delete,
+	delete,
 
 	/// <summary>
 	/// Does not append content from response (out of band items will still be processed).
 	/// </summary>
-	None,
+	none,
 }
 

--- a/src/Htmxor/SwapStyleBuilder.cs
+++ b/src/Htmxor/SwapStyleBuilder.cs
@@ -64,7 +64,7 @@ public sealed class SwapStyleBuilder
 	/// Specifies how to set the content scrollbar position after the swap and appends the modifier <c>scroll:<paramref name="direction"/></c>.
 	/// </summary>
 	/// <remarks>
-	/// Sets the swapped content scrollbar position after swapping immediately (without animation). For instance, using <see cref="ScrollDirection.Top"/>
+	/// Sets the swapped content scrollbar position after swapping immediately (without animation). For instance, using <see cref="ScrollDirection.top"/>
 	/// will add the modifier <c>scroll:top</c> which sets the scrollbar position to the top of swap content after the swap.
 	/// If css <paramref name="cssSelector"/> is present then the page is scrolled to the <paramref name="direction"/> of the content identified by the css cssSelector.
 	/// </remarks>
@@ -75,10 +75,10 @@ public sealed class SwapStyleBuilder
 	{
 		switch (direction)
 		{
-			case ScrollDirection.Top:
+			case ScrollDirection.top:
 				AddModifier("scroll", cssSelector is null ? "top" : $"{cssSelector}:top");
 				break;
-			case ScrollDirection.Bottom:
+			case ScrollDirection.bottom:
 				AddModifier("scroll", cssSelector is null ? "bottom" : $"{cssSelector}:bottom");
 				break;
 		}
@@ -96,7 +96,7 @@ public sealed class SwapStyleBuilder
 	/// </remarks>
 	/// <param name="cssSelector">Optional CSS cssSelector of the target element.</param>
 	/// <returns>This <see cref="SwapStyleBuilder"/> object instance.</returns>
-	public SwapStyleBuilder ScrollTop(string? cssSelector = null) => Scroll(ScrollDirection.Top, cssSelector);
+	public SwapStyleBuilder ScrollTop(string? cssSelector = null) => Scroll(ScrollDirection.top, cssSelector);
 
 	/// <summary>
 	/// Sets the content scrollbar position to the bottom of the swapped content after a swap.
@@ -108,7 +108,7 @@ public sealed class SwapStyleBuilder
 	/// </remarks>
 	/// <param name="cssSelector">Optional CSS cssSelector of the target element.</param>
 	/// <returns>This <see cref="SwapStyleBuilder"/> object instance.</returns>
-	public SwapStyleBuilder ScrollBottom(string? cssSelector = null) => Scroll(ScrollDirection.Bottom, cssSelector);
+	public SwapStyleBuilder ScrollBottom(string? cssSelector = null) => Scroll(ScrollDirection.bottom, cssSelector);
 
 	/// <summary>
 	/// Determines whether to ignore the document title in the swap response by appending the modifier
@@ -207,7 +207,7 @@ public sealed class SwapStyleBuilder
 	/// </summary>
 	/// <remarks>
 	/// Adds a show modifier with the specified CSS cssSelector and scroll direction. For example, if <paramref name="cssSelector"/>
-	/// is ".item" and <paramref name="direction"/> is <see cref="ScrollDirection.Top"/>, the modifier <c>show:.item:top</c>
+	/// is ".item" and <paramref name="direction"/> is <see cref="ScrollDirection.top"/>, the modifier <c>show:.item:top</c>
 	/// is added.
 	/// </remarks>
 	/// <param name="direction">The scroll direction after swap.</param>
@@ -217,10 +217,10 @@ public sealed class SwapStyleBuilder
 	{
 		switch (direction)
 		{
-			case ScrollDirection.Top:
+			case ScrollDirection.top:
 				AddModifier("show", cssSelector is null ? "top" : $"{cssSelector}:top");
 				break;
-			case ScrollDirection.Bottom:
+			case ScrollDirection.bottom:
 				AddModifier("show", cssSelector is null ? "bottom" : $"{cssSelector}:bottom");
 				break;
 		}
@@ -237,7 +237,7 @@ public sealed class SwapStyleBuilder
 	/// </remarks>
 	/// <param name="cssSelector">Optional CSS cssSelector of the target element.</param>
 	/// <returns>This <see cref="SwapStyleBuilder"/> object instance.</returns>
-	public SwapStyleBuilder ShowOnTop(string? cssSelector = null) => ShowOn(ScrollDirection.Top, cssSelector);
+	public SwapStyleBuilder ShowOnTop(string? cssSelector = null) => ShowOn(ScrollDirection.top, cssSelector);
 
 	/// <summary>
 	/// Specifies that the swap should show the bottom of the element matching the CSS cssSelector.
@@ -248,7 +248,7 @@ public sealed class SwapStyleBuilder
 	/// </remarks>
 	/// <param name="cssSelector">Optional CSS cssSelector of the target element.</param>
 	/// <returns>This <see cref="SwapStyleBuilder"/> object instance.</returns>
-	public SwapStyleBuilder ShowOnBottom(string? cssSelector = null) => ShowOn(ScrollDirection.Bottom, cssSelector);
+	public SwapStyleBuilder ShowOnBottom(string? cssSelector = null) => ShowOn(ScrollDirection.bottom, cssSelector);
 
 	/// <summary>
 	/// Specifies that the swap should show in the window by smoothly scrolling to either the top or bottom of the window.
@@ -263,10 +263,10 @@ public sealed class SwapStyleBuilder
 	{
 		switch (direction)
 		{
-			case ScrollDirection.Top:
+			case ScrollDirection.top:
 				AddModifier("show", "window:top");
 				break;
-			case ScrollDirection.Bottom:
+			case ScrollDirection.bottom:
 				AddModifier("show", "window:bottom");
 				break;
 		}
@@ -284,7 +284,7 @@ public sealed class SwapStyleBuilder
 	/// the user after a swap operation.
 	/// </remarks>
 	/// <returns>This <see cref="SwapStyleBuilder"/> object instance.</returns>
-	public SwapStyleBuilder ShowWindowTop() => ShowWindow(ScrollDirection.Top);
+	public SwapStyleBuilder ShowWindowTop() => ShowWindow(ScrollDirection.top);
 
 	/// <summary>
 	/// Specifies that the swap should smoothly scroll to the bottom of the window.
@@ -295,7 +295,7 @@ public sealed class SwapStyleBuilder
 	/// can be used for infinite scrolling, footers, or information appended at the end of the page.
 	/// </remarks>
 	/// <returns>This <see cref="SwapStyleBuilder"/> object instance.</returns>
-	public SwapStyleBuilder ShowWindowBottom() => ShowWindow(ScrollDirection.Bottom);
+	public SwapStyleBuilder ShowWindowBottom() => ShowWindow(ScrollDirection.bottom);
 
 	/// <summary>
 	/// Turns off scrolling after swap.

--- a/src/Htmxor/SwapStyleBuilderExtension.cs
+++ b/src/Htmxor/SwapStyleBuilderExtension.cs
@@ -39,7 +39,7 @@ public static class SwapStyleBuilderExtension
 	/// Specifies how to set the content scrollbar position after the swap and appends the modifier <c>scroll:<paramref name="direction"/></c>.
 	/// </summary>
 	/// <remarks>
-	/// Sets the swapped content scrollbar position after swapping immediately (without animation). For instance, using <see cref="ScrollDirection.Top"/>
+	/// Sets the swapped content scrollbar position after swapping immediately (without animation). For instance, using <see cref="ScrollDirection.top"/>
 	/// will add the modifier <c>scroll:top</c> which sets the scrollbar position to the top of swap content after the swap.
 	/// If css <paramref name="cssSelector"/> is present then the page is scrolled to the <paramref name="direction"/> of the content identified by the css cssSelector.
 	/// </remarks>
@@ -165,7 +165,7 @@ public static class SwapStyleBuilderExtension
 	/// </summary>
 	/// <remarks>
 	/// Adds a show modifier with the specified CSS selector and scroll direction. For example, if <paramref name="cssSelector"/>
-	/// is ".item" and <paramref name="direction"/> is <see cref="ScrollDirection.Top"/>, the modifier <c>show:.item:top</c>
+	/// is ".item" and <paramref name="direction"/> is <see cref="ScrollDirection.top"/>, the modifier <c>show:.item:top</c>
 	/// is added.
 	/// </remarks>
 	/// <param name="style">The swap style.</param>

--- a/src/Htmxor/SwapStyleExtensions.cs
+++ b/src/Htmxor/SwapStyleExtensions.cs
@@ -12,14 +12,14 @@ public static class SwapStyleExtensions
 	{
 		var style = swapStyle switch
 		{
-			SwapStyle.InnerHTML => Constants.SwapStyles.InnerHTML,
-			SwapStyle.OuterHTML => Constants.SwapStyles.OuterHTML,
-			SwapStyle.BeforeBegin => Constants.SwapStyles.BeforeBegin,
-			SwapStyle.AfterBegin => Constants.SwapStyles.AfterBegin,
-			SwapStyle.BeforeEnd => Constants.SwapStyles.BeforeEnd,
-			SwapStyle.AfterEnd => Constants.SwapStyles.AfterEnd,
-			SwapStyle.Delete => Constants.SwapStyles.Delete,
-			SwapStyle.None => Constants.SwapStyles.None,
+			SwapStyle.innerHTML => Constants.SwapStyles.InnerHTML,
+			SwapStyle.outerHTML => Constants.SwapStyles.OuterHTML,
+			SwapStyle.beforebegin => Constants.SwapStyles.BeforeBegin,
+			SwapStyle.afterbegin => Constants.SwapStyles.AfterBegin,
+			SwapStyle.beforeend => Constants.SwapStyles.BeforeEnd,
+			SwapStyle.afterend => Constants.SwapStyles.AfterEnd,
+			SwapStyle.delete => Constants.SwapStyles.Delete,
+			SwapStyle.none => Constants.SwapStyles.None,
 			SwapStyle.Default => Constants.SwapStyles.Default,
 			_ => throw new SwitchExpressionException(swapStyle),
 		};

--- a/src/Htmxor/TriggerModifierBuilder.cs
+++ b/src/Htmxor/TriggerModifierBuilder.cs
@@ -196,14 +196,14 @@ public sealed class TriggerModifierBuilder
     /// // Resulting hx-trigger: <![CDATA[<div hx-get="/process" hx-trigger="click queue:all">Queue All]]>
     /// </code>
     /// </example>
-    public TriggerModifierBuilder Queue(TriggerQueueOption option = TriggerQueueOption.Last)
+    public TriggerModifierBuilder Queue(TriggerQueueOption option = TriggerQueueOption.last)
     {
         var value = option switch
         {
-            TriggerQueueOption.First => "first",
-            TriggerQueueOption.Last => "last",
-            TriggerQueueOption.None => "none",
-            TriggerQueueOption.All => "all",
+            TriggerQueueOption.first => "first",
+            TriggerQueueOption.last => "last",
+            TriggerQueueOption.none => "none",
+            TriggerQueueOption.all => "all",
             _ => throw new SwitchExpressionException(option),
         };
 

--- a/src/Htmxor/TriggerQueueOption.cs
+++ b/src/Htmxor/TriggerQueueOption.cs
@@ -1,3 +1,4 @@
+// ReSharper disable InconsistentNaming
 namespace Htmxor;
 
 /// <summary>
@@ -8,20 +9,20 @@ public enum TriggerQueueOption
     /// <summary>
     /// queue the first event
     /// </summary>
-    First,
+    first,
 
     /// <summary>
     /// queue the last event (default)
     /// </summary>
-    Last,
+    last,
 
     /// <summary>
     /// queue all events (issue a request for each event)
     /// </summary>
-    All,
+    all,
 
     /// <summary>
     /// do not queue new events
     /// </summary>
-    None
+    none
 }

--- a/src/Htmxor/TriggerQueueOption.cs
+++ b/src/Htmxor/TriggerQueueOption.cs
@@ -4,6 +4,9 @@ namespace Htmxor;
 /// <summary>
 /// Determines how events are queued if an event occurs while a request for another event is in flight.
 /// </summary>
+/// <remarks>
+/// The casing on each of these values matches htmx attributes so that they can be used directly in markup
+/// </remarks>
 public enum TriggerQueueOption
 {
     /// <summary>

--- a/test/Htmxor.Tests/Configuration/HtmxHeadOutletTest.cs
+++ b/test/Htmxor.Tests/Configuration/HtmxHeadOutletTest.cs
@@ -19,7 +19,7 @@ public class HtmxHeadOutletTest : TestContext
 			DefaultFocusScroll = true,
 			DefaultSettleDelay = TimeSpan.FromHours(1),
 			DefaultSwapDelay = TimeSpan.FromMinutes(1),
-			DefaultSwapStyle = SwapStyle.BeforeBegin,
+			DefaultSwapStyle = SwapStyle.beforebegin,
 			DisableSelector = "disable-selector",
 			GetCacheBusterParam = true,
 			GlobalViewTransitions = true,

--- a/test/Htmxor.Tests/Configuration/HtmxHeadOutletTest.cs
+++ b/test/Htmxor.Tests/Configuration/HtmxHeadOutletTest.cs
@@ -32,7 +32,7 @@ public class HtmxHeadOutletTest : TestContext
 			MethodsThatUseUrlParams = ["GET", "POST", "DELETE"],
 			RefreshOnHistoryMiss = true,
 			RequestClass = "request-class",
-			ScrollBehavior = ScrollBehavior.Smooth,
+			ScrollBehavior = ScrollBehavior.smooth,
 			ScrollIntoViewOnBoost = true,
 			SelfRequestsOnly = true,
 			SettlingClass = "settling-class",

--- a/test/Htmxor.Tests/Http/HtmxResponseTests.cs
+++ b/test/Htmxor.Tests/Http/HtmxResponseTests.cs
@@ -152,7 +152,7 @@ public class HtmxResponseTests : TestContext
 		var response = context.GetHtmxContext().Response;
 
 		// Act
-		response.Reswap(SwapStyle.InnerHTML);
+		response.Reswap(SwapStyle.innerHTML);
 
 		// Assert
 		context.Response.Headers[HtmxResponseHeaderNames.Reswap].Should().Equal(["innerHTML"]);

--- a/test/Htmxor.Tests/SwapStyleBuilderTests.cs
+++ b/test/Htmxor.Tests/SwapStyleBuilderTests.cs
@@ -5,7 +5,7 @@ public class SwapStyleBuilderTests
 	[Fact]
 	public void SwapStyleBuilder_InitializeAndBuild_ReturnsCorrectValues()
 	{
-		var swapStyle = SwapStyle.InnerHTML;
+		var swapStyle = SwapStyle.innerHTML;
 		var sut = new SwapStyleBuilder(swapStyle);
 
 		var (resultStyle, modifiers) = sut.Build();
@@ -17,7 +17,7 @@ public class SwapStyleBuilderTests
 	[Fact]
 	public void SwapStyleBuilder_AfterSwap_AddsCorrectDelay()
 	{
-		var sut = new SwapStyleBuilder(SwapStyle.InnerHTML);
+		var sut = new SwapStyleBuilder(SwapStyle.innerHTML);
 
 		var (_, modifiers) = sut.AfterSwapDelay(TimeSpan.FromSeconds(1)).Build();
 
@@ -27,7 +27,7 @@ public class SwapStyleBuilderTests
 	[Fact]
 	public void SwapStyleBuilder_AfterSettle_AddsCorrectDelay()
 	{
-		var sut = new SwapStyleBuilder(SwapStyle.InnerHTML);
+		var sut = new SwapStyleBuilder(SwapStyle.innerHTML);
 
 		var (_, modifiers) = sut.AfterSettleDelay(TimeSpan.FromSeconds(1)).Build();
 
@@ -37,7 +37,7 @@ public class SwapStyleBuilderTests
 	[Fact]
 	public void SwapStyleBuilder_Scroll_AddsCorrectDirection()
 	{
-		var sut = new SwapStyleBuilder(SwapStyle.InnerHTML);
+		var sut = new SwapStyleBuilder(SwapStyle.innerHTML);
 
 		var (_, modifiers) = sut.Scroll(ScrollDirection.Bottom).Build();
 
@@ -47,7 +47,7 @@ public class SwapStyleBuilderTests
 	[Fact]
 	public void SwapStyleBuilder_IgnoreTitle_AddsCorrectFlag()
 	{
-		var sut = new SwapStyleBuilder(SwapStyle.InnerHTML);
+		var sut = new SwapStyleBuilder(SwapStyle.innerHTML);
 
 		var (_, modifiers) = sut.IgnoreTitle(true).Build();
 
@@ -57,7 +57,7 @@ public class SwapStyleBuilderTests
 	[Fact]
 	public void SwapStyleBuilder_Transition_AddsCorrectFlag()
 	{
-		var sut = new SwapStyleBuilder(SwapStyle.InnerHTML);
+		var sut = new SwapStyleBuilder(SwapStyle.innerHTML);
 
 		var (_, modifiers) = sut.Transition(true).Build();
 
@@ -67,7 +67,7 @@ public class SwapStyleBuilderTests
 	[Fact]
 	public void SwapStyleBuilder_ScrollFocus_AddsCorrectFlag()
 	{
-		var sut = new SwapStyleBuilder(SwapStyle.InnerHTML);
+		var sut = new SwapStyleBuilder(SwapStyle.innerHTML);
 
 		var (_, modifiers) = sut.ScrollFocus(true).Build();
 
@@ -77,7 +77,7 @@ public class SwapStyleBuilderTests
 	[Fact]
 	public void SwapStyleBuilder_ShowOn_AddsCorrectSelectorAndDirection()
 	{
-		var sut = new SwapStyleBuilder(SwapStyle.InnerHTML);
+		var sut = new SwapStyleBuilder(SwapStyle.innerHTML);
 		var selector = "#dynamic-area";
 
 		var (_, modifiers) = sut.ShowOn(ScrollDirection.Top, selector).Build();
@@ -88,7 +88,7 @@ public class SwapStyleBuilderTests
 	[Fact]
 	public void SwapStyleBuilder_ShowWindow_AddsCorrectWindowAndDirection()
 	{
-		var sut = new SwapStyleBuilder(SwapStyle.InnerHTML);
+		var sut = new SwapStyleBuilder(SwapStyle.innerHTML);
 
 		var (_, modifiers) = sut.ShowWindow(ScrollDirection.Top).Build();
 
@@ -98,7 +98,7 @@ public class SwapStyleBuilderTests
 	[Fact]
 	public void SwapStyleBuilder_ChainedOperations_AddsCorrectModifiers()
 	{
-		var sut = new SwapStyleBuilder(SwapStyle.InnerHTML);
+		var sut = new SwapStyleBuilder(SwapStyle.innerHTML);
 
 		var (_, modifiers) = sut
 			.AfterSwapDelay(TimeSpan.FromSeconds(1))
@@ -113,7 +113,7 @@ public class SwapStyleBuilderTests
 	[Fact]
 	public void SwapStyleBuilder_After_With250Milliseconds_AddsCorrectDelay()
 	{
-		var sut = new SwapStyleBuilder(SwapStyle.InnerHTML);
+		var sut = new SwapStyleBuilder(SwapStyle.innerHTML);
 
 		var (_, modifiers) = sut.AfterSwapDelay(TimeSpan.FromMilliseconds(250)).Build();
 
@@ -123,7 +123,7 @@ public class SwapStyleBuilderTests
 	[Fact]
 	public void SwapStyleBuilder_ShowOn_BottomDirection_AddsCorrectModifier()
 	{
-		var sut = new SwapStyleBuilder(SwapStyle.InnerHTML);
+		var sut = new SwapStyleBuilder(SwapStyle.innerHTML);
 		var selector = "#element-id";
 
 		var (_, modifiers) = sut.ShowOn(ScrollDirection.Bottom, selector).Build();
@@ -134,7 +134,7 @@ public class SwapStyleBuilderTests
 	[Fact]
 	public void SwapStyleBuilder_ShowWindow_BottomDirection_AddsCorrectModifier()
 	{
-		var sut = new SwapStyleBuilder(SwapStyle.InnerHTML);
+		var sut = new SwapStyleBuilder(SwapStyle.innerHTML);
 
 		var (_, modifiers) = sut.ShowWindow(ScrollDirection.Bottom).Build();
 
@@ -154,7 +154,7 @@ public class SwapStyleBuilderTests
 	[Fact]
 	public void SwapStyleBuilder_ShowNone_ReturnsCorrectValue()
 	{
-		var sut = new SwapStyleBuilder(SwapStyle.InnerHTML);
+		var sut = new SwapStyleBuilder(SwapStyle.innerHTML);
 
 		var (_, modifiers) = sut.ShowNone().Build();
 
@@ -164,7 +164,7 @@ public class SwapStyleBuilderTests
 	[Fact]
 	public void SwapStyleBuilder_ShowOnTop_ReturnsCorrectValue()
 	{
-		var sut = new SwapStyleBuilder(SwapStyle.InnerHTML);
+		var sut = new SwapStyleBuilder(SwapStyle.innerHTML);
 
 		var (_, modifiers) = sut.ShowOnTop().Build();
 
@@ -174,7 +174,7 @@ public class SwapStyleBuilderTests
 	[Fact]
 	public void SwapStyleBuilder_ShowOnBottom_ReturnsCorrectValue()
 	{
-		var sut = new SwapStyleBuilder(SwapStyle.InnerHTML);
+		var sut = new SwapStyleBuilder(SwapStyle.innerHTML);
 
 		var (_, modifiers) = sut.ShowOnBottom().Build();
 
@@ -184,7 +184,7 @@ public class SwapStyleBuilderTests
 	[Fact]
 	public void SwapStyleBuilder_MixedShowOverrides_ReturnsCorrectValue()
 	{
-		var sut = new SwapStyleBuilder(SwapStyle.InnerHTML);
+		var sut = new SwapStyleBuilder(SwapStyle.innerHTML);
 
 		var (_, modifiers) = sut.ShowOnTop()
 			.AfterSettleDelay(TimeSpan.FromMilliseconds(250))

--- a/test/Htmxor.Tests/SwapStyleBuilderTests.cs
+++ b/test/Htmxor.Tests/SwapStyleBuilderTests.cs
@@ -39,7 +39,7 @@ public class SwapStyleBuilderTests
 	{
 		var sut = new SwapStyleBuilder(SwapStyle.innerHTML);
 
-		var (_, modifiers) = sut.Scroll(ScrollDirection.Bottom).Build();
+		var (_, modifiers) = sut.Scroll(ScrollDirection.bottom).Build();
 
 		modifiers.Should().Be("scroll:bottom");
 	}
@@ -80,7 +80,7 @@ public class SwapStyleBuilderTests
 		var sut = new SwapStyleBuilder(SwapStyle.innerHTML);
 		var selector = "#dynamic-area";
 
-		var (_, modifiers) = sut.ShowOn(ScrollDirection.Top, selector).Build();
+		var (_, modifiers) = sut.ShowOn(ScrollDirection.top, selector).Build();
 
 		modifiers.Should().Be("show:#dynamic-area:top");
 	}
@@ -90,7 +90,7 @@ public class SwapStyleBuilderTests
 	{
 		var sut = new SwapStyleBuilder(SwapStyle.innerHTML);
 
-		var (_, modifiers) = sut.ShowWindow(ScrollDirection.Top).Build();
+		var (_, modifiers) = sut.ShowWindow(ScrollDirection.top).Build();
 
 		modifiers.Should().Be("show:window:top");
 	}
@@ -102,7 +102,7 @@ public class SwapStyleBuilderTests
 
 		var (_, modifiers) = sut
 			.AfterSwapDelay(TimeSpan.FromSeconds(1))
-			.Scroll(ScrollDirection.Top)
+			.Scroll(ScrollDirection.top)
 			.Transition(true)
 			.IgnoreTitle(false)
 			.Build();
@@ -126,7 +126,7 @@ public class SwapStyleBuilderTests
 		var sut = new SwapStyleBuilder(SwapStyle.innerHTML);
 		var selector = "#element-id";
 
-		var (_, modifiers) = sut.ShowOn(ScrollDirection.Bottom, selector).Build();
+		var (_, modifiers) = sut.ShowOn(ScrollDirection.bottom, selector).Build();
 
 		modifiers.Should().Be("show:#element-id:bottom");
 	}
@@ -136,7 +136,7 @@ public class SwapStyleBuilderTests
 	{
 		var sut = new SwapStyleBuilder(SwapStyle.innerHTML);
 
-		var (_, modifiers) = sut.ShowWindow(ScrollDirection.Bottom).Build();
+		var (_, modifiers) = sut.ShowWindow(ScrollDirection.bottom).Build();
 
 		modifiers.Should().Be("show:window:bottom");
 	}

--- a/test/Htmxor.Tests/TriggerBuilderTests.cs
+++ b/test/Htmxor.Tests/TriggerBuilderTests.cs
@@ -169,7 +169,7 @@ public class TriggerBuilderTests
 	{
 		var sut = new TriggerBuilder().OnEvent("click");
 
-		var (triggerString, _) = sut.Queue(TriggerQueueOption.All).Build();
+		var (triggerString, _) = sut.Queue(TriggerQueueOption.all).Build();
 
 		triggerString.Should().Be("click queue:all");
 	}
@@ -187,7 +187,7 @@ public class TriggerBuilderTests
 			.From("window")
 			.Target("#specificElement")
 			.Consume()
-			.Queue(TriggerQueueOption.First)
+			.Queue(TriggerQueueOption.first)
 			.Build();
 
 		triggerString.Should().Be("click[shiftKey] delay:500ms throttle:200ms from:window target:#specificElement consume queue:first");


### PR DESCRIPTION
Fixes #53 

Also alters other htmx enums to match style:
ScrollBehavior (Smooth/Auto to smooth/auto)
ScrollDirection (Top/Bottom to top/bottom)
TriggerQueueOption (First/Last/All/None to first/last/all/none)
TriggerTiming (left as is - this is technically not an htmx value but used only by Htmxor)
