### PR TITLE
docs: HtmxRequest.Path comment

### DIFF
--- a/src/Htmxor/Http/HtmxRequest.cs
+++ b/src/Htmxor/Http/HtmxRequest.cs
@@ -15,7 +15,7 @@ public sealed class HtmxRequest
 	public string Method { get; }
 
 	/// <summary>
-	/// Gets the HTTP method of the current request.
+	/// Gets the path of the current request.
 	/// </summary>
 	public PathString Path { get; }
 


### PR DESCRIPTION
Fixes a small mistake in the docs of HtmxRequest's Path property