### PR TITLE
Update HtmxFragment.cs

### DIFF
--- a/src/Htmxor/Components/HtmxFragment.cs
+++ b/src/Htmxor/Components/HtmxFragment.cs
@@ -43,5 +43,5 @@ public class HtmxFragment : ConditionalComponentBase
 	/// <inheritdoc/>
 	public override bool ShouldOutput([NotNull] HtmxContext context, int directConditionalChildren, int conditionalChildren)
 		=> (RenderDuringStandardRequest && context.Request.RoutingMode is RoutingMode.Standard)
-		|| (Match?.Invoke(context.Request) ?? true);
+		|| ((Match?.Invoke(context.Request) ?? true && context.Request.RoutingMode is RoutingMode.Direct));
 }


### PR DESCRIPTION
Hi Mr Egil 
I change ShouldOutput method because Match?.Invoke(context.Request) ?? true  must be done just when context.Request.RoutingMode is RoutingMode.Direct because RenderDuringStandardRequest has higher priority in RoutingMode.Standard