### PR TITLE
docs: define Htmxor v1 goal

### DIFF
--- a/docs/research/blazor-static-ssr-progressive-enhancement.md
+++ b/docs/research/blazor-static-ssr-progressive-enhancement.md
@@ -1,0 +1,312 @@
+# Blazor static SSR progressive enhancement
+
+Research date: 2026-08-26 UTC
+
+This note examines whether Htmxor can be added to an existing Blazor Web App without changing its behavior, then progressively enhance ordinary static server-side rendered components. It focuses on .NET 10 forms and reusable components. The latest servicing release at the research date is [.NET 10.0.11](https://github.com/dotnet/core/blob/main/release-notes/10.0/10.0.11/10.0.11.md).
+
+Sources are Microsoft Learn and the `dotnet/aspnetcore` implementation. Source links use the .NET 10 release tag where the repository exposes one. The few Htmxor recommendations are marked as design conclusions rather than framework facts.
+
+## Executive finding
+
+The requested compatibility goal is achievable, but only if Htmxor treats Blazor's static SSR endpoint pipeline as the platform contract:
+
+> A component that works as a stock Blazor static SSR component should continue to work unchanged inside a Htmxor response, including `EditForm`, built-in `Input*` components, form mapping, validation, antiforgery, and reusable library forms.
+
+That rules out a standalone custom renderer as the main v1 execution path. A generic HTML renderer can instantiate components and produce markup, but stock static form handling also requires request validation, form-handler selection, form-value mapping, component lifecycle execution, submit-event dispatch, rerendering, and enhanced-navigation response signaling. The framework's Razor component endpoint invoker coordinates those operations. [`RazorComponentEndpointInvoker`](https://github.com/dotnet/aspnetcore/blob/v10.0.0/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs) shows the full sequence.
+
+The safe v1 baseline is:
+
+1. Leave normal requests on the stock `MapRazorComponents` endpoints.
+2. Reuse the public [`IRazorComponentEndpointInvoker`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.components.endpoints.irazorcomponentendpointinvoker?view=aspnetcore-10.0), with the framework's endpoint metadata and services, for Htmxor component endpoints that must support stock static SSR behavior.
+3. Perform HTMX response selection around or within that execution path without taking ownership of form mapping or submit dispatch.
+4. Accept full-tree rendering and response buffering as the correctness baseline if the public API does not expose a cheaper fragment seam. Optimize only after parity tests prove that a new path preserves the same behavior.
+
+This is a useful constraint. It lets Htmxor support first-party and static-SSR-capable third-party components by inheritance rather than by reimplementing each Blazor feature.
+
+## The zero-break installation contract
+
+Adding Htmxor should be inert until the application opts a route or markup region into HTMX behavior. Installing the package and registering its services must not change existing component output or request handling.
+
+The concrete contract should be:
+
+- Htmxor does not replace Blazor's renderer, `IRazorComponentEndpointInvoker`, form mapper, antiforgery provider, navigation manager, or other services registered by `AddRazorComponents`.
+- Existing `MapRazorComponents<TRootComponent>()` endpoints remain the sole handlers for ordinary page GETs and stock form POSTs.
+- Htmxor does not inject an htmx script, enable `hx-boost`, or modify links and forms merely because its services are registered.
+- Htmxor-owned routes fail generation or startup when they collide with an existing ASP.NET Core endpoint. Registration order must not decide which route wins.
+- A request without an HTMX signal follows the same endpoint, render mode, authorization, antiforgery, lifecycle, status, redirect, streaming, and enhanced-navigation behavior as it did before Htmxor was installed.
+- A component that contains no Htmxor component or `hx-*` attribute has no runtime dependency on Htmxor.
+- Removing or failing to load htmx leaves every progressively enhanced link and form with a valid HTML navigation or submission path.
+
+Microsoft's library guidance supports this model. Static SSR runs components for one HTTP request, emits HTML, then discards the renderer and component state. Read-only components work naturally. Form `@onsubmit` is the special event that remains functional in static SSR. Components can provide better interactive behavior while keeping an HTML and form-post baseline. [Razor class libraries and static SSR](https://learn.microsoft.com/en-us/aspnet/core/blazor/components/class-libraries-and-static-server-side-rendering?view=aspnetcore-10.0).
+
+## How a stock static SSR form works
+
+Static form handling is not a single callback invocation. The framework coordinates several layers.
+
+### Initial render
+
+Consider an ordinary component:
+
+```razor
+@page "/contacts/{Id:int}/edit"
+
+<EditForm Model="Model"
+          FormName="EditContact"
+          OnValidSubmit="SaveAsync">
+    <DataAnnotationsValidator />
+    <ValidationSummary />
+
+    <InputText @bind-Value="Model!.Name" />
+    <button type="submit">Save</button>
+</EditForm>
+
+@code {
+    [SupplyParameterFromForm]
+    private ContactInput? Model { get; set; }
+
+    protected override void OnInitialized() => Model ??= new();
+
+    private Task SaveAsync() => Contacts.SaveAsync(Id, Model!);
+}
+```
+
+During static SSR, `EditForm`:
+
+- creates or accepts an `EditContext` and cascades it to its children;
+- renders a real HTML `<form>`;
+- sets `method="post"` when the static form-mapping context is present;
+- registers its `onsubmit` callback as a named event using `FormName`;
+- renders a form-mapping validator and an antiforgery token;
+- renders `data-enhance` only when the developer sets `Enhance`.
+
+These behaviors are in the [.NET 10 `EditForm` implementation](https://github.com/dotnet/aspnetcore/blob/v10.0.0/src/Components/Web/src/Forms/EditForm.cs). They depend on the `FormMappingContext` supplied by the endpoint rendering environment. When that context is missing, `EditForm` does not set up the static POST contract.
+
+`InputBase<TValue>` derives each input's HTML `name` from its bound value expression and field prefix. The form mapper uses the same naming convention. On a failed post, the input retrieves the attempted value and exposes validation state through the `EditContext`; it also emits `aria-invalid="true"` unless the component author supplied that attribute. [.NET 10 `InputBase<TValue>` source](https://github.com/dotnet/aspnetcore/blob/v10.0.0/src/Components/Web/src/Forms/InputBase.cs).
+
+### POST processing
+
+For a Razor component endpoint, the .NET 10 endpoint invoker performs this order:
+
+1. Validate the POST content type.
+2. Enforce endpoint antiforgery metadata, using middleware's result when available or validating through `IAntiforgery` itself.
+3. Read the form and obtain the single `_handler` value that identifies the named form.
+4. Initialize the renderer's request services with the page component type, selected handler, and posted form.
+5. Render the root component so `[SupplyParameterFromForm]` can populate the new component instance and named event registrations can be discovered.
+6. Dispatch the selected submit event on that rendered instance.
+7. Await non-streaming tasks, rerender, and write the response, including streaming framing when applicable.
+
+The implementation rejects an invalid content type, a missing or invalid antiforgery token, multiple `_handler` values, and unknown or ambiguous handlers. See [`RazorComponentEndpointInvoker.RenderComponentCore`](https://github.com/dotnet/aspnetcore/blob/v10.0.0/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs#L38) and its request validation path.
+
+This sequence explains why rendering a fresh component and independently calling a method is not equivalent. The handler must run on the instance that received route and form values and participated in the render tree. Its rerender carries validation messages, attempted invalid values, and callback state into the response.
+
+### Form mapping
+
+`[SupplyParameterFromForm]` is a cascading-value feature, not MVC model binding. It supports primitives, collections, complex and recursive types, constructors, and enums. `RazorComponentsServiceOptions` bounds collection size, recursion, error count, and key size. Microsoft recommends a dedicated form model or DTO to prevent overposting because MVC attributes such as `[BindNever]` don't apply. [Blazor forms binding](https://learn.microsoft.com/en-us/aspnet/core/blazor/forms/binding?view=aspnetcore-10.0).
+
+The framework records attempted values and mapping failures in `FormMappingContext`. `FormMappingValidator` transfers those failures to the form's `EditContext`, which stops `OnValidSubmit` from running when mapping failed. [`SupplyParameterFromFormValueProvider`](https://github.com/dotnet/aspnetcore/blob/v10.0.0/src/Components/Web/src/Forms/Mapping/SupplyParameterFromFormValueProvider.cs) owns the property lookup and error association.
+
+`FormName` is required when a statically rendered form is submitted. A name only has to be unique inside its form mapping scope. `FormMappingScope` exists so an application can include a library component whose author chose a form name that is also used elsewhere. [Form names and `FormMappingScope`](https://learn.microsoft.com/en-us/aspnet/core/blazor/forms/binding?view=aspnetcore-10.0#form-names).
+
+### Validation
+
+`EditForm` owns the submit validation convention:
+
+- `OnSubmit` gives the component responsibility for calling `EditContext.Validate()`.
+- Without `OnSubmit`, `EditForm` validates and then calls exactly one of `OnValidSubmit` or `OnInvalidSubmit`.
+- `DataAnnotationsValidator` attaches data-annotations validation to the `EditContext`.
+- `ValidationMessage` and `ValidationSummary` render the resulting messages.
+- Mapping errors participate in the same `EditContext`, so malformed values cannot reach `OnValidSubmit` as if they were valid.
+
+This behavior is documented in the [forms overview](https://learn.microsoft.com/en-us/aspnet/core/blazor/forms/?view=aspnetcore-10.0#handle-form-submission) and implemented by [.NET 10 `EditForm`](https://github.com/dotnet/aspnetcore/blob/v10.0.0/src/Components/Web/src/Forms/EditForm.cs).
+
+There is a documentation-version trap. The current Learn page rendered with `view=aspnetcore-10.0` contains both "client-side validation requires a circuit" and a statement that static SSR gains automatic client validation. The .NET 10 source has server validation on POST and no static-SSR client-validation emission. Static SSR client validation was announced as a [.NET 11 preview feature](https://github.com/dotnet/core/blob/main/release-notes/11.0/preview/preview5/aspnetcore.md#client-side-validation-for-blazor-static-ssr-forms). Htmxor should therefore treat server-side validation as the .NET 10 contract and not promise .NET 11 client validation while targeting .NET 10.
+
+### Antiforgery
+
+`AddRazorComponents` adds antiforgery services. In current .NET 10 apps, automatic header-based CSRF protection checks `Sec-Fetch-Site` and `Origin` on unsafe requests. Calling `UseAntiforgery` adds token validation; it must run after authentication and authorization and after routing. `EditForm` automatically renders `AntiforgeryToken` and requires validation. Plain HTML forms must include `<AntiforgeryToken />` themselves. [Blazor forms antiforgery guidance](https://learn.microsoft.com/en-us/aspnet/core/blazor/forms/?view=aspnetcore-10.0#antiforgery-support).
+
+For Htmxor, an HTMX form submission must retain the antiforgery cookie and hidden field, use a supported form content type, and reach an endpoint with the same antiforgery metadata. `HX-Request` is never an antiforgery or authorization signal.
+
+## Progressive enhancement with an ordinary `EditForm`
+
+An existing `EditForm` already has the correct non-JavaScript baseline. It posts to the current component route, names the form, sends the model fields and antiforgery token, invokes the component callback, and receives a new page.
+
+The least invasive HTMX enhancement is boosting a region rather than replacing `EditForm`:
+
+```razor
+<HtmxFragment Id="contact-editor">
+    <div hx-boost="true"
+         hx-target="#contact-editor"
+         hx-select="#contact-editor">
+        <EditForm Model="Model"
+                  FormName="EditContact"
+                  OnValidSubmit="SaveAsync">
+            <DataAnnotationsValidator />
+            <ValidationSummary />
+
+            <InputText @bind-Value="Model!.Name" />
+            <ValidationMessage For="() => Model!.Name" />
+            <button type="submit">Save</button>
+        </EditForm>
+    </div>
+</HtmxFragment>
+```
+
+This design has two execution paths:
+
+| Browser state | Result |
+| --- | --- |
+| htmx is absent, blocked, or disabled | The browser performs the stock full-page form POST. Blazor binds, validates, invokes the callback, and renders the complete page. |
+| htmx is active | Boosting submits the same form fields, `_handler`, and antiforgery token to the same URL. The same Blazor endpoint pipeline handles the POST. HTMX applies the selected response region. |
+
+No `hx-post` is needed on `EditForm`, and no Htmxor-specific form component is needed. Htmxor may use the request's target to select `contact-editor` server-side. The returned fragment must contain the form, inputs, and validation components when the post is invalid. Returning only a success child would discard the attempted values and validation UI.
+
+This is a design conclusion, not a claim that htmx and Blazor automatically coordinate. A form must have one JavaScript submission owner. `EditForm Enhance` emits `data-enhance`, which asks `blazor.web.js` to intercept the same submit event. Htmxor should do one of the following:
+
+- exclude `data-enhance` forms from Htmxor boosting by default; or
+- diagnose a form that is both Blazor-enhanced and HTMX-boosted and require the developer to choose.
+
+It should not rely on event-listener registration order. Microsoft states that enhanced form posts only work with Blazor endpoints and that `Enhance` is opt-in per form. [Enhanced form handling](https://learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/navigation?view=aspnetcore-10.0#enhanced-navigation-and-form-handling).
+
+The full-page fallback also means Htmxor must preserve ordinary `action`, `method`, submit-button names and values, multipart encoding, redirects, and status codes. An HTMX-only construct with no valid HTML fallback is an opt-in feature, not progressive enhancement.
+
+## First-party component compatibility
+
+If Htmxor preserves the endpoint pipeline, the following components need no Htmxor adapters:
+
+| Blazor feature | Static SSR behavior Htmxor should inherit |
+| --- | --- |
+| `EditForm` | Real form element, named submit callback, `EditContext`, automatic POST method in the mapping context, antiforgery token, validation dispatch |
+| `InputText`, `InputTextArea`, `InputNumber`, `InputDate`, `InputCheckbox`, `InputSelect`, `InputRadioGroup`, and related `InputBase<T>` controls | Stable HTML field names, field prefixes, attempted-value restoration, parsing errors, validation CSS, `aria-invalid` |
+| `[SupplyParameterFromForm]` | Request-scoped model construction and bounded form mapping, including private component properties |
+| `DataAnnotationsValidator` | Server-side validation attached to the posted form's `EditContext` in .NET 10 |
+| `ValidationMessage` and `ValidationSummary` | Errors included in the rerendered form or fragment |
+| `FormMappingScope` | Isolation of duplicate form names in reusable components and Razor class libraries |
+| `<AntiforgeryToken />` and `RequireAntiforgeryToken` | Hidden token generation and endpoint validation |
+| `[StreamRendering]` | Stock initial output and streamed updates, subject to response-selection support |
+| Route, query, authentication, and `HttpContext` cascading values | The same request-scoped values as a normal component endpoint |
+
+`InputFile` needs a narrower promise. Its rich `OnChange` and `IBrowserFile` APIs require an interactive runtime. A static-SSR-capable file component may still render a native `<input type="file">` and use a normal multipart form post. Microsoft explicitly recommends this kind of reduced HTML baseline for progressively enhanced library components. [Static SSR library guidance](https://learn.microsoft.com/en-us/aspnet/core/blazor/components/class-libraries-and-static-server-side-rendering?view=aspnetcore-10.0#options-for-component-authors) and [Blazor file uploads](https://learn.microsoft.com/en-us/aspnet/core/blazor/file-uploads?view=aspnetcore-10.0).
+
+## Third-party component compatibility
+
+The correct claim is not "every Blazor component works with Htmxor." It is:
+
+> Any component that meets Blazor's static SSR contract should retain that contract when rendered through Htmxor.
+
+That includes third-party components that:
+
+- render useful HTML without a live circuit or WebAssembly runtime;
+- use links or form posts for their static behavior;
+- use `EditForm`, `EditContext`, and the supported validation components without replacing their semantics;
+- derive custom fields from `InputBase<TValue>` and put `NameAttributeValue` on the actual HTML control when static rendering is possible;
+- or otherwise emit correct HTML `name` and `value` fields that match their `[SupplyParameterFromForm]` model;
+- use `FormMappingScope` or document form names when packaged forms may be repeated;
+- treat `HttpContext` as nullable and avoid requiring it in interactive modes;
+- avoid requiring `OnAfterRender`, element references, arbitrary .NET DOM events, or JavaScript interop for their static baseline.
+
+Microsoft specifically instructs custom `InputBase<TValue>` authors to emit `name="@NameAttributeValue"` when the component may be statically rendered. Without it, the component may look correct on GET but cannot bind its value on POST. [Custom input component guidance](https://learn.microsoft.com/en-us/aspnet/core/blazor/forms/binding?view=aspnetcore-10.0#custom-input-components).
+
+Components that only work interactively remain interactive-only. Htmxor should not imitate a circuit, synthesize arbitrary DOM events, or claim compatibility because the initial HTML happened to render. Static SSR discards component and renderer state after each request, and only form submit has the framework's special server event path. [Static SSR capabilities and restrictions](https://learn.microsoft.com/en-us/aspnet/core/blazor/components/class-libraries-and-static-server-side-rendering?view=aspnetcore-10.0#understand-the-capabilities-and-restrictions-of-static-ssr).
+
+## Public seams Htmxor can reuse
+
+| Public seam | Suitable Htmxor use | Constraint |
+| --- | --- | --- |
+| `AddRazorComponents` and `MapRazorComponents<TRootComponent>` | Keep all normal pages and their GET/POST behavior on the framework path | Htmxor must compose with these registrations, not replace them |
+| `IRazorComponentEndpointInvoker.Render(HttpContext)` | Execute a component endpoint with framework routing state, form handling, lifecycle, streaming, and response behavior | The endpoint must supply the metadata and middleware contract expected by the invoker |
+| `RootComponentMetadata` and `ComponentTypeMetadata` | Tell the invoker which application root and page component to render | Both are required by the implementation; route values and root composition must match stock behavior |
+| ASP.NET Core endpoint metadata and conventions | Apply authorization, antiforgery, HTTP methods, rate limits, caching rules, and request limits before rendering | Htmxor must not treat HTMX headers as policy |
+| `RazorComponentsServiceOptions` | Retain application-configured form-mapping limits and culture behavior | Do not create an independent form binder with different limits |
+| `FormMappingScope`, `FormMappingContext`, `EditContext`, and `InputBase<T>` | Let built-in and third-party components participate through Blazor's existing contracts | Most implementation details beneath these types remain framework-owned |
+| Response-body capture around a stock endpoint | Correctness-first full-page rendering followed by HTMX fragment extraction | It costs full rendering, buffering, and parsing; streaming requires a deliberate policy |
+| `RazorComponentResult<TComponent>` | Render a component as the result of an endpoint that already owns its HTTP operation | It is not a substitute for routed component form POST dispatch |
+| `HtmlRenderer` | Tests and generic static component rendering | It does not provide the routed endpoint's form selection, request validation, submit dispatch, navigation framing, or streaming coordination |
+
+`IRazorComponentEndpointInvoker`, `RootComponentMetadata`, and `ComponentTypeMetadata` are public .NET 10 APIs. The interface documentation says that Razor component endpoints provide the root and page components through those metadata types. [Endpoint API namespace](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.components.endpoints?view=aspnetcore-10.0). `AddRazorComponents` registers the framework implementation and form services. [.NET 10 service registration source](https://github.com/dotnet/aspnetcore/blob/v10.0.0/src/Components/Endpoints/src/DependencyInjection/RazorComponentsServiceCollectionExtensions.cs).
+
+This makes a public-API Htmxor endpoint plausible. It still needs a prototype. The prototype must prove that a generated endpoint with the same root/page metadata preserves route parameters, layouts, authorization, antiforgery, form mapping, named submit dispatch, redirects, not-found behavior, streaming, and interactive render-mode markers.
+
+## Where a custom renderer breaks behavior
+
+The prototype's renderer must not be treated as equivalent merely because it produces visually similar HTML. These are the failure points:
+
+1. Without the endpoint's initialized form mapper, `[SupplyParameterFromForm]` receives no posted model.
+2. Without `FormMappingContext`, `EditForm` does not activate its static SSR behavior, including automatic POST method, named event, mapping validator, and antiforgery child.
+3. Without named-event registration and `_handler` selection, multiple forms become ambiguous and the wrong callback may run.
+4. Without `FormMappingValidator`, parse and mapping errors do not join the `EditContext`; `OnValidSubmit` could run on invalid input.
+5. Without endpoint antiforgery metadata and the invoker's validation order, a forged POST may reach component code.
+6. Without dispatch on the rendered instance, the callback runs without the route/form/lifecycle state used to render the page.
+7. Without the second render, validation messages, attempted invalid values, success state, and navigation results do not reach the response.
+8. Without enhanced-navigation response signaling, a form marked `Enhance` is not a valid Blazor enhanced-form endpoint.
+9. Without streaming coordination, the renderer may emit the wrong phases of a POST response or allow headers and cookies to become immutable too early.
+10. Without the normal root component, layouts, head content, cascading authentication state, routing state, error boundaries, render modes, and persistent state may differ.
+
+The framework implementation is internal precisely where these operations are tightly coordinated. Htmxor should call the public invoker rather than subclass or copy `EndpointHtmlRenderer`.
+
+## Response selection and performance
+
+There is an unavoidable tension between fragment efficiency and framework compatibility.
+
+The public endpoint invoker writes a complete component endpoint response. It does not expose a public hook that returns a selected render-tree subtree after submit dispatch. Htmxor has three plausible stages:
+
+1. Start with stock execution plus buffered response selection. This preserves behavior but pays for the complete render and HTML parse.
+2. Let `HtmxFragment` suppress unrelated child content during the framework render when the request identifies one server-declared fragment. This can avoid work beneath those fragment boundaries, but the root, route, lifecycle, and form pipeline still run.
+3. Pursue a faster custom rendering path only if benchmarks justify it and a compatibility suite proves parity with the stock path.
+
+The performance documentation must be honest. Selecting one response region does not imply that the page component was never instantiated or that its lifecycle and data loading did not run. A third-party component inside a skipped `HtmxFragment` may avoid rendering, but components above the selection point still execute.
+
+For form failures, the selected response needs the whole form region. For success, a component may intentionally select a smaller result or an out-of-band update. Selection is representation logic after authorization, antiforgery, binding, and validation, never a shortcut around them.
+
+## Required compatibility suite
+
+The v1 gate should run the same component scenarios through stock Blazor and Htmxor and compare observable behavior.
+
+### Installation invariants
+
+- A static Blazor Web App with Htmxor services registered but no opted-in route or markup has unchanged GET and POST behavior.
+- Existing endpoint metadata, route precedence, status codes, redirects, content type, and render mode remain unchanged.
+- No script or `hx-*` attribute appears unless the app requested it.
+
+### Form parity
+
+- Plain HTML form with `@formname`, `@onsubmit`, `AntiforgeryToken`, and `[SupplyParameterFromForm]`.
+- `EditForm` with every built-in `InputBase<T>` input family.
+- Valid, invalid, unparseable, missing, repeated, nested, collection, and over-limit values.
+- `OnSubmit`, `OnValidSubmit`, and `OnInvalidSubmit` dispatch to the exact named form.
+- Two same-named library forms isolated by different `FormMappingScope` values.
+- Antiforgery success, missing token, invalid token, and cross-origin rejection.
+- URL-encoded and multipart posts.
+- Redirect, not found, cookie/header mutation, and an async submit handler.
+- Validation fragment contains attempted values, messages, `aria-invalid`, and the refreshed token.
+
+### Progressive enhancement
+
+- With htmx unavailable, the boosted example completes as an ordinary full-page POST.
+- With htmx available, the same form reaches the same callback and swaps only the declared region.
+- `data-enhance` and HTMX ownership conflict produces a diagnostic or deterministic exclusion.
+- A nested third-party static SSR form posts without Htmxor-specific code.
+- History, focus, and validation summary behavior remain accessible after a swap.
+
+### Rendering boundaries
+
+- Static-only page and component.
+- Static page containing Interactive Server, WebAssembly, and Auto islands outside the HTMX target.
+- An attempted HTMX replacement of a live interactive root is rejected or diagnosed.
+- Streaming GET and POST behavior is either preserved or explicitly disabled with documented buffering.
+
+## Roadmap consequence
+
+Progressive enhancement should become a protected v1 behavior, not a sample-only convenience:
+
+1. Define the zero-break installation contract and encode it in integration tests before changing the renderer.
+2. Prototype Htmxor endpoints through `IRazorComponentEndpointInvoker` with public root/page metadata.
+3. Prove stock `EditForm`, `Input*`, form mapping, validation, and antiforgery parity.
+4. Add an HTMX-boosted form path whose no-JavaScript fallback is the unchanged Blazor POST.
+5. Define the one-owner rule for Blazor enhanced forms versus HTMX forms.
+6. Restore server-side fragment selection without taking form ownership away from Blazor.
+7. Benchmark the correctness-first path, then optimize selected rendering behind the same compatibility suite.
+
+The practical design rule is simple:
+
+> Htmxor should add another representation of a Blazor component request. It should not create another Blazor form runtime.

--- a/docs/research/dotnet-11-blazor-aspnetcore-opportunities.md
+++ b/docs/research/dotnet-11-blazor-aspnetcore-opportunities.md
@@ -1,0 +1,336 @@
+# .NET 11 Blazor and ASP.NET Core opportunities for Htmxor
+
+Research date: 2026-08-26
+
+Htmxor baseline: [`d8e09e4`](https://github.com/egil/Htmxor/tree/d8e09e4da17ab4c74fbea95d8e995137785c8395)
+
+Upstream source snapshot: ASP.NET Core [`24708c2`](https://github.com/dotnet/aspnetcore/tree/24708c2fffe78d8fa10cc7d0139af1b54d901433), plus the published [.NET 11 Preview 7 ASP.NET Core release notes](https://github.com/dotnet/core/blob/main/release-notes/11.0/preview/preview7/aspnetcore.md). .NET 11 is still a preview and is scheduled to ship in November 2026, so unshipped APIs can still change.
+
+This is a source and API review. Anything described as a hypothesis or spike has not been proved in an executable Htmxor prototype, browser test, or benchmark.
+
+## Executive conclusion
+
+.NET 11 makes the desired Htmxor v1 direction more attractive, but it does not remove its hardest implementation gap.
+
+- Static SSR gains first-class client validation, async validation, TempData, Session-backed parameters, static QuickGrid sorting and paging, safer CSRF integration, and subtree caching. Htmxor inherits these features most reliably by delegating to the stock Razor component endpoint pipeline.
+- The existing public `IRazorComponentEndpointInvoker`, `RootComponentMetadata`, and `ComponentTypeMetadata` form a much more promising execution seam than `RazorComponentResult`. For an existing `@page`, a public final endpoint convention may be able to wrap the already-built stock endpoint and select a direct root only for HTMX requests. An HTMX-only component still needs a generated endpoint carrying the stock metadata. These are the first architecture candidates to run.
+- `RazorComponentResult` renders a component, but its executor does not initialize routed form handling, dispatch named forms, finish Session or TempData persistence, emit initializers, or serialize persisted component state. It is not a lifecycle-equivalent substitute for a mapped Razor component endpoint.
+- The stock endpoint invoker is still POST-only for form dispatch. It has no public PUT, PATCH, or DELETE component-lifecycle action hook. Source generation can remove runtime discovery and ambiguous dispatch, but it cannot manufacture a missing renderer-owned instance invocation seam.
+- The proposed Native AOT component-metadata stack could eventually provide generated route, layout, render-mode, parameter, injection, and custom attribute metadata. It is open, experimental, stacked work with no milestone. Htmxor should be able to consume it later, but v1 should not wait for it or promise it.
+- No merged .NET 11 work provides direct named-fragment invocation or proves a cheaper per-request fragment path. Output selection still needs a Htmxor component convention and benchmarks.
+
+The practical roadmap consequence is: keep the v1 product contract, replace the prototype's private framework integration, and put a short set of executable .NET 10/.NET 11 feasibility gates ahead of implementation-ready endpoint, action, validation, caching, and performance issues.
+
+## Status model
+
+This report uses four classifications deliberately:
+
+| Classification | Meaning |
+| --- | --- |
+| **Published Preview 7** | Merged and included in a published .NET 11 preview at the research date |
+| **Merged main** | Present in the pinned ASP.NET Core main snapshot, but not necessarily documented as a published preview feature |
+| **Existing API** | Already shipped before .NET 11; useful, but not a new .NET 11 opportunity |
+| **Open proposal or inference** | Not available as a stable dependency; requires watching or executable proof |
+
+## The most important existing execution seam
+
+### `IRazorComponentEndpointInvoker` plus endpoint metadata
+
+`IRazorComponentEndpointInvoker` is public. Its contract says that a Razor component endpoint supplies the root component through `RootComponentMetadata` and the page through `ComponentTypeMetadata`. Both metadata classes and their constructors are public. These are existing APIs, not .NET 11 additions: [interface](https://github.com/dotnet/aspnetcore/blob/24708c2fffe78d8fa10cc7d0139af1b54d901433/src/Components/Endpoints/src/IRazorComponentEndpointInvoker.cs), [root metadata](https://github.com/dotnet/aspnetcore/blob/24708c2fffe78d8fa10cc7d0139af1b54d901433/src/Components/Endpoints/src/Builder/RootComponentMetadata.cs), and [page metadata](https://github.com/dotnet/aspnetcore/blob/24708c2fffe78d8fa10cc7d0139af1b54d901433/src/Components/Endpoints/src/Builder/ComponentTypeMetadata.cs).
+
+The registered implementation remains internal, but Htmxor does not need its concrete type if it can create an endpoint with the stock metadata and call the public interface. On .NET 11 main, that implementation owns substantially more than HTML rendering:
+
+- routing-state and standard component-service initialization;
+- named POST form dispatch on the renderer-created page instance;
+- navigation, not-found, status-code-page, enhanced-navigation, and streaming behavior;
+- antiforgery/CSRF verdict consumption;
+- Session and TempData persistence after rendering;
+- JavaScript initializer emission and persisted component-state serialization.
+
+Those responsibilities are visible together in the current [stock endpoint invoker](https://github.com/dotnet/aspnetcore/blob/24708c2fffe78d8fa10cc7d0139af1b54d901433/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs). Reusing it would let Htmxor progressively enhance a stock static-SSR Blazor application without replacing its renderer, routing-state provider, navigation manager, or endpoint invoker.
+
+This is an opportunity, not yet a conclusion. A generated endpoint must reproduce all metadata and structural conventions the invoker expects. It must also coexist with the normal `MapRazorComponents` candidate at the same route. The executable gate is specified below.
+
+### Why `RazorComponentResult` is not equivalent
+
+The public result is useful for rendering an arbitrary component, but the current [result executor](https://github.com/dotnet/aspnetcore/blob/24708c2fffe78d8fa10cc7d0139af1b54d901433/src/Components/Endpoints/src/Results/RazorComponentResultExecutor.cs) only initializes streaming framing, prerenders a host component, writes streaming updates, and flushes the response. It does not perform the endpoint-invoker responsibilities listed above.
+
+This creates a concrete .NET 11 parity gap. `[SupplyParameterFromSession]` writes values back before the response is sent, and the stock invoker explicitly calls Session and TempData persistence after all rendering completes. The result executor does neither. The Preview 5 [Session documentation](https://github.com/dotnet/core/blob/main/release-notes/11.0/preview/preview5/aspnetcore.md#supplyparameterfromsession-for-blazor) and current sources therefore make `RazorComponentResult<TWrapper>` an unsafe sole v1 seam until an integration test proves otherwise or ASP.NET Core closes the gap.
+
+### Other public-but-framework-oriented seams
+
+`IComponentPrerenderer` is also public and existing, but its API takes a render mode and parameters, not route/form handler state. It has no public static-render-mode value, form-dispatch argument, or streaming toggle. Its public shape does not replace the mapped endpoint lifecycle. Treat it as framework plumbing rather than a v1 extension contract. See [`IComponentPrerenderer`](https://github.com/dotnet/aspnetcore/blob/24708c2fffe78d8fa10cc7d0139af1b54d901433/src/Components/Endpoints/src/DependencyInjection/IComponentPrerenderer.cs).
+
+The request to expose the internal `EndpointHtmlRenderer` specifically for integrating frameworks was closed as not planned in [aspnetcore#51148](https://github.com/dotnet/aspnetcore/issues/51148). Htmxor should not wait for that renderer to become public.
+
+## Endpoint discovery and convention APIs
+
+### Existing `@page` endpoints are the richest starting point
+
+The public `RazorComponentsEndpointConventionBuilder.Add` and `Finally` methods can inspect and modify the endpoints produced by `MapRazorComponents`. Those endpoints already carry the stock request delegate, `ComponentTypeMetadata`, `RootComponentMetadata`, page attributes, antiforgery requirements, configured render modes, and every convention applied directly to the Razor-components builder. See the current [endpoint factory](https://github.com/dotnet/aspnetcore/blob/24708c2fffe78d8fa10cc7d0139af1b54d901433/src/Components/Endpoints/src/Builder/RazorComponentEndpointFactory.cs) and [convention builder](https://github.com/dotnet/aspnetcore/blob/24708c2fffe78d8fa10cc7d0139af1b54d901433/src/Components/Endpoints/src/Builder/RazorComponentsEndpointConventionBuilder.cs).
+
+This creates a stronger **inferred spike** for normal/dual `@page` components than copying their routes into a second data source:
+
+1. identify the stock page endpoint through public component metadata in a final convention;
+2. leave its normal request delegate and endpoint untouched for non-HTMX requests;
+3. for a direct request, temporarily expose a cached cloned endpoint whose metadata selects the Htmxor direct root, then call the original stock delegate;
+4. restore the original endpoint feature after invocation.
+
+The involved route endpoint and endpoint-feature types are public, but this exact composition is not a documented Blazor extension pattern. The spike must prove metadata precedence, middleware policy timing, status-page re-execution, concurrency safety, and render-mode behavior. If it works, the normal path remains byte-for-byte stock and all builder-level conventions remain attached to the one routed endpoint.
+
+An HTMX-only component has no stock page endpoint to wrap. That path still needs a source-generated endpoint on the exact route builder, public root/page metadata, and the stock invoker. It must address the builder-only convention gap described below.
+
+### A useful helper, but not a component catalog
+
+`ComponentEndpointConventionBuilderHelper` is public under an `.Infrastructure` namespace and explicitly says it is not recommended outside the Blazor framework. The helper type exists in .NET 8, while `GetEndpointRouteBuilder` appears by .NET 9 and remains in current main. The method can replace Htmxor's reflection over the builder's private `ApplicationBuilder` property, but it exposes only the route builder. It exposes neither discovered component types nor the builder's accumulated conventions. Compare the [.NET 8 helper](https://github.com/dotnet/aspnetcore/blob/v8.0.29/src/Components/Endpoints/src/Builder/ComponentEndpointConventionBuilderHelper.cs), [.NET 9 helper](https://github.com/dotnet/aspnetcore/blob/v9.0.0/src/Components/Endpoints/src/Builder/ComponentEndpointConventionBuilderHelper.cs), and [current helper](https://github.com/dotnet/aspnetcore/blob/24708c2fffe78d8fa10cc7d0139af1b54d901433/src/Components/Endpoints/src/Builder/ComponentEndpointConventionBuilderHelper.cs).
+
+The helper can remove one private-reflection dependency immediately. It cannot solve route discovery, and its own documentation makes it a compatibility aid rather than a durable architectural center.
+
+### Builder-only conventions still do not flow to separate endpoints
+
+`RazorComponentsEndpointConventionBuilder.Add` stores conventions in private lists. A separately generated Htmxor endpoint on the same `IEndpointRouteBuilder` does not automatically inherit a `.RequireAuthorization()`, `.RequireRateLimiting()`, host restriction, request-size limit, or other convention applied only to the Razor components builder. The current [builder source](https://github.com/dotnet/aspnetcore/blob/24708c2fffe78d8fa10cc7d0139af1b54d901433/src/Components/Endpoints/src/Builder/RazorComponentsEndpointConventionBuilder.cs) has no public convention enumeration or forwarding surface.
+
+The v1 design should therefore keep both endpoint families under the same route group for shared structural policy and validate security-relevant effective metadata at startup. .NET 11 Preview 7 adds `AuthorizationPolicy.CombineAsync(IAuthorizationPolicyProvider, IEnumerable<object>)`, which gives Htmxor a supported way to compare effective authorization requirements expressed as `IAuthorizeData`, `AuthorizationPolicy`, and `IAuthorizationRequirementData`. It does not copy or compare the other endpoint metadata classes. See the [Preview 7 authorization notes](https://github.com/dotnet/core/blob/main/release-notes/11.0/preview/preview7/aspnetcore.md#consistent-authorization-metadata-across-the-stack).
+
+## Published .NET 11 changes Htmxor should inherit
+
+### Static SSR forms and validation
+
+.NET 11 Preview 5 adds browser-side validation for static SSR `EditForm` components containing `DataAnnotationsValidator`, including enhanced and non-enhanced forms. It also adds async form validation and localization; Preview 7 stabilizes the API and makes `EditContext.ValidateAsync` the preferred path. See [Preview 5 client validation](https://github.com/dotnet/core/blob/main/release-notes/11.0/preview/preview5/aspnetcore.md#blazor-ssr-supports-client-side-validation) and the [Preview 7 API refinements](https://github.com/dotnet/core/blob/main/release-notes/11.0/preview/preview7/aspnetcore.md#breaking-changes).
+
+This directly supports Htmxor's progressive-enhancement contract: built-in `EditForm`, `Input*`, `ValidationMessage`, and third-party components designed for stock static SSR should continue to work when Htmxor is added. That contract is realistic only when direct Htmxor requests retain the stock form mapper and renderer lifecycle.
+
+There is one HTMX-specific edge that the release notes do not cover. Current browser source initializes validation at initial DOM load and on Blazor's `enhancedload`. `createBlazorValidation()` returns without defining its custom element when the document contains no `<blazor-client-validation-data>` carrier. Once initialized, the carrier's `connectedCallback` and `disconnectedCallback` register and remove rules, so ordinary later DOM insertion should work. HTMX swaps do not emit Blazor `enhancedload`. Therefore, if the first validatable form arrives through HTMX after a form-free initial page, the validation service may never initialize. This is a source-based hypothesis requiring a browser test, not a confirmed defect. See [`Boot.Web.ts`](https://github.com/dotnet/aspnetcore/blob/24708c2fffe78d8fa10cc7d0139af1b54d901433/src/Components/Web.JS/src/Boot.Web.ts) and [`BlazorAdapter.ts`](https://github.com/dotnet/aspnetcore/blob/24708c2fffe78d8fa10cc7d0139af1b54d901433/src/Components/Web.JS/src/Validation/Adapters/BlazorAdapter.ts).
+
+### TempData and Session
+
+Preview 2 adds TempData to Blazor SSR. Preview 4 adds `[SupplyParameterFromTempData]`, and Preview 5 adds `[SupplyParameterFromSession]`. They support status messages, redirect-after-post, carts, and multi-step forms without app-specific glue. See [TempData support](https://github.com/dotnet/core/blob/main/release-notes/11.0/preview/preview2/aspnetcore.md#tempdata-support-for-blazor), [`SupplyParameterFromTempData`](https://github.com/dotnet/core/blob/main/release-notes/11.0/preview/preview4/aspnetcore.md#supplyparameterfromtempdata-for-blazor), and [`SupplyParameterFromSession`](https://github.com/dotnet/core/blob/main/release-notes/11.0/preview/preview5/aspnetcore.md#supplyparameterfromsession-for-blazor).
+
+These features are useful beyond their direct functionality: they are lifecycle canaries. An Htmxor direct request that renders plausible markup but loses write-back or redirect behavior is not compatible with stock static SSR. The stock-invoker spike must cover both.
+
+### A supported custom cascading-parameter supplier
+
+.NET 11 main adds public `TryAddCascadingValueSupplier<TAttribute>` and `CascadingParameterSubscription`. Htmxor can use this supported seam for an optional attribute-shaped request value such as `[SupplyParameterFromHtmx]`, rather than replacing the renderer or wrapping every page only to supply request state. The existing `AddCascadingValue` remains sufficient for a normal typed `HtmxContext` cascade. See the current [registration API](https://github.com/dotnet/aspnetcore/blob/24708c2fffe78d8fa10cc7d0139af1b54d901433/src/Components/Components/src/CascadingValueServiceCollectionExtensions.cs) and [subscription contract](https://github.com/dotnet/aspnetcore/blob/24708c2fffe78d8fa10cc7d0139af1b54d901433/src/Components/Components/src/CascadingParameterSubscription.cs).
+
+This is a useful public extension point, not a reason to add a new public Htmxor attribute unless real developer code benefits from it.
+
+The supplier callback also receives the current `ComponentState`, whose public `Component` property exposes the actual renderer-created instance. In principle, an Htmxor-specific cascading attribute could use this callback to register an opted-in component instance in a request-scoped action registry. That is the most promising newly identified instance-access experiment in .NET 11.
+
+It is not yet an action-dispatch solution. `ComponentState` is documented as an internal renderer implementation detail, the supplier callback constructs a synchronous subscription rather than an awaited pre-response action, and it exposes no supported operation that pauses the stock invoker, invokes an async custom verb, rerenders, and lets the stock invoker serialize the result. See [`ComponentState`](https://github.com/dotnet/aspnetcore/blob/24708c2fffe78d8fa10cc7d0139af1b54d901433/src/Components/Components/src/Rendering/ComponentState.cs). Include this route in the unsafe-action spike, but do not make a pubternal implementation-detail type part of the v1 public contract.
+
+Preview 1's new `IComponentPropertyActivator` is narrower still: it customizes how `[Inject]` properties are populated. It does not expose component routing, construction, lifecycle, or event dispatch. See the [Preview 1 API description](https://github.com/dotnet/core/blob/main/release-notes/11.0/preview/preview1/aspnetcore.md#icomponentpropertyactivator).
+
+### QuickGrid as a progressive-enhancement compatibility test
+
+Preview 5 makes QuickGrid sorting and pagination work in static SSR by rendering URL-driven enhanced controls instead of requiring `@onclick`. See [QuickGrid without interactivity](https://github.com/dotnet/core/blob/main/release-notes/11.0/preview/preview5/aspnetcore.md#quickgrid-works-without-interactivity).
+
+QuickGrid is a strong first-party compatibility canary for Htmxor. Its tests should cover:
+
+- full static SSR with no Htmxor behavior;
+- the same component after adding Htmxor;
+- HTMX-owned updates where requested;
+- ordinary query navigation and history restoration;
+- no double interception between HTMX, Blazor enhanced navigation, and enhanced forms.
+
+Passing this case would provide better evidence for third-party static-SSR compatibility than Htmxor-only sample components.
+
+### CSRF and antiforgery integration
+
+.NET 11 Preview 6 introduces Fetch Metadata and Origin-based CSRF protection. The final Preview 7 scope validates only endpoints whose metadata has `IAntiforgeryMetadata.RequiresValidation`; Blazor SSR form endpoints attach the required metadata automatically. The middleware records a verdict in `IAntiforgeryValidationFeature`, and the stock component invoker consumes it when it processes a form. See the [Preview 7 correction](https://github.com/dotnet/core/blob/main/release-notes/11.0/preview/preview7/aspnetcore.md#breaking-changes), the merged [consumer-verdict change](https://github.com/dotnet/aspnetcore/pull/67082), and the merged [metadata scoping change](https://github.com/dotnet/aspnetcore/pull/67460).
+
+Htmxor should borrow the framework's ordering and verdict instead of copying cryptographic form-validation logic:
+
+1. Every generated unsafe endpoint carries the correct `IAntiforgeryMetadata` unless explicitly and validly disabled.
+2. Middleware runs before binding or application callbacks.
+3. A failed verdict stops the request with a generic non-swappable response.
+4. Token-based antiforgery remains supported. Fetch Metadata and Origin checks intentionally tolerate clients that do not send browser headers, so the new CSRF middleware is not a universal replacement for tokens.
+
+The stock component invoker still only enters its form path for `POST`. A generated PUT, PATCH, or DELETE action therefore needs its own consumer that enforces the same middleware verdict before form reading, binding, or callback invocation. This is a remaining Htmxor responsibility.
+
+The prototype does not currently meet that requirement. Its unsafe-method condition includes POST, PUT, and PATCH in the validation branch but omits DELETE, and operator precedence applies the exception-handler guard only to PATCH. See the current [custom invoker](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Endpoints/HtmxorComponentEndpointInvoker.cs#L155-L166). The unsafe-action gate must retain DELETE as a negative regression even if the prototype path is later removed.
+
+### `CacheView` and fragment safety
+
+Preview 7 adds `CacheView`, which caches the rendered HTML of a static-SSR subtree. A cache hit avoids instantiating and rendering the cached child components. It supports route, query, header, cookie, user, culture, and custom vary dimensions. It skips non-GET requests and streaming SSR. See the [Preview 7 feature notes](https://github.com/dotnet/core/blob/main/release-notes/11.0/preview/preview7/aspnetcore.md#cache-blazor-ssr-output-with-cacheview) and current [`CacheView`](https://github.com/dotnet/aspnetcore/blob/24708c2fffe78d8fa10cc7d0139af1b54d901433/src/Components/Endpoints/src/CacheView/CacheView.cs).
+
+The related `[CacheBehavior]` and `[CacheCondition]` APIs create a safety model for request-dependent components. `Rerender` creates a live per-request hole; `Throw` rejects an unsafe placement unless declared vary dimensions make it safe. See [`CacheBehaviorAttribute`](https://github.com/dotnet/aspnetcore/blob/24708c2fffe78d8fa10cc7d0139af1b54d901433/src/Components/Components/src/CacheBehaviorAttribute.cs) and [`CacheConditionAttribute`](https://github.com/dotnet/aspnetcore/blob/24708c2fffe78d8fa10cc7d0139af1b54d901433/src/Components/Components/src/CacheConditionAttribute.cs).
+
+`HtmxFragment` cannot be a `Rerender` live hole. A live cached component's parameters are captured once and replayed, and the CacheView writer explicitly rejects `RenderFragment` and `RenderFragment<T>` parameters because their content would be frozen to the first render. `HtmxFragment.ChildContent` is a `RenderFragment`, so `[CacheBehavior(CacheBehavior.Rerender)]` would fail. See the current [`CacheViewTextWriter`](https://github.com/dotnet/aspnetcore/blob/24708c2fffe78d8fa10cc7d0139af1b54d901433/src/Components/Endpoints/src/Rendering/CacheViewTextWriter.cs).
+
+The fail-closed v1 annotation should instead be `[CacheBehavior(CacheBehavior.Throw)]`: an application cannot accidentally place the request-dependent selection boundary inside an outer `CacheView`. A developer may place a `CacheView` *inside* the selected `HtmxFragment` to cache intentionally stable content. That arrangement reduces work in a selected GET subtree without caching the request-dependent fragment boundary.
+
+`CacheView` does not replace HTTP output caching. Htmxor must still emit the correct `Vary` response fields, including request headers that choose full-page versus fragment representations, and must keep unsafe or personalized responses private or uncached. `VaryByHeader="HX-Request,HX-Target"` affects the component subtree key; it does not emit HTTP `Vary` on Htmxor's behalf.
+
+Preview 1's public `IOutputCachePolicyProvider` can support application- or tenant-specific HTTP output-cache policy selection, but it does not infer Htmxor's representation headers. Htmxor still owns safe endpoint metadata and variation. See the [Preview 1 output-cache API](https://github.com/dotnet/core/blob/main/release-notes/11.0/preview/preview1/aspnetcore.md#ioutputcachepolicyprovider).
+
+### Child content across render-mode boundaries
+
+Preview 5 allows non-generic `RenderFragment` child content to cross SSR-to-interactive render-mode boundaries. The framework renders and captures the fragment on the server, then projects the captured tree into the interactive component. See [the Preview 5 feature](https://github.com/dotnet/core/blob/main/release-notes/11.0/preview/preview5/aspnetcore.md#pass-child-content-across-render-mode-boundaries) and merged [aspnetcore#66528](https://github.com/dotnet/aspnetcore/pull/66528).
+
+This helps markup-only composition in pages that also use Server, WebAssembly, or Auto render modes. It does not serialize Htmxor action callbacks, generic `RenderFragment<T>`, element references, or event ownership, and it does not turn an HTMX fragment into an interactive Blazor component.
+
+The stable model remains two paths:
+
+- a normal page request stays on the stock Blazor endpoint and may use Static, Interactive Server, Interactive WebAssembly, or Interactive Auto;
+- a direct Htmxor request returns static SSR for an HTMX-owned region.
+
+Htmxor can coexist with Auto mode, but neither runtime should own the same live DOM region or the same navigation. .NET 11 does not add a feature that dynamically converts an HTMX-owned fragment into a running Auto component.
+
+There is a narrower render-mode uncertainty. If Auto is applied globally to the normal `<Routes>` root, a separate Htmxor direct root can plausibly remain static. A page component that carries its own definition-level `@rendermode InteractiveAuto` may still emit an interactive boundary when the stock renderer invokes it, and no public per-invocation "ignore this render mode" switch was identified. The stock-invoker gate must test these two cases separately.
+
+### Navigation and browser configuration
+
+Preview 1 adds relative navigation support and other `NavigationManager` helpers. Preview 6 adds server-side `WithBrowserOptions`, including Blazor DOM-preservation and Server/WebAssembly/Auto options. See [relative navigation](https://github.com/dotnet/core/blob/main/release-notes/11.0/preview/preview1/aspnetcore.md#relative-navigation-with-relativetocurrenturi) and [browser options](https://github.com/dotnet/core/blob/main/release-notes/11.0/preview/preview6/aspnetcore.md#configure-blazor-client-behavior-from-the-server).
+
+These features reinforce the recommendation to retain stock `NavigationManager` behavior. Browser options may help an application configure the Blazor side of DOM preservation, but they do not coordinate HTMX swaps or settle navigation ownership. That remains an Htmxor browser-conformance concern.
+
+## What .NET 11 does not solve
+
+### PUT, PATCH, and DELETE instance actions
+
+The current stock invoker calculates its form path with `HttpMethods.IsPost`. PUT, PATCH, and DELETE requests do not initialize the form handler or call `DispatchSubmitEventAsync`; they follow the non-POST rendering path. This is explicit in the current [invoker source](https://github.com/dotnet/aspnetcore/blob/24708c2fffe78d8fa10cc7d0139af1b54d901433/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs).
+
+There is no merged public API that says, in effect, "render this routed component, locate this generated component-local handler on the renderer-owned instance, invoke it, then continue the stock lifecycle." That gap is why replacing instance callbacks with static methods appeared attractive in the earlier interface sketch. Static methods avoid renderer-instance access, but they also recreate endpoint handlers inside a `.razor` file and abandon the component lifecycle. That trade is inconsistent with the revised convention-over-configuration direction.
+
+The v1 action spike should retain lifecycle-preserving instance dispatch as the design goal, with build-time route/verb/handler validation and no runtime render-tree scanning. If the framework exposes no supported way to dispatch such actions, Htmxor should document the boundary and consider an upstream API proposal before freezing a static alternative.
+
+### Direct named-fragment invocation
+
+No merged .NET 11 API maps an endpoint directly to a named region inside a routed component. Htmxor can still render the owning component under a selection cascade so unselected `HtmxFragment` child content is not invoked, but routing, component construction, parameter binding, and owning lifecycle work still run. This is output pruning, not complete execution pruning.
+
+`CacheView` can avoid repeated stable subtree work. It does not provide request-time named selection, and it is inactive on unsafe verbs and streaming renders.
+
+### A new public endpoint-renderer extension point
+
+No published .NET 11 feature exposes `EndpointHtmlRenderer`, its form dispatcher, or a new public route-to-component execution builder. The open async-rendering work in [aspnetcore#65206](https://github.com/dotnet/aspnetcore/pull/65206) changes framework internals and remains a blocked draft with no milestone. It is not a v1 dependency.
+
+### A measured per-request performance improvement
+
+.NET 11 runtime libraries use [runtime-async](https://github.com/dotnet/core/blob/main/release-notes/11.0/preview/preview4/runtime.md#runtime-libraries-are-now-compiled-with-runtime-async), which may reduce async state-machine overhead in framework code, and `CacheView` can eliminate repeated GET subtree rendering. Neither establishes Htmxor's per-request performance. The Blazor SSR performance investigation [aspnetcore#65193](https://github.com/dotnet/aspnetcore/issues/65193) is open under .NET 12 Planning.
+
+Htmxor still needs benchmarks for normal pages, direct whole-component responses, one and multiple selected fragments, valid and invalid forms, unsafe actions, streaming, and errors. Measure latency, allocations, bytes, component instantiation, and lifecycle work on .NET 10 and the current .NET 11 preview before setting a v1 contract.
+
+## Open proposals worth watching, not building v1 around
+
+### Native AOT component metadata stack
+
+Four closely related Blazor PRs are open and unmilestoned at the research date:
+
+| PR | Proposed capability | Current status | Htmxor relevance |
+| --- | --- | --- | --- |
+| [#68295](https://github.com/dotnet/aspnetcore/pull/68295) | Metadata-first serialization and application metadata registration | Open; based on `main` | Foundation only |
+| [#68299](https://github.com/dotnet/aspnetcore/pull/68299) | Generate application component descriptors | Open; stacked and blocked | High if it lands |
+| [#68300](https://github.com/dotnet/aspnetcore/pull/68300) | Generate framework component descriptors | Open; stacked and blocked | Completes framework coverage |
+| [#68302](https://github.com/dotnet/aspnetcore/pull/68302) | Strict Native AOT proof | Open; stacked and blocked | Proof, not an execution API |
+
+The proposed public `ComponentDescriptor` is experimental and includes type, activation, parameters, injectables, and an open metadata list. The generator proposal says it reconstructs route, layout, render-mode, endpoint, and custom component attributes and moves discovery toward generated metadata first, reflection last. If it lands, Htmxor could consume compiler-generated `RouteAttribute` and Htmxor component attributes instead of maintaining a parallel reflection catalog.
+
+It would not automatically discover or dispatch arbitrary inline `@onpost`, `@ondelete`, or lambda expressions. Htmxor must encode action identity as analyzable metadata and still needs a runtime instance-dispatch seam. The final proof also explicitly excludes HTTP form mapping as not Native-AOT-supported in that matrix. Generated component metadata would therefore not make Htmxor forms or unsafe actions Native AOT compatible by itself.
+
+Keep Htmxor discovery behind an adapter:
+
+1. v1 owns a generated catalog from stable inputs;
+2. a future adapter may consume framework `ComponentDescriptor.Metadata` when it becomes a shipped contract;
+3. reflection remains a compatibility fallback only where the target framework requires it.
+
+### Source generation over Razor files
+
+The Razor SDK already passes `.razor` files to the compiler as `AdditionalFiles`, so an Htmxor incremental generator can read their raw text. See the SDK's [`Microsoft.NET.Sdk.Razor.SourceGenerators.targets`](https://github.com/dotnet/sdk/blob/main/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.SourceGenerators.targets). Roslyn generators run unordered and do not see files created by other generators, so a separate Htmxor generator cannot assume it can inspect Razor's generated C# semantic model in the same pass. See the [Roslyn source-generator design](https://github.com/dotnet/roslyn/blob/main/docs/features/source-generators.md#high-level-design-goals).
+
+The Razor team froze the old compiler packages while it works toward a future supported analyzer/compiler API; no new stable third-party Razor semantic extension point was identified for .NET 11. See the official [Razor compiler API announcement](https://github.com/dotnet/razor/issues/8399).
+
+Consequently, source generation can clearly own route/component attribute discovery and deterministic endpoint catalogs. Exact semantic discovery of conditional attributes, lambdas, reused child components, and inline callback expressions remains a spike. An analyzer may treat literal `hx-get`, `hx-post`, and related attributes as evidence and diagnostics, but they should not silently grant server verbs when the handler binding cannot be proved.
+
+### Other open work
+
+- [#67617](https://github.com/dotnet/aspnetcore/pull/67617), a `RazorComponentResult` parameter analyzer, is open and dirty. It improves type diagnostics if merged but does not add lifecycle parity.
+- [#63821](https://github.com/dotnet/aspnetcore/pull/63821), framework endpoint marker/configuration APIs, is an open dirty draft. It targets Blazor infrastructure endpoints, not component-local Htmxor routes or handlers.
+- Nested routing [#11212](https://github.com/dotnet/aspnetcore/issues/11212) and custom route constraints [#28938](https://github.com/dotnet/aspnetcore/issues/28938) are open under .NET 12 Planning. Htmxor should not assume .NET 11 will add either capability.
+
+## Direct comparison with the prototype
+
+| Prototype technique | Better current direction | Remaining gap |
+| --- | --- | --- |
+| Reflect private builder/application/component collection to discover pages | Wrap existing `@page` endpoints through public final conventions; use a generated catalog and `GetEndpointRouteBuilder` for HTMX-only components | No public stock component catalog, and the conditional endpoint-metadata swap is still an inferred spike |
+| Replace `IRazorComponentEndpointInvoker` | Generate endpoints that delegate to stock `IRazorComponentEndpointInvoker` | Must prove full metadata and route-candidate parity |
+| Copy/fork `EndpointHtmlRenderer` behavior | Keep stock invoker and renderer | No public lifecycle action dispatch for PUT/PATCH/DELETE |
+| Reflect private form and antiforgery renderer state | Consume endpoint metadata and `IAntiforgeryValidationFeature`; use stock POST form pipeline | Htmxor unsafe-verb consumer still required |
+| Replace `NavigationManager` | Preserve stock navigation and redirect handling | Translate direct HTMX redirects/history without double ownership |
+| Render to discover callbacks and scan the render tree | Generate deterministic handler/verb catalog and diagnostics | Binding an instance handler to the renderer-owned component is unproved |
+| Cascading-value replacement hacks | Existing `AddCascadingValue`; optional .NET 11 `TryAddCascadingValueSupplier<TAttribute>` | Decide whether an attribute-shaped public API earns its complexity |
+| `HtmxFragment` with request predicate | Generated selection plan plus request cascade; fail-closed `CacheBehavior.Throw`; allow `CacheView` inside the selected fragment | Cache safety and lifecycle/performance measurements |
+
+The prototype dependencies are visible in its [service replacements](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/DependencyInjection/HtmxorApplicationBuilderExtensions.cs), [private endpoint discovery](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Builder/HtmxorComponentEndpointRouteBuilderExtensions.cs), [custom invoker](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Endpoints/HtmxorComponentEndpointInvoker.cs), and [renderer fork](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Rendering/HtmxorRenderer.cs).
+
+## Required executable gates before v1 breakdown
+
+### Gate 1: stock-invoker dual and HTMX-only endpoints
+
+Create two bounded candidates that delegate to the registered `IRazorComponentEndpointInvoker`:
+
+1. for an existing `@page`, use a public final endpoint convention and conditionally invoke the original stock delegate with the direct-root metadata while leaving normal requests untouched;
+2. for an HTMX-only component, create the smallest generated endpoint carrying `RootComponentMetadata`, `ComponentTypeMetadata`, route values, HTTP method metadata, authorization, antiforgery, render-mode metadata, and the Htmxor selection cascade on the exact route group.
+
+Prove on .NET 10 and .NET 11 Preview 7:
+
+- full normal GET remains stock;
+- direct GET renders the intended page/component representation;
+- route, query, form, and cascading parameters match stock behavior;
+- valid and invalid named `EditForm` POSTs run the renderer-owned component handler;
+- authorization, antiforgery, request-size, rate-limit, and host policy are no weaker;
+- navigation, redirects, not-found, status-code pages, streaming, and exception handling match stock behavior;
+- TempData and Session read/write survive the request;
+- interactive normal routes still support Server, WebAssembly, and Auto while direct responses remain static SSR;
+- builder-only convention mismatches are detected rather than silently ignored.
+- root-level Auto and definition-level `@rendermode InteractiveAuto` are tested as distinct cases.
+
+Pass condition: the dual route preserves the original stock normal delegate and its effective metadata, the HTMX-only route uses no app-authored endpoint handler, and neither path uses private reflection, service replacement, or a renderer copy. Failure should identify the exact missing public seam.
+
+### Gate 2: lifecycle-preserving unsafe actions
+
+First prove the negative contract: PUT, PATCH, and DELETE do not dispatch through the stock named-form path. Then prototype generated component-local handler metadata and attempt to invoke the renderer-owned component instance without scanning the render tree or creating static Minimal-API-style methods.
+
+Cover exact method matching, inherited/component-local handlers, ambiguous handlers, authorization composition, antiforgery verdicts, binding failures, validation, navigation, and declared fragment results.
+
+Pass condition: normal Blazor lifecycle is retained and the handler/verb set is known before serving requests. If this cannot be achieved on a supported API, record the limitation and draft an upstream API proposal before freezing the v1 action syntax.
+
+### Gate 3: HTMX-inserted static validation
+
+Use a real browser and the shipped Preview 7 Blazor script:
+
+1. load a page with no validatable form, then insert the first static-SSR `EditForm` through HTMX;
+2. load a page with an initial form, then replace and remove form carriers through HTMX;
+3. verify built-in and custom validation, cleanup, `novalidate`, invalid-submit blocking, and server fallback;
+4. verify no dependence on a particular htmx version beyond the replaceable adapter hook.
+
+Pass condition: stock validation works after each swap. If the first-form hypothesis reproduces, implement the smallest public bridge or pursue an upstream initialization hook.
+
+### Gate 4: fragment cache isolation
+
+Test that `[CacheBehavior(CacheBehavior.Throw)]` prevents an `HtmxFragment` from being captured by an outer `CacheView`, and test a stable `CacheView` inside a selected fragment. Vary request mode, target, route, query, identity, and culture across concurrent requests.
+
+Pass condition: no full/fragment, target, identity, antiforgery, or culture data crosses requests; lifecycle behavior is documented; HTTP `Vary` remains correct independently of `CacheView`.
+
+### Gate 5: compatibility and performance matrix
+
+Run built-in `EditForm`/`Input*`/validation, QuickGrid, TempData, Session, streaming, and one representative third-party static-SSR component before and after adding Htmxor. Add Interactive Auto normal pages and an HTMX-owned static region to the browser suite.
+
+Benchmark normal, direct whole-component, one-fragment, multi/OOB, form, unsafe action, validation-error, and unhandled-error paths. Compare stock .NET 10, stock .NET 11, the prototype, and the public-seam spike.
+
+Pass condition: compatibility deltas and per-request costs are measured. Do not set a v1 latency or allocation promise from framework release notes alone.
+
+## Roadmap recommendation
+
+Do not wait for .NET 11 GA or the open Native AOT stack before beginning v1. Use .NET 10 LTS as the stable implementation baseline and keep a .NET 11 preview/RC compatibility lane so the new static-SSR features shape the design before it freezes.
+
+Add one high-level roadmap workstream named **ASP.NET Core execution and compatibility**, with the five gates above. Only break route generation, unsafe actions, validation interop, cache integration, and performance into agent-ready implementation issues after their respective gate passes.
+
+Maintain a separate upstream watch list for:
+
+- the Native AOT component-metadata stack;
+- any public Razor semantic analyzer API;
+- a public component action/form dispatch seam;
+- `RazorComponentResult` endpoint-lifecycle parity;
+- Blazor SSR performance work.
+
+The v1 product contract should remain unchanged by this research: `.razor` route ownership, normal-only/HTMX-only/both reachability, convention-over-configuration defaults, instance lifecycle, standard Blazor static-SSR compatibility, inline single/multiple fragment selection, application-owned htmx assets, and explicit security/cache invariants. The part to discard is the prototype's private framework integration, not its developer-facing reason for existing.

--- a/docs/research/htmx-backend-framework-comparison.md
+++ b/docs/research/htmx-backend-framework-comparison.md
@@ -1,0 +1,465 @@
+# HTMX backend framework comparison
+
+Research date: 2026-08-26 UTC
+
+This report compares the developer-facing interfaces of representative backend frameworks and libraries that explicitly support HTMX. It uses project documentation, source repositories, release pages, and package registries maintained by the projects or their publishers. Version numbers are a dated snapshot, not a promise about future compatibility.
+
+The comparison focuses on the question that matters for Htmxor: can a developer keep routing, request handling, full-page rendering, and fragment rendering local to a Razor component without writing a parallel controller, Minimal API endpoint, or handler?
+
+## Executive finding
+
+### Observed facts
+
+Most surveyed alternatives leave the HTTP route in application-authored controller, handler, URL configuration, or endpoint code:
+
+- Htmx.Net and axum-htmx add typed request and response protocol helpers to routes the application already owns.
+- django-htmx and htmx-spring-boot make full-versus-fragment selection convenient, but the choice remains in a view or controller.
+- FastHX decorates an existing FastAPI route.
+- RazorX and Rizzy render Razor components through explicit Minimal API or MVC routes.
+- templ can keep named fragments in one component file, but a Go handler owns the route and chooses the fragment.
+
+holm is the important exception. It discovers page and layout modules from the Python package tree, creates routes without manual FastAPI registration, and can colocate generated POST submit handlers and decorated HTML actions with a page. Actions return unwrapped components suited to HTMX fragment requests. A page can also inspect `HX-Request` and return `without_layout(content)` to serve a full page and an HTMX fragment from the same URL. [holm file-system routing](https://volfpeter.github.io/holm/file-system-based-routing/), [application components](https://volfpeter.github.io/holm/application-components/), and [`without_layout`](https://volfpeter.github.io/holm/utilities/).
+
+Htmxor's current route discovery still has a distinct shape. A Razor `@page` route is also registered as a direct Htmxor route, while `[HtmxRoute]` can give a component a direct route without making it a normal Blazor page. Inline `HtmxFragment` components select output within the same routable component. holm's same-URL alternative is an application-authored header branch over a locally constructed `content` value; it does not provide declarative normal-only, HTMX-only, and dual modes or Htmxor-style named/predicate inline selection and multiple-fragment composition. Htmxor's behaviors are visible in the [component route catalog](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Builder/ComponentInfo.cs), [route attribute](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/HtmxRouteAttribute.cs), and [fragment component](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Components/HtmxFragment.cs).
+
+No surveyed alternative provides the proposed combination below. Htmxor today provides most of it, but v1 would still need to add normal-only reachability and harden action binding:
+
+1. a UI component or page owns or conventionally derives its route without separate endpoint registration;
+2. normal-only, HTMX-only, and dual reachability are explicit declarative choices;
+3. the same routable component can return its full output, one inline fragment, or several inline and out-of-band fragments;
+4. HTTP actions remain local to that component and are bound to explicit verbs.
+
+### Assessment
+
+The proposed v1 should preserve and complete that interface. It should not move Htmxor toward controller-owned or Minimal API-owned feature endpoints. The part to replace is the implementation beneath the interface: private Blazor service replacement, reflection over internal types, and copied renderer behavior. The comparison supports a public-API and generated-registration architecture, not a different authoring model.
+
+The most useful outside ideas are complementary:
+
+- Htmx.Net's small typed protocol layer and explicit cache support;
+- Rizzy's use of the public Razor component result path;
+- Django 6 and Thymeleaf's named fragments colocated with a full template;
+- FastHX's explicit reachability modes and selectable error renderers;
+- holm's automatic UI route discovery, local submit handlers, and verb-specific HTML actions;
+- Spring's CSRF and authentication-flow integration;
+- axum-htmx's automatic `Vary` handling and warning that HTMX headers are not authorization;
+- templ's compile-time component model and explicit fragment execution semantics.
+
+## Version snapshot
+
+The stable browser-library reference for this review is htmx 2.0.10, published in the [official npm package](https://www.npmjs.com/package/htmx.org/v/2.0.10). This is a dated research and test baseline, not a proposed Htmxor dependency. htmx 4 remained prerelease software at the research date, so a backend library's verified behavior with an htmx 4 beta is recorded separately from stable htmx 2 evidence.
+
+| Project | Reviewed version or revision | Evidence |
+| --- | --- | --- |
+| Htmxor | commit `d8e09e4da17ab4c74fbea95d8e995137785c8395`, 2024-09-09; targets .NET 8 and embeds htmx 1.9.12 | [repository revision](https://github.com/egil/Htmxor/tree/d8e09e4da17ab4c74fbea95d8e995137785c8395), [project file](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Htmxor.csproj), [embedded asset](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/wwwroot/htmx/htmx.min.js) |
+| Htmx.Net / Htmx.TagHelpers | 1.12.0, 2026-03-02; documents htmx 1.x and 2.x | [NuGet](https://www.nuget.org/packages/Htmx/1.12.0), [repository](https://github.com/khalidabuhakmeh/Htmx.Net) |
+| Rizzy | 5.4.0, 2026-06-09; .NET 10 | [NuGet](https://www.nuget.org/packages/Rizzy/5.4.0), [repository](https://github.com/JalexSocial/Rizzy) |
+| RazorX | repository template marked `1.0.0-beta`; requires .NET 9 or later | [repository and README](https://github.com/ranzlee/razorx) |
+| Giraffe.ViewEngine.Htmx | 2.0.10, 2026-07-03; htmx 2.0.10 and .NET 8 through 10 | [NuGet](https://www.nuget.org/packages/Giraffe.ViewEngine.Htmx/2.0.10), [repository](https://git.bitbadger.solutions/bit-badger/Giraffe.Htmx) |
+| django-htmx | 1.29.0, 2026-08-05; Django 5.2 through 6.1 | [PyPI](https://pypi.org/project/django-htmx/1.29.0/) |
+| Django template partials | Django 6.0 core feature | [Django 6.0 release notes](https://docs.djangoproject.com/en/6.0/releases/6.0/), [template language reference](https://docs.djangoproject.com/en/6.0/ref/templates/language/#template-partials) |
+| FastHX | 3.2.2, 2026-07-23 | [PyPI](https://pypi.org/project/fasthx/3.2.2/), [repository](https://github.com/volfpeter/fasthx) |
+| holm | 0.10.0, 2026-07-23 | [PyPI](https://pypi.org/project/holm/0.10.0/), [documentation](https://volfpeter.github.io/holm/) |
+| htmx-spring-boot | 5.1.0; compatibility table names Spring Boot 4.0.3 and Java 17 | [Maven Central](https://central.sonatype.com/artifact/io.github.wimdeblauwe/htmx-spring-boot/5.1.0), [compatibility matrix](https://github.com/wimdeblauwe/htmx-spring-boot#compatibility) |
+| axum-htmx | 0.8.1, 2025-06-05 | [docs.rs release page](https://docs.rs/crate/axum-htmx/0.8.1) |
+| templ | 0.3.1020, 2026-05-10 | [GitHub release](https://github.com/a-h/templ/releases/tag/v0.3.1020) |
+
+Rizzy and Giraffe.ViewEngine.Htmx are included because they expose two particularly relevant .NET patterns: public Razor component rendering and server-side fragment selection from a colocated template. Biff and axum-routing-htmx appear later as brief secondary examples.
+
+## Comparison criteria
+
+The report uses these terms consistently:
+
+- **Normal-only** means a route is intentionally unavailable as an HTMX representation.
+- **HTMX-only** means a non-HTMX request does not receive the endpoint's ordinary representation. This is a representation constraint, not an authorization boundary.
+- **Both** means one logical URL can serve a normal full page and an HTMX-specific component or fragment response.
+- **Inline fragment** means a selectable region is declared in the same source template or component as its full representation.
+- **Endpoint boilerplate** means application code must repeat route, verb, handler, or component selection outside the UI component.
+- **Maintenance coupling** describes how much host framework machinery the library replaces or owns. It is not a feature score.
+
+Ease-of-use and maintainability comments are qualitative assessments based on the documented authoring surface and implementation seams. They are not benchmark results.
+
+## Same feature at the call site
+
+Assume a feature needs `/users` as a full page and a user-list fragment for an HTMX refresh. The core authoring difference is visible before comparing the larger capability sets:
+
+| System | What the feature author writes | Separate routing/selection boundary |
+| --- | --- | --- |
+| **Htmxor today** | One `.razor` file with `@page "/users"`, `<HtmxFragment>...</HtmxFragment>`, HTMX attributes, and optional `@onpost` or other local handlers | No per-feature endpoint. Htmxor discovers the page route and selects normal or direct rendering |
+| **holm** | `users/page.py` with `def page(request)`, optional `handle_submit`, and colocated `@action.get/post/...` functions | No FastAPI registration. A fragment can use a separate action or a manual `HX-Request` plus `without_layout` branch in `page`; there is no declarative inline match/selection model |
+| **RazorX or Rizzy** | A `.razor` component plus a C# handler/controller that calls `MapGet(... RenderComponent<Users>())`, `View<Users>()`, or `PartialView<UserList>()` | The C# endpoint owns route, verb, security policy, and component selection |
+| **Django 6** | A template with `{% partialdef user-list %}` plus URLconf and a Python view that selects `users.html` or `users.html#user-list` | The view owns the HTMX branch and template-name selection |
+| **htmx-spring-boot** | A Thymeleaf template fragment plus `@GetMapping("/users")`, often with `@HxRequest`, returning `"users :: list"` | The controller owns route conditions and fragment selection |
+| **templ** | A `.templ` file with `@templ.Fragment("user-list")` plus a Go handler using `templ.WithFragments("user-list")` | The handler owns route and fragment selection; the containing template still executes |
+
+This is why a thin library can be easy to maintain while still imposing more work on each consumer. holm removes explicit route registration, but Htmxor can go further by retaining the full page, local action, and inline selected output in one Razor component contract.
+
+## Developer-facing routing and rendering matrix
+
+The following table records documented behavior. An application's ability to hand-code a branch is not treated as a first-class library feature.
+
+| System | Where the developer declares the route | Normal-only, HTMX-only, and both | Full versus fragment response | Inline and multiple fragments |
+| --- | --- | --- | --- | --- |
+| **Htmxor today** | The `.razor` component through `@page` and/or `[HtmxRoute]`; one application-level registration maps discovered components | `@page` currently means both; `[HtmxRoute]` without `@page` supplies HTMX-only reachability; no first-class normal-only opt-out | Routing mode automatically chooses the normal Blazor root path or direct component path | `HtmxFragment` and `HtmxFragmentElement` select inline output; layouts and ordinary HTMX OOB markup can return additional swaps |
+| **Htmx.Net / TagHelpers** | Razor Page handler, MVC action, or named route remains application code | All modes are possible through application routing and `Request.IsHtmx()` branches; the library does not declare a mode | Developer returns `Page()` or `Partial(...)` | Razor partials remain separate views unless the application supplies another convention; content and OOB composition are app-owned |
+| **Rizzy** | MVC controller or Minimal API route names the Razor component | `[HtmxRequest]` can constrain an action to HTMX; ordinary routes remain normal; dual behavior uses Rizzy result/layout conventions | `View<TComponent>()`, `PartialView<TComponent>()`, `RenderFragment`, and `HtmxLayout` | Separate Razor components or render fragments; a service supports multiple OOB swaps |
+| **RazorX** | `IRequestHandler.MapRoutes` explicitly maps each Minimal API route and handler | The handler and endpoint policy decide the mode | Handler returns `RenderComponent<T>()`; mutations map another route and render a leaf component | Component decomposition supplies fragments; route-to-component choice is in C# handler code |
+| **django-htmx + Django 6** | Django URL configuration and Python view | Normal is an ordinary view; both requires a `request.htmx` branch; HTMX-only requires an app guard | View chooses `page.html` or `page.html#partial` | Django 6 `{% partialdef %}` keeps named partials inline; the view selects one named partial. Multiple/OOB output is template/application markup |
+| **FastHX** | Existing FastAPI route plus `@jinja.hx`, `@htmy.hx`, or `page` decorator | `page` always renders HTML; `hx(..., no_data=True)` is HTMX-only; ordinary `hx` renders HTML for HTMX and leaves the non-HTMX route data unchanged, often JSON | Rendering decorator and optional component selector choose the renderer | Selector chooses a template/component, including an error component. Inline sub-selection depends on the renderer rather than FastHX itself |
+| **holm** | File-system conventions discover `page.py`; `handle_submit` adds POST on the same URL; `@action.get/post/...` creates relative HTML routes without FastAPI registration | No first-class normal-only or HTMX-only guard. A page can manually branch on `HX-Request`; generated actions remain ordinary HTTP endpoints | Pages receive automatic layouts; a page can return `without_layout(content)` for HTMX; actions are unwrapped by default and can opt into layouts | Returned htmy components can be fragments, but there is no named inline selector or first-class multiple/OOB result model |
+| **htmx-spring-boot** | Spring MVC controller method with `@GetMapping` and optionally `@HxRequest` | Ordinary mapping is normal; `@HxRequest` is HTMX-conditioned; separate conditioned and ordinary handlers or a branch can serve both | Controller returns a view, `view :: fragment`, a redirect/refresh view, or a multi-fragment result | Thymeleaf markup selectors keep fragments in a template. Spring `FragmentsRendering` returns several fragments, including OOB responses |
+| **axum-htmx** | Explicit Axum router and Rust handler | Ordinary routes are normal; `HxRequestGuardLayer` can require HTMX; both requires app branching | No rendering abstraction; handler selects its HTML/template result | No fragment model; application or template engine owns all content selection |
+| **templ** | Explicit Go `http.Handler` or framework route | Application handler decides all modes | Handler renders a full component, a leaf component, or named fragments; the official HTMX example also demonstrates returning a full page and letting client `hx-select` extract one element | `@templ.Fragment("name")` and `templ.WithFragments(...)` select one or more named inline fragments, but the containing template still executes |
+| **Giraffe.ViewEngine.Htmx** | Explicit Giraffe route and F# handler | Application handler decides all modes | Handler can render the full view or find a fragment by element `id` | One view can contain the named element, avoiding a separate partial file; route and selection remain in the handler |
+
+Sources for the table: [Htmxor routing and fragments](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/docs/index.md#routing), [Htmx.Net README](https://github.com/khalidabuhakmeh/Htmx.Net/blob/main/Readme.md), [Rizzy endpoint mapping](https://jalexsocial.github.io/rizzy.docs/docs/framework/minimalapi/mapping-endpoints/), [Rizzy OOB swapping](https://jalexsocial.github.io/rizzy.docs/docs/htmx/out-of-band-swapping/), [RazorX request cycle](https://github.com/ranzlee/razorx#requestresponse-cycle), [django-htmx partial rendering](https://django-htmx.readthedocs.io/en/latest/tips.html#partial-rendering), [FastHX Jinja API](https://volfpeter.github.io/fasthx/api/jinja/), [FastHX component selectors](https://volfpeter.github.io/fasthx/api/component_selectors/), [holm application components](https://volfpeter.github.io/holm/application-components/), [holm HTMX actions](https://volfpeter.github.io/holm/guides/actions-with-htmx/), [holm `without_layout`](https://volfpeter.github.io/holm/utilities/), [htmx-spring-boot README](https://github.com/wimdeblauwe/htmx-spring-boot), [axum-htmx API](https://docs.rs/axum-htmx/latest/axum_htmx/), [templ fragments](https://templ.guide/syntax-and-usage/fragments/), and [Giraffe fragment rendering](https://bitbadger.solutions/blog/2022/fragment-rendering-in-giraffe-view-engine.html).
+
+## Protocol, security, caching, and assets matrix
+
+| System | Request and response helpers | Forms, CSRF, and authentication | Cache variation | Browser asset and streaming support |
+| --- | --- | --- | --- | --- |
+| **Htmxor today** | `HtmxContext`, typed request values, and fluent `HtmxResponse` headers; component-local `@onget`, `@onpost`, and related events | Uses ASP.NET antiforgery metadata and `UseHtmxAntiforgery`; current endpoint/action binding needs hardening because route defaults and rendered-event dispatch are broader than a stable v1 should allow | No first-class automatic `Vary` policy in the reviewed source | Embeds htmx 1.9.12 and emits it from `HtmxHeadOutlet`; current design is coupled to a fixed, outdated asset |
+| **Htmx.Net / TagHelpers** | `Request.IsHtmx()`, typed header access, and fluent response-header builders | Opt-in antiforgery meta tag plus mapped script adds the token to non-GET requests; ASP.NET auth and page/model binding remain authoritative | `WithVary()` explicitly adds `Vary: HX-Request` | Caller owns the htmx browser asset; no rendering or streaming layer |
+| **Rizzy** | HTMX request constraints, response abstractions, layouts, OOB swaps, and component results | MVC actions can use standard authorization and antiforgery attributes. Minimal API routes still need endpoint-owned policies; rendering a component does not add them automatically | `HtmxLayout` adds `Vary: HX-Request` | Client package currently references an htmx 4 beta; a streaming extension exists |
+| **RazorX** | Component response extensions and trigger builders | Public endpoint filters apply antiforgery, authorization, and validation policies | Application/endpoint policy | Application owns browser integration; rendering uses public ASP.NET component APIs |
+| **django-htmx** | `request.htmx`; redirect, location, refresh, stop-polling responses; push, replace, reswap, retarget, reselect, and trigger modifiers | Django forms, auth, and CSRF remain authoritative. Official guidance places `x-csrftoken` in ancestor `hx-headers` | Official tips require `Vary: HX-Request` when the response branches | `{% htmx_script %}` can serve stable htmx 2.0.10 or opt-in htmx 4 beta 6 with matched extensions and a CSP nonce |
+| **FastHX** | Rendering decorators and request-aware component/error selectors; fewer typed HX response helpers than Spring or Htmx.Net | FastAPI dependencies, forms, auth, and app CSRF remain authoritative; `no_data=True` is not a security boundary | Application policy | Renderer-owned; HTMY integration supports async streaming when the renderer supports it |
+| **holm** | Page, submit-handler, and action conventions render through FastHX/htmy; standard FastAPI dependencies remain available | htmy escapes output by default. holm recommends secure cookie settings and avoiding unsafe GETs, but leaves CSRF-token implementation to the application | No automatic HTMX cache variation documented in the reviewed guides | Application includes htmx; holm itself has no JavaScript dependency. Rendering inherits FastHX/htmy behavior |
+| **htmx-spring-boot** | Injectable `HtmxRequest`/`HtmxResponse`; response annotations; redirect, location, refresh, reselect, reswap, retarget, history, and trigger APIs | Thymeleaf dialect adds Spring Security CSRF to unsafe `hx:*` requests, including non-form elements. Dedicated auth success, failure, logout, entry-point, and access-denied adapters return suitable HX flows | Application/Spring cache policy; request conditions are explicit | Application owns htmx inclusion; library supplies server modules and Thymeleaf dialect rather than a pinned client |
+| **axum-htmx** | Typed extractors for request headers, typed response parts for standard HX headers, JSON event support, and HTMX route guard | Axum/Tower application owns forms, CSRF, and auth. Documentation explicitly warns the request guard is not authorization because headers are forgeable | Optional `AutoVaryLayer` adds the headers implied by extractors | No asset, template, or streaming ownership |
+| **templ** | HTMX protocol remains ordinary Go headers; `templ.Handler` controls rendering behavior | App owns authentication and CSRF. Project docs point to Go's cross-origin protection; generated templates provide contextual escaping, typed script attributes, and URL sanitization | Application policy | User downloads/serves htmx. Handler supports normal buffered and streaming rendering; fragment filtering does not skip execution of the containing template |
+| **Giraffe.ViewEngine.Htmx** | Typed F# attributes and request/response helpers | Existing Giraffe/ASP.NET middleware owns security | Application policy | Local and CDN htmx nodes are available and release version tracks htmx 2.0.10 |
+
+Sources for the table: [Htmxor response API](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Http/HtmxResponse.cs), [Htmxor antiforgery endpoint metadata](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Builder/ComponentEndpointDataSource.cs), [Htmx.Net antiforgery and response helpers](https://github.com/khalidabuhakmeh/Htmx.Net/blob/main/Readme.md), [Rizzy repository](https://github.com/JalexSocial/Rizzy), [django-htmx installation and CSRF](https://django-htmx.readthedocs.io/en/stable/installation.html), [django-htmx response helpers](https://django-htmx.readthedocs.io/en/latest/http.html), [django-htmx template assets](https://django-htmx.readthedocs.io/en/latest/template_tags.html), [FastHX HTMY API](https://volfpeter.github.io/fasthx/api/htmy/), [holm security](https://volfpeter.github.io/holm/security/), [htmx-spring-boot security integration](https://github.com/wimdeblauwe/htmx-spring-boot#spring-security), [axum-htmx API](https://docs.rs/axum-htmx/latest/axum_htmx/), [templ HTMX guide](https://templ.guide/server-side-rendering/htmx/), [templ security guide](https://templ.guide/security/injection-attacks/), and [Giraffe package](https://www.nuget.org/packages/Giraffe.ViewEngine.Htmx/2.0.10).
+
+## Detailed interface comparison
+
+### Htmxor baseline
+
+**Observed interface.** A user performs one application-level registration with `AddHtmx`, `UseHtmxAntiforgery`, and `AddHtmxorComponentEndpoints`, then works in `.razor` components. A component's normal `@page` route is copied into the Htmxor route set. An explicit `[HtmxRoute]` can add route, HTTP method, current URL, target, and trigger constraints. The default `HtmxRouteAttribute.Methods` currently contains GET, POST, PUT, PATCH, and DELETE. [Startup example](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/samples/MinimalHtmxorApp/Program.cs), [component route discovery](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Builder/ComponentInfo.cs), and [route constraints](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/HtmxRouteAttribute.cs). Component-local `@onget`, `@onpost`, and related handlers currently receive a generated hash in rendered markup and are selected from the supplied event-handler id on the later request. [Rendered event registration](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Rendering/HtmxorRenderer.HtmlWriting.cs) and [request dispatch](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Rendering/HtmxorRenderer.HtmxorEventDispatch.cs).
+
+Normal requests travel through the root component and Blazor router. Direct requests render the matching component, with an optional `HtmxLayout`. `HtmxFragment` evaluates a request predicate and conditionally emits its child content. `HtmxFragmentElement` wraps selected content in a targetable element. Page title, response headers, layouts, and OOB layouts are supported. [Routing modes](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/docs/index.md#routing), [fragment source](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Components/HtmxFragment.cs), and [OOB layout example](https://github.com/egil/Htmxor/tree/d8e09e4da17ab4c74fbea95d8e995137785c8395/samples/HtmxorExamples/Components/Pages/Examples/OutOfBandOutlets).
+
+The implementation replaces or removes Blazor services, implements a custom endpoint invoker, copies renderer behavior, and reflects over internal renderer/form types. [Service replacement](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/DependencyInjection/HtmxorApplicationBuilderExtensions.cs), [custom invoker](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Endpoints/HtmxorComponentEndpointInvoker.cs), and [renderer reflection](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Rendering/HtmxorRenderer.cs).
+
+**Assessment.** The authoring interface has unusually strong locality. Its gaps are a missing normal-only declaration, unsafe verb defaults, action identity that needs exact route-and-verb binding, an old embedded client, incomplete cache variation, and high private-framework coupling. These are reasons to rebuild the plumbing, not reasons to require a controller beside every component.
+
+### Htmx.Net and Htmx.TagHelpers
+
+**Observed interface.** The canonical Razor Pages example keeps selection in the page handler:
+
+```csharp
+return Request.IsHtmx()
+    ? Partial("_Form", this)
+    : Page();
+```
+
+Tag Helpers generate URLs from `hx-page`, `hx-page-handler`, controller/action, named route, and route values. They do not create the endpoint. Request headers and response headers have typed/fluent APIs, including `WithVary()`. Antiforgery integration maps a small script that sends the framework token on non-GET requests. The application chooses and serves the htmx browser version. [Project README and examples](https://github.com/khalidabuhakmeh/Htmx.Net/blob/main/Readme.md).
+
+**Assessment.** This has the lowest coupling among the surveyed .NET integrations because it extends public `HttpRequest`, `HttpResponse`, MVC, and Razor Pages seams. The cost is repeated branching and coordination among route handler, full page, and partial view. Htmxor should borrow its protocol types, explicit `Vary` support, and caller-controlled asset strategy without adopting its per-handler authoring burden.
+
+### Rizzy
+
+**Observed interface.** Rizzy renders Razor components from MVC or Minimal API endpoints. A handler returns a full `View<TComponent>()`, `PartialView<TComponent>()`, or render fragment. `HtmxLayout` removes the root/page layout for HTMX requests and adds `Vary: HX-Request`. `[HtmxRequest]` constrains an MVC action to HTMX, and an OOB swap service composes several updates. Its full view path uses the public ASP.NET `RazorComponentResult` seam. MVC actions can use ordinary authorization and antiforgery attributes; Minimal API routes still require the application to attach the corresponding endpoint policies. [Minimal API mapping](https://jalexsocial.github.io/rizzy.docs/docs/framework/minimalapi/mapping-endpoints/), [OOB swapping](https://jalexsocial.github.io/rizzy.docs/docs/htmx/out-of-band-swapping/), and [repository source](https://github.com/JalexSocial/Rizzy).
+
+**Assessment.** Rizzy is the closest current .NET evidence that rich Razor component responses can sit on supported ASP.NET APIs. It still splits route/action ownership from the `.razor` file, so copying its public rendering seam is useful while copying its endpoint authoring model would remove Htmxor's differentiator. Its current htmx 4 beta dependency also makes it a poor model for Htmxor's stable-client policy.
+
+### RazorX
+
+**Observed interface.** RazorX describes itself as an ASP.NET and HTMX meta-framework that uses Minimal APIs for routing and Razor components as templates rather than Blazor routing or interactivity. A feature typically contains a page component and a C# request handler. The handler's `MapRoutes` method calls `MapGet`, `MapPost`, and related APIs, then returns `RenderComponent<T>()`. Endpoint filters cover antiforgery, authorization, and validation. [Request/response cycle and sample](https://github.com/ranzlee/razorx#requestresponse-cycle).
+
+**Assessment.** The explicit split makes the runtime easy to understand and keeps it on public APIs. It also creates the separate endpoint file and per-component mapping Htmxor is intended to avoid: the `.razor` component is not reachable until a C# handler maps it. RazorX is a useful implementation reference, not the right Htmxor user interface.
+
+### Giraffe.ViewEngine.Htmx
+
+**Observed interface.** This F# package tracks htmx versions and supplies typed attributes plus request and response helpers. Its fragment-rendering facility can locate an element by `id` within one view and render that subtree, which avoids maintaining a second partial template. The application still declares a Giraffe route and chooses full or fragment output in the handler. [Package metadata](https://www.nuget.org/packages/Giraffe.ViewEngine.Htmx/2.0.10), [source repository](https://git.bitbadger.solutions/bit-badger/Giraffe.Htmx), and [fragment rendering design](https://bitbadger.solutions/blog/2022/fragment-rendering-in-giraffe-view-engine.html).
+
+**Assessment.** Its element-id selection validates the value of fragment locality in a .NET stack. Htmxor can offer a stronger version because the fragment and the route both stay with the Razor component.
+
+### django-htmx with Django 6 template partials
+
+**Observed interface.** Middleware attaches a typed `request.htmx` object. A view commonly chooses a template as follows:
+
+```python
+template_name = "countries.html"
+if request.htmx:
+    template_name += "#country-table"
+return render(request, template_name, context)
+```
+
+Django 6 defines `{% partialdef country-table inline %}` in the same template and allows direct rendering with `countries.html#country-table`. django-htmx supplies request data, response helpers, cache guidance, CSRF guidance, and a script tag that can serve htmx 2.0.10 or an opt-in htmx 4 beta with matching extensions and CSP nonce support. `request.htmx` recognizes the exact `HX-Request: true` value, and its absolute-current-URL helper rejects a different scheme or host. [Partial rendering](https://django-htmx.readthedocs.io/en/latest/tips.html#partial-rendering), [middleware](https://django-htmx.readthedocs.io/en/latest/middleware.html), [Django partial syntax](https://docs.djangoproject.com/en/6.0/ref/templates/language/#template-partials), [response helpers](https://django-htmx.readthedocs.io/en/latest/http.html), and [asset tag](https://django-htmx.readthedocs.io/en/latest/template_tags.html).
+
+**Assessment.** Django 6 provides the closest template-level analogy to `HtmxFragment`: named partials are local to the full template. The route and request branch remain elsewhere. Its shallow middleware/template-loader implementation is maintainable, but every feature owns URLconf/view/template coordination. Its stable-versus-prerelease asset choice, CSP support, exact header parsing, and documented cache variation are good v1 patterns.
+
+### FastHX
+
+**Observed interface.** FastHX wraps an ordinary FastAPI route with a renderer decorator:
+
+```python
+@app.get("/users")
+@jinja.hx("user-list.html")
+async def users() -> list[User]:
+    return await load_users()
+```
+
+`hx()` renders HTML for an HTMX request and otherwise leaves the route's data result unchanged. `no_data=True` rejects the non-HTMX data representation and therefore supplies an HTMX-only mode. `page()` always renders HTML. A component selector can choose a template/component from a request header, and an error selector can choose presentation for failures. Renderer protocols can support async streaming. [Jinja examples](https://volfpeter.github.io/fasthx/examples/jinja-templating/), [Jinja API](https://volfpeter.github.io/fasthx/api/jinja/), [selectors](https://volfpeter.github.io/fasthx/api/component_selectors/), and [HTMY streaming](https://volfpeter.github.io/fasthx/api/htmy/).
+
+**Assessment.** FastHX has the clearest explicit vocabulary for always-HTML, HTMX-conditioned HTML, and HTMX-only rendering. Its ordinary `hx` mode is often HTML-versus-JSON rather than full-page-versus-fragment HTML, so it is not the whole Htmxor model. The two decorators are concise and based on public FastAPI behavior, but the route still lives outside the template. Htmxor should put similarly explicit reachability choices on the component.
+
+### holm
+
+**Observed interface.** holm is the strongest counterexample to the claim that backend HTMX integrations always require manual endpoint registration. Its file-system router discovers a `page.py` module and creates the page's GET route. A `handle_submit` function in the same module creates POST at the same URL. Verb-specific `@action.get()`, `@action.post()`, and related functions can live in `page.py` or `actions.py`; holm derives their relative paths and renders returned htmy components without layouts by default, which is intended for HTMX fragments.
+
+```python
+# users/page.py becomes GET /users
+def page(request: Request) -> Component:
+    content = UsersPage()
+    if request.headers.get("HX-Request") == "true":
+        return without_layout(content)
+    return content
+
+# The same file also creates POST /users.
+def handle_submit() -> Component:
+    return UpdatedUsersPage()
+
+# Creates GET /users/count and returns an unwrapped fragment.
+@action.get()
+def count() -> Component:
+    return UserCount()
+```
+
+Pages and actions use normal FastAPI dependency injection, and layouts are composed from the package tree. Actions can opt back into their owner layouts. The example above preserves one route and keeps the branch in `page.py`, but the developer reads the header and chooses the response explicitly. holm has no named inline-region matcher or first-class multiple-fragment result. Generated page and action routes remain ordinary HTTP routes unless the application adds a FastAPI dependency or another guard. [Application components](https://volfpeter.github.io/holm/application-components/), [file-system routing](https://volfpeter.github.io/holm/file-system-based-routing/), [actions with HTMX](https://volfpeter.github.io/holm/guides/actions-with-htmx/), and [`without_layout`](https://volfpeter.github.io/holm/utilities/).
+
+holm uses htmy's default escaping and standard FastAPI dependencies. Its security guide recommends secure cookie settings, SameSite, and unsafe-verb discipline, but says applications that need CSRF tokens must implement them according to their architecture. It does not document Spring-style automatic tokens, Htmxor-style endpoint antiforgery metadata, or automatic `Vary` behavior for the documented full/partial branch. [holm security](https://volfpeter.github.io/holm/security/).
+
+`App()` locates the caller package, scans and imports known files at startup, builds nested public FastAPI `APIRouter` instances, and wraps generated operations with FastHX `HTMY.page`. This is a deep module with high caller leverage and locality, built on public adapters rather than private host-framework replacement. The tradeoff is runtime discovery: route mistakes lack compile-time diagnostics, imports execute during startup, and the tagged implementation logs and skips an import that raises. Version 0.10.0 also replaced the earlier `layout.html` convention with Jinja layouts, evidence that this pre-1.0 interface is still moving. [Tagged application implementation](https://github.com/volfpeter/holm/blob/v0.10.0/holm/app.py), [tagged application model](https://github.com/volfpeter/holm/blob/v0.10.0/holm/_model.py), and [0.10 upgrade guide](https://github.com/volfpeter/holm/blob/v0.10.0/docs/upgrade-guides/0.9.0-to-0.10.0.md).
+
+**Assessment.** holm proves that automatic UI route discovery, local HTTP actions, and same-URL full/partial branching can be implemented as a maintainable framework convention. It is closer to Htmxor's desired developer experience than FastHX alone, and Htmxor should borrow its explicit method decorators and deterministic route naming. Htmxor remains distinct in retaining standard Blazor `@page` ownership while adding declarative reachability and inline named/predicate selection with multiple-fragment composition, without requiring a manual header branch. It should exceed holm's security posture by carrying ASP.NET authorization and mandatory antiforgery metadata onto every generated unsafe endpoint.
+
+### htmx-spring-boot
+
+**Observed interface.** Spring controller methods retain route ownership:
+
+```java
+@HxRequest
+@GetMapping("/users")
+public String users() {
+    return "users :: list";
+}
+```
+
+`@HxRequest` can constrain trigger id, trigger name, target, and boosted state, and it can be composed into a custom mapping annotation. A project can use an HTMX-conditioned handler beside an ordinary handler for the same path, or branch from an injectable `HtmxRequest`. `HtmxResponse`, annotations, special view names, and dedicated views cover the standard response headers. A Thymeleaf `template :: fragment` selects one inline fragment; Spring `FragmentsRendering` composes several. [Project README](https://github.com/wimdeblauwe/htmx-spring-boot) and [5.1.0 API](https://javadoc.io/doc/io.github.wimdeblauwe/htmx-spring-boot/5.1.0/).
+
+The Thymeleaf dialect automatically puts the Spring Security CSRF token in `hx-headers` for POST, PUT, PATCH, and DELETE attributes, including elements that are not forms. Security success, failure, logout, entry-point, and access-denied integrations translate redirects or refreshes into HTMX-compatible responses. [Spring Security integration](https://github.com/wimdeblauwe/htmx-spring-boot#spring-security).
+
+**Assessment.** This is the richest protocol and security integration in the survey. It uses supported Spring extension points and publishes an explicit compatibility matrix, which is a better maintenance posture than depending on private renderer types. Its user code remains split between controller and template. Htmxor should borrow its security completeness, endpoint conditions, and multi-fragment result semantics while keeping component-owned routes and handlers.
+
+### axum-htmx
+
+**Observed interface.** A Rust handler opts into typed request extractors and returns typed response parts. `HxRequestGuardLayer` can reject or redirect non-HTMX traffic for a router. `AutoVaryLayer` observes the request extractors in use and adds the corresponding `Vary` fields. The crate does not select templates, bind forms, provide CSRF, authorize callers, or ship browser assets. Its documentation explicitly warns that the HTMX guard cannot enforce authorization because a client can forge `HX-Request`. [axum-htmx API and security warning](https://docs.rs/axum-htmx/latest/axum_htmx/).
+
+**Assessment.** This is the thinnest integration reviewed. It has a small maintenance surface and predictable framework behavior, while pushing almost all application behavior into handlers. Its typed header parts, automatic cache variation, and explicit security warning should be adopted in Htmxor's protocol layer.
+
+### templ
+
+**Observed interface.** templ compiles `.templ` components to typed Go code, but routes remain explicit `http.Handler` or framework registrations. The official HTMX counter example renders the complete page on each request and uses client-side `hx-select` to extract `#countsForm`. This keeps one renderer path but executes and transmits the full document. [HTMX example](https://templ.guide/server-side-rendering/htmx/) and [server-rendered application example](https://templ.guide/server-side-rendering/example-counter-application/).
+
+For server-side selection, a template can define `@templ.Fragment("name")`, and a handler can use `templ.WithFragments("name")`. Multiple and nested matches are supported. The documentation warns that fragment filtering discards nonmatching output after executing the containing template, so component code outside the selected fragment still runs. [Fragment documentation](https://templ.guide/syntax-and-usage/fragments/).
+
+**Assessment.** templ is the closest comparison for inline, named, server-selected component fragments. It also documents the performance boundary Htmxor must state clearly: output selection does not automatically become lifecycle or data-loading selection. Htmxor has the opportunity to retain the same locality while removing the explicit route and handler selection code.
+
+## Brief secondary examples
+
+### Biff
+
+Biff is a Clojure web framework that uses HTMX in its standard application model. Routes are data structures that point to handlers, and handlers return Hiccup trees. Forms use Ring antiforgery, `biff/form` inserts the token, and the starter setup places the token in HTMX headers. This gives forms an explicit CSRF path, while route and component output remain separate program elements. [Biff message tutorial](https://biffweb.com/docs/tutorial/messages/) and [security reference](https://biffweb.com/docs/reference/security/).
+
+### axum-routing-htmx
+
+axum-routing-htmx adds Rust macros such as `#[hx_get("/title")]` and builds an `HtmxRouter`. It makes the server route more declarative, but the Rust handler function still owns the route and response. It does not move route ownership into a UI template/component. [Crate documentation](https://docs.rs/axum-routing-htmx/latest/axum_routing_htmx/).
+
+### Htmx.Components
+
+Htmx.Components 2.0.4 is a larger .NET 10 MVC/ViewComponent framework. Controllers can return models and let result filters choose a full view or multi-swap response. It includes tables, CRUD, page state, navigation, authorization flows, and a browser runtime. That breadth demonstrates how much application boilerplate result filters can remove, but it also couples consumers to a domain-specific MVC/filter architecture. It is not a component-owned routing model. [NuGet release](https://www.nuget.org/packages/Htmx.Components/2.0.4), [developer architecture](https://ucdavis.github.io/Htmx.Components/articles/developer-guide/architecture.html), and [source repository](https://github.com/ucdavis/Htmx.Components).
+
+## Investigated adjacent projects excluded from the main matrices
+
+- **Hydro** has attractive component-local server actions and generated component endpoints, but its current documentation describes a custom AJAX protocol with Alpine.js and contrasts that model with HTMX. It is useful evidence for action locality, not evidence of HTMX compatibility. [Hydro overview](https://usehydro.dev/introduction/overview.html) and [framework comparison](https://usehydro.dev/introduction/comparisons.html).
+- **RazorSlices** is a public-API, low-allocation Razor rendering library for Minimal APIs. Its current README lists HTMX extensions as an area of interest rather than a supported integration, so it is not included in the capability matrices. [RazorSlices repository](https://github.com/DamianEdwards/RazorSlices).
+- **htmxRazor 2.1.2** explicitly supports HTMX through Razor Tag Helpers, more than 90 server-rendered UI components, packaged assets, response helpers, and interaction patterns. Application routing still comes from Razor Pages or MVC, so it is a useful UI-layer comparison rather than a peer for Htmxor's route and component-response model. [htmxRazor package](https://www.nuget.org/packages/htmxRazor/).
+
+## Maintainability comparison
+
+### Observed implementation spectrum
+
+1. **Thin protocol adapters:** Htmx.Net, django-htmx, and axum-htmx use public request, response, middleware, template, or layer extension points. They own little rendering behavior. Application code owns the branch and the route.
+2. **Rendering adapters:** FastHX, htmx-spring-boot, Rizzy, and Giraffe.ViewEngine.Htmx connect public framework routing to a renderer or fragment selector. They reduce response boilerplate while retaining a handler/controller boundary.
+3. **Convention-routed SSR framework:** holm discovers pages, layouts, submit handlers, and actions from public Python modules, then composes FastAPI, FastHX, and htmy. It owns route conventions without owning private host-framework machinery.
+4. **Component compiler:** templ owns compilation and rendering but leaves routes to Go handlers.
+5. **Component-routed integration:** Htmxor discovers Blazor component routes and owns the direct rendering path as well as HTMX integration.
+
+The documented and source seams reviewed for the maintained integrations use public host-framework extension points rather than replacing a private renderer or endpoint invoker. Spring's larger API surface is implemented through MVC argument resolvers, request conditions, views, auto-configuration, and a template dialect. Rizzy uses `RazorComponentResult`. The thin adapters operate at HTTP boundaries.
+
+### Assessment
+
+Thin adapters are easiest for their maintainers to keep compatible because the host framework owns routing and rendering. They shift coordination, branching, and partial-file drift into every application. Htmxor's value is precisely that it centralizes this work once. A stable design therefore needs a deeper module built only from supported host APIs, with generated metadata where reflection over private runtime state would otherwise be required.
+
+In codebase-design terms, Htmxor is pursuing **depth**: a compact developer interface hides a substantial routing, rendering, protocol, and security implementation. Its **leverage** comes from removing endpoint and branching code from every consuming application. That complexity needs **locality** inside one module, with a generated catalog as the seam between Razor authoring and small public-framework adapters.
+
+The target is not “as thin as possible.” The target is the smallest maintainable implementation that preserves component-owned routes and fragments.
+
+## Htmx changes the prototype never absorbed
+
+Yes, the comparison reveals gaps that are easy to miss if the review stops at backend APIs. There is a timing nuance: htmx 2.0.0 through 2.0.2 were released before Htmxor's last code commit on `main` on 2024-09-09, but Htmxor still embeds 1.9.12. Treating those releases as unfinished prototype migration work is an assessment, not proof that implementation had started. htmx 2.0.3 through 2.0.10 were released after that commit and add behavior that the prototype could not have covered.
+
+The official sources for this boundary are the [htmx 2.0 release](https://htmx.org/posts/2024-06-17-htmx-2-0-0-is-released/), [1.x-to-2.x migration guide](https://htmx.org/migration-guide-htmx-1/), current [htmx documentation](https://htmx.org/docs/), and [2.x changelog](https://github.com/bigskysoftware/htmx/blob/master/CHANGELOG.md).
+
+| Client change or current contract | Timing relative to Htmxor | Gap exposed by the backend comparison | Htmxor v1 consequence |
+| --- | --- | --- | --- |
+| Extensions moved out of core; legacy `hx-sse`/`hx-ws` were removed; module builds were added | htmx 2.0.0; not adopted by the 1.9.12 prototype | Most thin adapters intentionally leave extension loading and version matching to the app; django-htmx and Giraffe provide more asset help | Leave the htmx runtime and native extensions application-owned; test Htmxor's replaceable browser adapter, script order, and CSP without constraining the runtime version |
+| DELETE now sends parameters in the URL/query instead of a form-encoded body; `selfRequestsOnly` now defaults to `true`; `scrollBehavior` changed from `smooth` to `instant`; legacy `hx-on` became `hx-on:` | htmx 2.0.0; released before the last Htmxor commit but not adopted | Typed protocol libraries usually expose the request but do not prove application binders and typed option values against changed wire/default behavior | Generate DELETE route/query binding, add `instant` to typed configuration, diagnose old event syntax, and test rather than assume htmx 1 form bodies |
+| Default 4xx/5xx response handling does not swap; applications can configure `responseHandling` or `htmx:beforeSwap` | Current htmx 2 contract; absent from the prototype's declared-error model | None of the reviewed documented interfaces combined a server marker for intentional error fragments with matching client response handling | Mark intentional error fragments server-side and let the Htmxor adapter opt only those responses into swapping; unexpected/security failures remain errors |
+| A history-cache miss needs a complete page; official guidance says `historyRestoreAsHxRequest` should be `false` when `HX-Request` selects partials | Current htmx 2 contract; history paths changed again in 2.0.5, 2.0.8, and 2.0.9 | `Vary: HX-Request` helpers do not configure the browser or guarantee that history restore reaches a full representation | Emit the safe client profile and make `HX-History-Restore-Request: true` select the normal full-page candidate regardless of `HX-Request` |
+| Nested OOB processing is configurable; 2.0.3 enabled `hx-preserve` in OOB swaps | 2.0.3 shipped after Htmxor's last change | Libraries with OOB helpers generally leave nested extraction and preservation semantics to htmx/application configuration | Choose and document a nested-OOB profile; test reusable fragments, preserved nodes, and Blazor DOM ownership |
+| 2.0.5 moved history cache to `sessionStorage`, routed restoration through standard swap paths, and added `inherit` for several inherited attributes | After Htmxor | Backend integrations rarely surface these because they are browser behavior, but their fragment and navigation tests can still fail | Run pushed-URL, boosted-form, inheritance, and cache-hit/miss tests against exact recorded versions while allowing applications to run newer versions through the same conformance suite |
+| 2.0.7 added optional form `reportValidity()` behavior and an indicator accessibility fix | After Htmxor | Server-side validation helpers do not restore the browser's visible constraint-validation UX | Set `reportValidityOfForms: true` in the supported profile and retain authoritative server validation |
+| 2.0.8 added `htmx.ajax` `pushURL` and a relative-history fix; 2.0.9 fixed `HX-Location` push/replace, history normalization, and OOB diagnostics; 2.0.10 restored type definitions and improved settle-selector escaping | After Htmxor | A broad “supports htmx 2” claim hides patch-sensitive navigation, OOB, typing, and selector behavior | Publish exact verified test runs, not a runtime allowlist, and let applications execute the same suite against an upgraded client |
+
+This does not mean every omission is a defect in the other libraries. Htmx.Net, django-htmx, and axum-htmx are deliberately thin in places. But Htmxor promises automatic same-URL full/fragment selection, selected/OOB rendering, and a browser bridge, so history, response handling, cache variation, and client defaults cross its abstraction boundary and become Htmxor responsibilities.
+
+Among the reviewed .NET integrations and documented versions, none presents the complete Htmxor combination proposed here: component-owned `.razor` routes, normal-only/HTMX-only/both reachability, component-local explicit actions, inline single/multiple fragment selection, automatic HTTP variation with fail-closed cache storage, marked error-fragment swapping, and coexistence with stock Blazor render modes. The non-.NET comparisons demonstrate individual patterns rather than being expected to support Blazor. That combination is the opportunity, provided v1 proves it on public framework seams.
+
+The companion [Htmxor v1 interface sketch](htmxor-v1-interface-sketch.md) shows the proposed developer code and the generated routing, security, rendering, cache, error-response, and htmx 2 browser contracts behind it.
+
+## Recommended v1 developer contract
+
+The following is a design assessment derived from the comparison. Exact attribute and directive names remain a separate API-design decision.
+
+### Keep route ownership in the Razor component
+
+One application-level setup call is acceptable. Per-feature endpoint code is not.
+
+| Component declaration | Normal request | HTMX request | v1 intent |
+| --- | --- | --- | --- |
+| `@page` with default Htmxor participation | Stock Blazor page | Direct static SSR component/fragment | **Both** |
+| explicit Htmxor route without `@page` | Not routed by Blazor | Direct static SSR component/fragment | **HTMX-only** |
+| `@page` with an explicit Htmxor opt-out | Stock Blazor page | No direct Htmxor endpoint | **Normal-only** |
+
+This completes the original model instead of replacing it. Existing `@page` dual reachability should be retained as the compatibility default unless migration evidence justifies an opt-in default.
+
+### Make endpoint verbs explicit server declarations
+
+An inferred `@page` Htmxor endpoint should default to GET. POST, PUT, PATCH, and DELETE require an explicit server-side declaration and mandatory antiforgery validation. An HTMX-only or dual route should bind each local handler to the exact normalized route and HTTP verb.
+
+A source generator may inspect literal and transitive `hx-get`, `hx-post`, and related attributes to produce diagnostics and catch missing declarations. Those client attributes cannot be the authority that creates server verbs:
+
+- markup can target another component or an external/dynamic URL;
+- attributes can be conditional, splatted, or computed at runtime;
+- a reused child component must not silently widen the parent's server attack surface;
+- request headers and element ids are forgeable.
+
+The generator should validate resolvable call sites against declared endpoints. The route/action catalog should come from explicit component metadata and handlers.
+
+A build-time catalog may safely derive POST from an explicit component-local `@onpost` handler, or from `[HtmxRoute(Methods = ...)]`, because those are server declarations. Finding `hx-post` only proves that a caller may exist; it must not create or widen the endpoint.
+
+The exact build-time mechanism needs a spike. Roslyn generators run unordered and ordinarily cannot see files produced by another generator. Because Razor compilation can itself use a source generator, a separate C# generator must not assume that Razor-generated component syntax is a supported input seam. Options include treating `.razor` files as explicit additional inputs, using a supported Razor-aware analyzer/compiler extension, or producing the manifest in an earlier build stage. Route correctness must not depend on experimental generator ordering. [Roslyn source-generator design](https://github.com/dotnet/roslyn/blob/main/docs/features/source-generators.md).
+
+### Preserve whole, selected, and OOB output
+
+The direct endpoint should support:
+
+1. the whole component output by default;
+2. one inline named or predicate-selected fragment;
+3. several selected fragments in one response;
+4. OOB fragments and layout-owned outlets;
+5. typed HX response headers and status control.
+
+Django, Thymeleaf, Giraffe, and templ all validate the maintainability benefit of fragment locality. Htmxor should keep fragments in the `.razor` component and allow request metadata to choose them without a C# controller branch.
+
+The performance contract must be explicit. Selecting output can avoid building and serializing nonselected child subtrees, but it does not imply that the enclosing component was never instantiated or that its lifecycle/data loading did not run. templ documents the same boundary. If v1 promises stronger execution pruning, that behavior needs a separate public design and benchmark evidence.
+
+### Treat HTMX selection as representation, never authorization
+
+`HX-Request`, `HX-Target`, `HX-Trigger`, and custom fragment selectors are client input. They can select among server-declared representations after routing and authorization. They cannot grant access, enable a verb, or identify a trusted action.
+
+Endpoint metadata should carry standard ASP.NET authorization, antiforgery, rate-limit, cache, and request-size policies. Unsafe methods should fail closed when antiforgery is missing or invalid. Spring's automatic unsafe-verb CSRF integration and axum-htmx's explicit guard warning are the clearest models in the survey.
+
+### Make cache and protocol behavior automatic
+
+When the same URL has normal and HTMX representations, Htmxor should add `Vary: HX-Request`. If output also varies by history restore, target, trigger, or another declared selector, the endpoint should add only the matching `Vary` fields. This follows django-htmx's cache guidance and axum-htmx's `AutoVaryLayer` pattern.
+
+Correct `Vary` fields prevent full and fragment representations from colliding, but they do not make personalized content safe for a shared cache. Responses affected by authorization, cookies, user state, or antiforgery-derived content need the appropriate `private`, `no-store`, or output-cache policy as well.
+
+For v1, Razor component output should receive `Cache-Control: private, no-store` by default as well as bypassing ASP.NET output-cache storage. Shared storage should require a mechanically enforced token-free response class with canonical selectors; a source scan that merely fails to notice a nested or dynamic antiforgery token is not sufficient. HTTP `Vary` remains correct and automatic even while all storage is disabled.
+
+Typed request parsing should use exact protocol values and validate URL-valued headers before exposing trusted-looking conveniences. Typed response helpers should cover the stable htmx 2 response headers. Protocol support should be separable from component routing so it can be tested without rendering Blazor components.
+
+### Decouple the browser asset
+
+Htmxor should not hardwire any browser-library release into the renderer or server package. Application ownership, as in Htmx.Net and Spring, should be the default and the server should neither inspect nor enforce `htmx.version`.
+
+The maintainable boundary has two extension points:
+
+- a small browser-core module for Htmxor's antiforgery and handled-fragment behavior, connected through a replaceable runtime adapter that maps public htmx lifecycle events;
+- a declarative typed protocol registry for custom request and response headers, parsing, automatic `Vary`, size limits, URL validation, and conflict handling.
+
+Htmx native extensions, `hx-ext`, unknown future `hx-*` attributes, htmx configuration, and the core script stay in application code. A maintained htmx 2 adapter and a separate htmx 4 preview adapter may provide defaults, but neither should include htmx or constrain the version the application serves. Optional asset bundles can exist as non-transitive conveniences.
+
+This is more future-proof than copying all of `htmx.config` into C# or wrapping htmx's extension API. Htmx 2 currently exposes `htmx.defineExtension`, `htmx:configRequest`, and `htmx:beforeSwap`; the [htmx 4 preview extension model](https://four.htmx.org/docs/extensions/using-extensions) already uses a different registration and event-hook shape. The application can replace that small adapter when the browser API moves while retaining the same Razor routes and server protocol features. [Htmx 2 events](https://htmx.org/events/), [extension interface](https://htmx.org/extensions/building/), and [`hx-ext`](https://htmx.org/attributes/hx-ext/).
+
+Compatibility documentation should distinguish **verified** from **required**. Each CI row records the exact htmx and adapter versions exercised. Unknown or newer versions remain allowed; applications can run a published browser conformance kit against their selected script and extensions. CSP nonce, integrity, unsafe-request antiforgery, history restoration, marked-error swapping, OOB behavior, and Blazor DOM ownership belong in that suite.
+
+### Coexist with stock Blazor endpoints and render modes
+
+Normal requests should remain on the stock Blazor endpoint and continue to support static SSR, Interactive Server, Interactive WebAssembly, and Interactive Auto according to normal Blazor rules. The HTMX path should be an additive Htmxor static SSR component/fragment endpoint, built from supported public APIs. [Microsoft Learn describes the .NET 10 render modes and their render locations](https://learn.microsoft.com/en-us/aspnet/core/blazor/components/render-modes?view=aspnetcore-10.0).
+
+This coexistence has two constraints:
+
+- Interactive Auto does not migrate an already rendered component in place merely because its runtime becomes available. Microsoft states that Auto makes an initial decision and never dynamically changes the render mode of a component already on the page. Serving the same `@rendermode Auto` page through a static direct endpoint needs a public-API prototype before v1 promises it. [Microsoft Learn, Automatic rendering](https://learn.microsoft.com/en-us/aspnet/core/blazor/components/render-modes?view=aspnetcore-10.0#automatic-auto-rendering).
+- HTMX must not replace DOM owned by an active interactive Blazor root. The integration needs a documented ownership boundary and diagnostics for unsafe target placement.
+
+This is a two-path model, not hydration of an HTMX fragment. Normal `@page` requests may use Interactive Auto; direct HTMX requests return static SSR markup. `RazorComponentResult` is the public static-SSR result seam and does not expose a render-mode option. The prototype must establish whether a component declared with `@rendermode InteractiveAuto` can also be rendered through that static result as Htmxor markup without emitting or depending on interactive markers. [RazorComponentResult API](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.http.httpresults.razorcomponentresult?view=aspnetcore-10.0).
+
+These constraints preserve Blazor behavior rather than turning Htmxor into an alternative interactive-component runtime.
+
+## Recommended implementation boundary
+
+The comparison points to five modules with different reasons to change:
+
+1. **Build-time route and action catalog.** Compile component-owned `@page`, Htmxor route, reachability, verb, fragment, and handler declarations into deterministic metadata through a supported Razor-aware seam. Produce diagnostics for conflicts and resolvable `hx-*` call sites.
+2. **Public ASP.NET endpoint adapter.** Map the generated catalog through public routing and endpoint-convention APIs. Attach standard HTTP method, authorization, antiforgery, cache, and request-size metadata.
+3. **Public Razor rendering adapter.** Use supported component result/rendering APIs, taking Rizzy's `RazorComponentResult` path as evidence. Prototype full and selected fragment rendering before fixing the API.
+4. **Independent HTMX protocol layer.** Parse typed request headers, write typed response headers, calculate `Vary`, and enforce URL/header validation without depending on the component renderer.
+5. **Browser adapter and protocol extension boundary.** Keep htmx application-owned; expose one replaceable lifecycle adapter and one declarative typed feature registry; publish exact verified runs and a caller-runnable conformance kit.
+
+The v1 implementation should not remove/replace private Blazor services, copy a private endpoint invoker, or reflect over private renderer/form types. Those seams are the source of upgrade fragility in the prototype; the documented and source integration seams reviewed for the maintained alternatives instead use public host-framework extension points.
+
+## What to borrow, preserve, and avoid
+
+| Source | Borrow | Preserve in Htmxor instead | Avoid |
+| --- | --- | --- | --- |
+| Htmx.Net | Typed HTTP protocol layer, explicit `Vary`, caller-owned assets | Component-owned route and automatic full/direct choice | Repeated page-handler branches and partial naming |
+| Rizzy | Public Razor component result seam, layout/OOB response concepts | `.razor` route ownership | Mandatory controller or Minimal API route for each component; beta-only client coupling |
+| RazorX | Public endpoint policies and explicit security metadata | Zero feature endpoint boilerplate | Page component plus separate route-handler pair |
+| Django 6 / django-htmx | Inline named partials, exact header parsing, CSP-aware asset selection, cache guidance | Route and fragment choice in the component | Repeated URLconf/view/template coordination |
+| FastHX | Clear reachability modes, component and error selectors, renderer protocol | Full-page HTML and HTMX fragment from one component route | Treating HTMX-only as authorization |
+| holm | Automatic page/action discovery, local submit handlers, explicit verb decorators, deterministic route names | `.razor` `@page` ownership, declarative reachability, and inline named/multiple selection from the same component | Runtime-only route diagnostics, manual HX-header branching, and application-defined CSRF/cache variation |
+| htmx-spring-boot | Unsafe-verb CSRF, auth-flow adapters, request conditions, multi-fragment results, compatibility matrix | Component-local route and action | Controller/template split |
+| axum-htmx | Typed extractors/response parts, automatic `Vary`, explicit header-spoofing warning | Razor rendering integration | Leaving all protocol and selection plumbing to each app |
+| templ | Compile-time component model, inline named fragments, honest execution semantics | No app-authored handler for each route | Full-page render and transfer when only one server fragment is needed |
+
+## Roadmap consequences
+
+The comparison supports these priorities for a stable v1 roadmap:
+
+1. Freeze the component-owned authoring contract and specify all three reachability modes.
+2. Specify route, verb, local-handler identity, antiforgery, authorization, and header-trust invariants before renderer work.
+3. Prove a public-API endpoint and Razor component rendering path on supported .NET versions. Cover a normal Auto page with static HTMX fragments outside interactive roots, the same `@rendermode Auto` page reached through both paths, `hx-boost` versus Blazor enhanced-navigation ownership, insertion and removal of interactive roots, DOM cleanup, and whether either runtime must explicitly process newly inserted content.
+4. Select and prove the Razor-aware build-time generation seam, then build route/action metadata and diagnostics. Treat markup inspection as validation only.
+5. Restore whole-component, inline fragment, multiple-fragment, layout, and OOB behavior on the new rendering seam.
+6. Split typed HTMX protocol and automatic HTTP/cache-key variation from rendering; keep shared component-output storage disabled until token-free rendering is mechanically enforced.
+7. Remove the embedded 1.9.12 client. Make the htmx runtime, native extensions, configuration, and upgrade schedule application-owned; ship a separately replaceable htmx 2 reference adapter.
+8. Specify and prove the typed protocol feature registry, protected-header rules, automatic variation, browser-core contract, and adapter security ordering.
+9. Publish the browser conformance kit. Record exact verified htmx/adapter runs in CI without turning them into a dependency or runtime allowlist.
+10. Benchmark normal Blazor requests, direct whole-component requests, single-fragment requests, multiple/OOB requests, form posts, and streaming where supported. Measure allocations, time to first byte, total time, and work performed outside selected fragments.
+
+The central product decision is therefore clear. holm shows that endpoint-free page/action discovery and same-URL full/partial branching are not unique by themselves. Htmxor's defensible combination is idiomatic Blazor `@page` ownership, explicit declarative reachability modes, component-local handlers, and inline server-selected single/multiple fragments. Keep that interface. Move away only from private Blazor implementation seams, broad implicit verb exposure, fixed client assets, and unspecified security/cache behavior.

--- a/docs/research/htmxor-v1-interface-sketch.md
+++ b/docs/research/htmxor-v1-interface-sketch.md
@@ -1,0 +1,1351 @@
+# Htmxor v1 interface sketch
+
+Design date: 2026-08-26 UTC
+
+Status: proposed interface for discussion. Names and signatures in this document do not exist yet unless identified as current Htmxor behavior.
+
+This document turns the [backend framework comparison](htmx-backend-framework-comparison.md) into developer code. The aim is to preserve Htmxor's defining interface: Razor components own routes, actions, and fragments. Endpoint registration, security metadata, HTMX protocol handling, and static SSR rendering stay behind that interface.
+
+## Outcome
+
+The recommended shape keeps:
+
+- `@page` as the normal route declaration;
+- `[HtmxRoute]` for an HTMX-only component route;
+- `HtmxFragment`, `HtmxFragmentElement`, `HtmxLayout`, and standard OOB markup;
+- one application-level registration call;
+- standard ASP.NET authorization, antiforgery, rate-limit, cache, and request-size policies.
+
+It adds:
+
+- an explicit normal-only reachability declaration;
+- named inline fragments and an immutable multi-fragment render result;
+- build-time, route-bound local actions with explicit HTTP verbs;
+- generated endpoint metadata and diagnostics;
+- exact typed HTMX request values and typed response parts;
+- automatic HTTP variation and fail-closed output-cache variation;
+- an application-owned htmx runtime with replaceable browser adapters and typed protocol extensions;
+- static direct rendering through public ASP.NET and Razor component interfaces.
+
+One part of the prototype should not remain the v1 core: runtime replay of `@onpost`, `@ondelete`, and related callback ids discovered by rendering the component. The v1 action is still declared in the `.razor` file, but it is a real generated HTTP handler bound to one route and verb.
+
+The proposal extends current [`HtmxRoute`](../../src/Htmxor/HtmxRouteAttribute.cs), [`HtmxFragment`](../../src/Htmxor/Components/HtmxFragment.cs), [`HtmxFragmentElement`](../../src/Htmxor/Components/HtmxFragmentElement.cs), [`HtmxContext`](../../src/Htmxor/Http/HtmxContext.cs), and [`HtmxLayout`](../../src/Htmxor/HtmxLayoutAttribute.cs) concepts. It changes the current [runtime event-handler dispatch](../../src/Htmxor/Rendering/HtmxorRenderer.HtmxorEventDispatch.cs) and [private endpoint discovery](../../src/Htmxor/Builder/HtmxorComponentEndpointRouteBuilderExtensions.cs).
+
+## Requirements used for the design
+
+The callers are application developers writing `.razor` files. They should not write controllers, Minimal API mappings, or parallel partial views for each feature.
+
+The module must support:
+
+- normal-only, HTMX-only, and dual routes;
+- safe GET rendering and explicitly declared unsafe actions;
+- whole-component, one-fragment, multi-fragment, layout, and OOB output;
+- normal Blazor static, Server, WebAssembly, and Auto behavior on the normal route;
+- static SSR on the direct HTMX route;
+- standard ASP.NET endpoint policies;
+- verified htmx 2 behavior without requiring, bundling, or runtime-gating a specific htmx release;
+- pass-through support for unknown `hx-*` attributes and public extension seams for future client and wire-protocol features;
+- build-time diagnostics where the source is statically knowable;
+- a measured per-request cost.
+
+The implementation should hide endpoint construction, route naming, request parsing, policy propagation, antiforgery validation, cache variation, authentication redirects, and Razor component rendering.
+
+Native AOT and trimmed Razor Components are not v1 promises. Generating routes can still reduce reflection and startup work, but the current ASP.NET [Native AOT compatibility matrix](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/native-aot?view=aspnetcore-10.0) does not support Blazor Server, which is one of the normal render modes in scope.
+
+## Three action models and one optional link layer
+
+### 1. Compile the current Razor event syntax
+
+This is the smallest caller change:
+
+```razor
+@page "/contacts"
+
+<form hx-post="/contacts" @onpost="CreateAsync">
+    ...
+</form>
+
+@code {
+    private Task CreateAsync(HtmxEventArgs args) => ...;
+}
+```
+
+A Razor-aware build step could compile the literal route, POST verb, and method group into endpoint metadata. It could reject an `hx-post` without a matching server declaration. This hides action identity, antiforgery, dispatch, and rendering.
+
+The interface is familiar, but its hard cases are not small. Lambdas, conditional attributes, reused child components, multiple handlers on one route, and instance state make static binding difficult. Falling back to render-time callback discovery recreates the prototype's security and request-cost problems. This shape is useful as a migration syntax only when the build can prove the binding.
+
+### 2. Declare static local actions and return a render result
+
+The action remains in the component file, but it becomes a statically bindable HTTP handler:
+
+```csharp
+[AttributeUsage(AttributeTargets.Method)]
+public sealed class HtmxPostAttribute(string? template = null) : Attribute
+{
+    public string? Template { get; } = template;
+}
+
+public readonly record struct HtmxFragmentName(string Value)
+{
+    public static implicit operator HtmxFragmentName(string value) =>
+        new(value);
+}
+
+public sealed record HtmxRender
+{
+    public ImmutableArray<HtmxFragmentName> FragmentNames { get; private init; }
+        = [];
+
+    public int StatusCode { get; private init; }
+        = StatusCodes.Status200OK;
+
+    public ComponentParameterCollection Parameters { get; private init; }
+        = ComponentParameterCollection.Empty;
+
+    public HtmxTarget? RetargetTo { get; private init; }
+    public HtmxSwap? ReswapWith { get; private init; }
+    public bool IsHandledError { get; private init; }
+
+    public ImmutableArray<HtmxEvent> Events { get; private init; }
+        = [];
+
+    public static HtmxRender Full() => new();
+
+    public static HtmxRender Fragment(HtmxFragmentName name) =>
+        new() { FragmentNames = [name] };
+
+    public static HtmxRender Fragments(
+        params HtmxFragmentName[] names) =>
+        new() { FragmentNames = ImmutableArray.CreateRange(names) };
+
+    public static HtmxRender HandledError(
+        HtmxFragmentName name,
+        int statusCode) =>
+        new()
+        {
+            FragmentNames = [name],
+            StatusCode = statusCode,
+            IsHandledError = true
+        };
+
+    public HtmxRender WithStatus(int statusCode) =>
+        this with { StatusCode = statusCode };
+
+    public HtmxRender WithParameters<TParameters>(TParameters parameters) =>
+        this with
+        {
+            Parameters = ComponentParameterCollection.Snapshot(parameters)
+        };
+
+    public HtmxRender Retarget(HtmxTarget target) =>
+        this with { RetargetTo = target };
+
+    public HtmxRender Reswap(HtmxSwap swap) =>
+        this with { ReswapWith = swap };
+
+    public HtmxRender Trigger(HtmxEvent @event) =>
+        this with { Events = Events.Add(@event) };
+}
+```
+
+The factories copy caller-provided fragment names, and `ComponentParameterCollection.Snapshot` copies the parameter-name/value map. Parameter values are request-local references, not recursively cloned objects. This is an immutable dispatch envelope, not a claim that arbitrary application models become deeply immutable.
+
+Usage stays local:
+
+```razor
+@code {
+    [HtmxPost]
+    [Authorize(Policy = "Contacts.Write")]
+    private static async Task<HtmxRender> CreateAsync(
+        [FromForm] ContactInput input,
+        ContactStore contacts,
+        CancellationToken cancellationToken)
+    {
+        var result = await contacts.CreateAsync(input, cancellationToken);
+
+        return result.IsValid
+            ? HtmxRender.Fragments("contact-list", "contact-count", "toast")
+            : HtmxRender.HandledError(
+                    "editor",
+                    StatusCodes.Status422UnprocessableEntity)
+                .WithParameters(new { Input = input });
+    }
+}
+```
+
+The proposed generator emits a dispatcher and binder intended to follow documented ASP.NET route, query, form, conversion, and dependency-injection conventions. Those semantics are not inherited automatically merely because the method resembles a Minimal API handler; proving parity is a prototype gate. The dispatcher invokes the static action, then renders a fresh owning component according to the returned result. No controller or `MapPost` appears in application code.
+
+This is the recommended shape for the first v1 spike, not a frozen public interface. The static method cannot mutate a renderer-owned component instance. That is intentional. An HTTP action mutates application state, then Htmxor renders a new static representation. The method's route, verb, security policy, parameters, and possible output are visible before a request runs.
+
+### Optional layer: generate typed action references
+
+The strongest compile-time design also generates route references:
+
+```razor
+<EditForm Model="Input"
+          @attributes="ContactsActions.Create()">
+    ...
+</EditForm>
+
+<button @attributes="ContactsActions.Delete(contact.Id)"
+        hx-target="#contact-list"
+        hx-swap="outerHTML">
+    Delete
+</button>
+```
+
+Conceptually, the generated interface is:
+
+```csharp
+public static class ContactsActions
+{
+    public static HtmxActionAttributes Create();
+    public static HtmxActionAttributes Delete(Guid id);
+}
+```
+
+`HtmxActionAttributes` uses `LinkGenerator` and emits the correct `hx-post` or `hx-delete` attribute. Route constraints become typed factory parameters. A renamed action breaks callers at build time.
+
+This catches more mistakes than literal `hx-*` URLs, but the generated attribute bag hides ordinary HTMX markup and increases compiler coupling. It is a good follow-up if diagnostics on literal routes prove insufficient. It should not be required for v1.
+
+### 3. Put every action behind an explicit policy object
+
+The high-control design separates a handler from the component:
+
+```csharp
+public interface IHtmxorAction<TComponent>
+    where TComponent : IComponent
+{
+    static abstract HtmxorEndpointPolicy Policy { get; }
+
+    ValueTask<HtmxRender> ExecuteAsync(
+        HtmxorActionContext context,
+        CancellationToken cancellationToken);
+}
+```
+
+```csharp
+public sealed class DeleteContact(ContactStore contacts)
+    : IHtmxorAction<Contacts>
+{
+    public static HtmxorEndpointPolicy Policy { get; } = new()
+    {
+        Route = "/contacts/{id:guid}",
+        Method = HttpMethod.Delete,
+        AuthorizationPolicy = "Contacts.Write",
+        Cache = HtmxorCachePolicy.NoStore
+    };
+
+    public async ValueTask<HtmxRender> ExecuteAsync(
+        HtmxorActionContext context,
+        CancellationToken cancellationToken)
+    {
+        await contacts.DeleteAsync(
+            context.RouteValues.GetRequired<Guid>("id"),
+            cancellationToken);
+
+        return HtmxRender.Fragments("contact-list", "contact-count");
+    }
+}
+```
+
+Policies and results are easy to inspect and unit test. The cost is a handler type and policy object for every action. Route knowledge moves out of the component and starts to resemble the controller split Htmxor exists to remove.
+
+### Comparison and synthesis
+
+The compiled-event design has the smallest interface, but it either rejects common Razor expressions or forces the implementation back into render-time event discovery. It is easy to write and too easy to make ambiguous.
+
+Static local actions expose slightly more, but they make familiar ASP.NET binding annotations, dependency injection, authorization metadata, and antiforgery statically available before rendering. The implementation can stay on public framework seams if the binding spike proves equivalent behavior. This is the best depth tradeoff.
+
+Typed action references make route construction safer, but they also hide the `hx-*` verb and introduce generated types at every call site. Literal URLs plus build-time diagnostics are a better v1 default. Typed references can remain an optional later addition.
+
+Separate policy objects maximize control and testability. They lose the locality that distinguishes Htmxor. Their immutable policy and result types are still useful inside the generated implementation.
+
+The synthesis is therefore:
+
+1. use static, verb-decorated methods in the `.razor` file for stable actions;
+2. return immutable `HtmxRender` values;
+3. keep ordinary `hx-*` markup and validate statically resolvable routes;
+4. compile immutable endpoint policies internally;
+5. support current event syntax only where the build can lower it to the same action descriptor without runtime replay.
+
+## Recommended application setup
+
+The application registers Htmxor once. Both normal Blazor endpoints and direct Htmxor endpoints live under the same route group so common endpoint conventions apply structurally:
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services
+    .AddAuthentication()
+    .AddCookie();
+
+builder.Services.AddAuthorization(options =>
+{
+    options.AddPolicy("Contacts.Read", policy =>
+        policy.RequireAuthenticatedUser());
+
+    options.AddPolicy("Contacts.Write", policy =>
+        policy.RequireClaim("scope", "contacts.write"));
+});
+
+builder.Services
+    .AddRazorComponents()
+    .AddInteractiveServerComponents()
+    .AddInteractiveWebAssemblyComponents()
+    .AddHtmxor(options =>
+    {
+        options.Assets = HtmxAssets.ApplicationOwned;
+        options.Errors.DefaultComponent = typeof(DefaultHtmxProblem);
+    });
+
+builder.Services.AddOutputCache();
+builder.Services.AddRateLimiter(options =>
+    options.AddFixedWindowLimiter("ui", limiter =>
+    {
+        limiter.PermitLimit = 100;
+        limiter.Window = TimeSpan.FromMinutes(1);
+        limiter.QueueLimit = 0;
+    }));
+
+var app = builder.Build();
+
+app.UseAuthentication();
+app.UseAuthorization();
+app.UseRateLimiter();
+app.UseAntiforgery();
+app.UseOutputCache();
+
+var ui = app.MapGroup("")
+    .RequireRateLimiting("ui");
+
+ui.MapRazorComponents<App>()
+    .AddInteractiveServerRenderMode()
+    .AddInteractiveWebAssemblyRenderMode();
+
+ui.MapHtmxorEndpoints();
+
+app.Run();
+```
+
+`AddHtmxor` and `MapHtmxorEndpoints` are proposed names. `MapHtmxorEndpoints` consumes the generated catalog. It does not scan assemblies or reflect over the private `RazorComponentsEndpointConventionBuilder` implementation. If the application inserts antiforgery middleware explicitly, it runs after authentication and authorization as shown.
+
+The route group is important. Authorization, CORS, rate limiting, host restrictions, and other conventions applied to `ui` cover both endpoint families. Per-component and per-action attributes add narrower metadata.
+
+## Reachability examples
+
+Plain `@page` remains dual by default for compatibility:
+
+```razor
+@page "/contacts"
+```
+
+The explicit equivalent is:
+
+```razor
+@page "/contacts"
+@attribute [HtmxReachability(HtmxReachabilityMode.Both)]
+```
+
+A normal-only page opts out of direct HTMX routing:
+
+```razor
+@page "/account/security"
+@attribute [HtmxReachability(HtmxReachabilityMode.NormalOnly)]
+```
+
+An HTMX-only component keeps the existing `[HtmxRoute]` idea and has no `@page`:
+
+```razor
+@attribute [HtmxRoute(
+    "/contacts/suggestions",
+    Methods = [HttpMethods.Get])]
+@attribute [HtmxReachability(HtmxReachabilityMode.HtmxOnly)]
+```
+
+`HtmxReachabilityMode.HtmxOnly` is a representation constraint. It is not authorization. A caller can forge `HX-Request`.
+
+An HTMX-only URL is not automatically a valid browser-history location. A literal `hx-push-url` or boosted navigation to it is a build diagnostic unless the application declares a normal full-page fallback for that URL.
+
+## One complete component
+
+The following component shows the proposed route, local actions, inline fragments, multi-fragment results, standard endpoint policies, and honest execution behavior in one file.
+
+```razor
+@page "/contacts"
+@attribute [HtmxReachability(HtmxReachabilityMode.Both)]
+@attribute [HtmxLayout(typeof(ContactsHtmxLayout))]
+@attribute [Authorize(Policy = "Contacts.Read")]
+@attribute [EnableRateLimiting("ui")]
+@attribute [RequestSizeLimit(32_768)]
+@attribute [HtmxError(
+    typeof(ContactNotFoundException),
+    typeof(ContactNotFoundFragment),
+    StatusCode = StatusCodes.Status404NotFound)]
+@inject ContactStore ContactStore
+@inject HtmxContext Htmx
+
+<PageTitle>Contacts</PageTitle>
+
+<HtmxFragment Name="editor">
+    <EditForm id="editor"
+              Model="Input"
+              FormName="create-contact"
+              hx-post="/contacts"
+              hx-target="#contact-list"
+              hx-swap="outerHTML">
+        <AntiforgeryToken />
+        <DataAnnotationsValidator />
+        <HtmxServerValidation Messages="Validation" />
+        <InputText @bind-Value="Input.Name" />
+        <ValidationSummary />
+        <button type="submit">Add</button>
+    </EditForm>
+</HtmxFragment>
+
+<HtmxFragmentElement Name="contact-list" Id="contact-list">
+    <ul>
+        @foreach (var contact in Contacts)
+        {
+            <li>
+                @contact.Name
+                <button hx-delete="/contacts/@contact.Id"
+                        hx-target="#contact-list"
+                        hx-swap="outerHTML">
+                    Delete
+                </button>
+            </li>
+        }
+    </ul>
+</HtmxFragmentElement>
+
+<HtmxFragment Name="contact-count">
+    <span id="contact-count" hx-swap-oob="outerHTML">
+        @Contacts.Count contact(s)
+    </span>
+</HtmxFragment>
+
+<HtmxFragment Name="toast" RenderDuringStandardRequest="false">
+    <div id="toast" hx-swap-oob="outerHTML" role="status">
+        Contact saved.
+    </div>
+</HtmxFragment>
+
+@code {
+    [Parameter]
+    public ContactInput Input { get; set; } = new();
+
+    [Parameter]
+    public HtmxValidationState Validation { get; set; }
+        = HtmxValidationState.Empty;
+
+    private IReadOnlyList<Contact> Contacts { get; set; } = [];
+
+    protected override async Task OnParametersSetAsync()
+    {
+        // Full requests include every fragment. A selected response includes
+        // only the named fragments. The owning component lifecycle still runs.
+        if (Htmx.Selection.IncludesAny("contact-list", "contact-count"))
+        {
+            Contacts = await ContactStore.ListAsync();
+        }
+    }
+
+    [HtmxPost]
+    [Authorize(Policy = "Contacts.Write")]
+    private static async Task<HtmxRender> CreateAsync(
+        [FromForm] ContactInput input,
+        ContactStore contacts,
+        CancellationToken cancellationToken)
+    {
+        var result = await contacts.CreateAsync(input, cancellationToken);
+
+        return result.IsValid
+            ? HtmxRender
+                .Fragments("contact-list", "contact-count", "toast")
+                .Trigger(HtmxEvent.AfterSwap(
+                    "contacts:changed",
+                    new { result.ContactId }))
+            : HtmxRender
+                .HandledError(
+                    "editor",
+                    StatusCodes.Status422UnprocessableEntity)
+                .WithParameters(new
+                {
+                    Input = input,
+                    Validation = HtmxValidationState.From(result.Errors)
+                })
+                .Retarget(HtmxTarget.Id("editor"));
+    }
+
+    [HtmxDelete("{id:guid}")]
+    [Authorize(Policy = "Contacts.Write")]
+    private static async Task<HtmxRender> DeleteAsync(
+        Guid id,
+        ContactStore contacts,
+        CancellationToken cancellationToken)
+    {
+        await contacts.DeleteAsync(id, cancellationToken);
+
+        return HtmxRender.Fragments("contact-list", "contact-count");
+    }
+}
+```
+
+The proposed action templates are relative to the owning component route:
+
+```text
+GET     /contacts             render Contacts
+POST    /contacts             invoke CreateAsync, then render its selection
+DELETE  /contacts/{id:guid}   invoke DeleteAsync, then render its selection
+```
+
+If a component has several `@page` routes, a relative action must identify its base route. Ambiguous routes fail the build.
+
+Static action methods use familiar ASP.NET binding annotations and injected parameter shapes. Htmxor's generated binder must implement and test the promised subset; it is not automatically the Minimal API binder. The implementation does not have to instantiate a Blazor component to invoke the action. After the mutation, Htmxor creates a new component response through the public Razor rendering path.
+
+`HtmxServerValidation` is a proposed small component that copies `HtmxValidationState` into the current form's `ValidationMessageStore`. That makes application validation visible in the fresh render. Malformed input that fails generated binding before the action still needs the separate binding-error contract listed in the prototype gates below.
+
+Generated actions are HTMX-only in the proposed v1 contract. An exact `HX-Request: true` selects the generated POST or DELETE candidate. Without that header, the candidate is ineligible and normal Blazor form handling applies if the application declared it; otherwise the request receives the normal 405/404 result. The example therefore does not imply a no-JavaScript POST fallback. A future progressive-enhancement mode would need an explicit normal handler and Post/Redirect/Get contract rather than silently reusing an HTMX fragment action.
+
+## What the build emits
+
+The generated code is implementation detail. An approximate catalog entry makes the security and performance model easier to see:
+
+```csharp
+private static void MapContacts(RouteGroupBuilder ui)
+{
+    ui.MapMethods(
+            "/contacts",
+            [HttpMethods.Get],
+            static (HttpContext context) =>
+                HtmxorResults.Render<Contacts>(context))
+        .WithName("Htmxor.Contacts.GET")
+        .WithMetadata(new HtmxorCandidateMetadata(
+            routeFamily: "Contacts.GET",
+            kind: HtmxorCandidateKind.DirectGet))
+        .RequireAuthorization("Contacts.Read")
+        .RequireRateLimiting("ui");
+
+    ui.MapMethods(
+            "/contacts",
+            [HttpMethods.Post],
+            ContactsActions.DispatchCreateAsync)
+        .WithName("Htmxor.Contacts.POST.Create")
+        .WithMetadata(
+            new HtmxorCandidateMetadata(
+                "Contacts.POST.Create",
+                HtmxorCandidateKind.HtmxAction),
+            new RequireAntiforgeryTokenAttribute(),
+            HtmxorCachePolicy.UnsafeNoStore)
+        .RequireAuthorization("Contacts.Read")
+        .RequireAuthorization("Contacts.Write")
+        .RequireRateLimiting("ui");
+
+    ui.MapMethods(
+            "/contacts/{id:guid}",
+            [HttpMethods.Delete],
+            ContactsActions.DispatchDeleteAsync)
+        .WithName("Htmxor.Contacts.DELETE.Delete")
+        .WithMetadata(
+            new HtmxorCandidateMetadata(
+                "Contacts.DELETE.Delete",
+                HtmxorCandidateKind.HtmxAction),
+            new RequireAntiforgeryTokenAttribute(),
+            HtmxorCachePolicy.UnsafeNoStore)
+        .RequireAuthorization("Contacts.Read")
+        .RequireAuthorization("Contacts.Write")
+        .RequireRateLimiting("ui");
+}
+```
+
+The matching normal GET endpoint receives `HtmxorCandidateKind.NormalPage` and the same route-family id through a supported endpoint convention. A public `MatcherPolicy`/`IEndpointSelectorPolicy` runs during routing:
+
+```csharp
+public sealed class HtmxorCandidateMatcherPolicy
+    : MatcherPolicy, IEndpointSelectorPolicy
+{
+    public override int Order => HtmxorMatcherOrder.AfterHttpMethod;
+
+    public bool AppliesToEndpoints(IReadOnlyList<Endpoint> endpoints) =>
+        endpoints.Any(endpoint =>
+            endpoint.Metadata.GetMetadata<HtmxorCandidateMetadata>()
+                is not null);
+
+    public Task ApplyAsync(
+        HttpContext context,
+        CandidateSet candidates)
+    {
+        var historyRestore =
+            HtmxHeaders.IsExactlyTrue(
+                context.Request.Headers["HX-History-Restore-Request"]);
+
+        var directRequest = !historyRestore &&
+            HtmxHeaders.IsExactlyTrue(
+                context.Request.Headers["HX-Request"]);
+
+        foreach (var routeFamily in candidates.HtmxorRouteFamilies())
+        {
+            routeFamily.KeepOnly(directRequest
+                ? HtmxorCandidateKind.DirectGetOrHtmxAction
+                : HtmxorCandidateKind.NormalPage);
+        }
+
+        return Task.CompletedTask;
+    }
+}
+```
+
+`AddHtmxor` registers this public matcher as a singleton `MatcherPolicy`. Its exact order relative to built-in method/host matching is part of the routing prototype, not an arbitrary value exposed to applications.
+
+This header check is necessarily a routing discriminator, before authorization. It grants no permission: direct and normal GET paths enforce equivalent route-group and component base policies, while an action enforces those policies plus its action-specific restrictions. The normal path retains stock Blazor authorization semantics; the generated direct endpoint lifts the component requirements into endpoint metadata. History restoration always selects a full normal page, even if a misconfigured client also sends `HX-Request`.
+
+Both the matcher and the convention that tags stock Razor candidates must be proved on public ASP.NET APIs. If the stock candidate cannot be tagged without private reflection, this same-path candidate design is not ready for v1.
+
+Metadata alone is not the unsafe-verb enforcement mechanism. Every generated unsafe dispatcher validates before it binds request data or calls application code:
+
+```csharp
+private static async Task<IResult> DispatchDeleteAsync(
+    HttpContext context)
+{
+    if (!await HtmxorAntiforgery.IsValidAsync(context))
+    {
+        return HtmxorResults.AntiforgeryRejected();
+    }
+
+    var arguments = await ContactsActionBinding
+        .BindDeleteAsync(context);
+
+    var contacts = context.RequestServices
+        .GetRequiredService<ContactStore>();
+
+    var render = await Contacts.DeleteAsync(
+        arguments.Id,
+        contacts,
+        context.RequestAborted);
+
+    return HtmxorResults.RenderNoStore<Contacts>(context, render);
+}
+```
+
+The helper reuses the middleware verdict when it exists and validates explicitly otherwise:
+
+```csharp
+public static async ValueTask<bool> IsValidAsync(HttpContext context)
+{
+    var validation = context.Features
+        .Get<IAntiforgeryValidationFeature>();
+
+    if (validation is not null)
+    {
+        return validation.IsValid;
+    }
+
+    var antiforgery = context.RequestServices
+        .GetRequiredService<IAntiforgery>();
+
+    return await antiforgery.IsRequestValidAsync(context);
+}
+```
+
+This avoids repeating POST/PUT/PATCH form parsing and cryptography after `UseAntiforgery`, while explicitly covering DELETE and configurations where middleware produced no verdict. An invalid verdict returns a generic 400 with `Cache-Control: private, no-store`; it carries no handled-fragment marker, and neither binding nor application code runs. Genuine service/configuration failures still propagate to the exception handler. The [`IAntiforgery` guidance](https://learn.microsoft.com/en-us/aspnet/core/security/anti-request-forgery?view=aspnetcore-10.0#http-method-limitations-and-httpmethodoverridemiddleware-interaction) explicitly calls for validation on DELETE. Regression tests cover failed middleware verdicts, missing/invalid DELETE tokens, missing cookie/header values, binder/action non-invocation, and the generic production response. The build-time binding spike must prove route, query, form, nullability, conversion-error, and validation behavior on this ordering.
+
+The generator also reports:
+
+- duplicate routes, methods, endpoint names, or fragment names;
+- unsafe component routes without a declared action;
+- a statically resolvable `hx-post`, `hx-put`, `hx-patch`, or `hx-delete` with no matching declared endpoint;
+- a statically resolvable verb mismatch;
+- an action that returns an unknown literal fragment name;
+- a statically resolvable pushed/history URL that has no full-page representation;
+- an HTMX target inside a known interactive Blazor root;
+- an arbitrary fragment predicate that affects output caching but declares no variation fields.
+
+Client markup supplies evidence for diagnostics. It never creates an endpoint. The action attribute and component route remain the server authority.
+
+The analyzer may follow statically known child-component usages and literal `hx-get`, `hx-post`, `hx-put`, `hx-patch`, and `hx-delete` values to report a missing or mismatched declaration. It cannot soundly infer authority from a computed URL, attribute splat, conditional render, or reusable child that targets a different component. Those cases remain runtime links to an explicitly declared server action.
+
+## Public Razor static rendering
+
+The direct endpoint should render an ordinary response host with `RazorComponentResult`:
+
+```csharp
+private static IResult Render<TPage>(
+    HttpContext context,
+    HtmxRender render,
+    IReadOnlyDictionary<string, object?> pageParameters)
+    where TPage : IComponent
+{
+    var plan = HtmxRenderPlan.Create(context, render);
+    var hostParameters = new Dictionary<string, object?>
+    {
+        [nameof(HtmxorResponseHost<TPage>.PageParameters)] = pageParameters,
+        [nameof(HtmxorResponseHost<TPage>.Plan)] = plan
+    };
+
+    return new RazorComponentResult<HtmxorResponseHost<TPage>>(
+        hostParameters)
+    {
+        ContentType = "text/html; charset=utf-8",
+        StatusCode = plan.StatusCode,
+        PreventStreamingRendering = plan.MustChooseBeforeHeaders
+    };
+}
+```
+
+`HtmxorResponseHost<TPage>` is an ordinary Razor component. It cascades the typed request and render plan, applies the selected `HtmxLayout`, and renders the owning page. `HtmxFragment` checks the plan before invoking its child content. Htmxor does not replace Blazor's private endpoint invoker or copy its HTML renderer.
+
+`pageParameters` is produced by generated route/query conversion; `RazorComponentResult` does not bind route values to component parameters automatically. The complete plan, including status and selected error component, must exist before the result is returned. `PreventStreamingRendering` waits for quiescence but does not make late status changes or post-render error selection possible. A behavior that can fail during rendering either needs an already selected error result or a separately proved buffering result.
+
+This approach borrows Rizzy's public component-result seam while preserving Htmxor's component-owned route and inline fragments. The result type and its static SSR behavior are documented by the [`RazorComponentResult` API](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.http.httpresults.razorcomponentresult?view=aspnetcore-10.0).
+
+## Inline, multiple, layout, and OOB output
+
+`Name` extends the current fragment interface without removing target matching:
+
+```razor
+<HtmxFragmentElement Name="contact-list" Id="contact-list">
+    ...
+</HtmxFragmentElement>
+```
+
+The selection rules are:
+
+1. A normal request renders the whole page.
+2. A direct request with no explicit result can match `HX-Target` to `HtmxFragmentElement.Id`, preserving current behavior.
+3. `HtmxRender.Fragment("contact-list")` selects one named region.
+4. `HtmxRender.Fragments("contact-list", "contact-count", "toast")` selects several regions in source order.
+5. Secondary regions declare ordinary `hx-swap-oob` markup or flow through existing `SectionContent` and `SectionOutlet` layout outlets.
+
+The HTMX layout remains simple:
+
+```razor
+@inherits HtmxLayoutComponentBase
+
+<SectionOutlet SectionName="notifications" />
+@Body
+<ToastOutlet />
+```
+
+The page supplies that outlet through standard Blazor sections:
+
+```razor
+<SectionContent SectionName="notifications">
+    <aside id="notifications" hx-swap-oob="outerHTML">
+        Contact saved.
+    </aside>
+</SectionContent>
+```
+
+There is no application-level OOB service that concatenates arbitrary HTML. The component and layout own the markup.
+
+## Honest execution semantics
+
+Named fragment selection controls output, not the entire component lifecycle.
+
+For a request selecting `contact-list`:
+
+- routing, authorization, parameter binding, component construction, and the owning component lifecycle run;
+- child content under `contact-list` runs;
+- child content under an unselected fragment need not run if `HtmxFragment` rejects it before invoking the render fragment;
+- work placed directly in the owning component lifecycle still runs unless the developer gates it with `Htmx.Selection`;
+- Htmxor does not promise that an arbitrary span of Razor source becomes an independently executable function.
+
+The practical default is to put expensive fragment-specific loading inside a child component under that fragment. `Htmx.Selection.Includes` exists for the cases where the owning component must coordinate loading. This adopts templ's documented execution honesty without forcing a separate Go-style handler for every response.
+
+## Typed request and response protocol
+
+The existing `HtmxContext` is worth keeping. Its request values should parse the htmx protocol exactly and make untrusted values hard to mistake for server facts:
+
+```csharp
+public sealed record HtmxRequest
+{
+    public bool IsRequest { get; init; }
+    public bool IsBoosted { get; init; }
+    public bool IsHistoryRestore { get; init; }
+
+    // Client supplied. Useful for representation selection, never authorization.
+    public Uri? ClientCurrentUrl { get; init; }
+
+    // Set only when the supplied URL matches the active scheme, host, and port.
+    public PathString? SameOriginCurrentPath { get; init; }
+
+    public HtmxTarget? Target { get; init; }
+    public HtmxTrigger? Trigger { get; init; }
+    public string? TriggerName { get; init; }
+    public string? Prompt { get; init; }
+}
+```
+
+Developer code remains concise:
+
+```csharp
+if (Htmx.Request.Target == HtmxTarget.Id("contact-list"))
+{
+    // Select a representation. Do not make an authorization decision here.
+}
+```
+
+Boolean request headers count as true only when there is exactly one value and that value is `true`. Header presence alone is insufficient. URL-valued headers are parsed and same-origin checked before Htmxor exposes a local path.
+
+The immutable `HtmxRender` result contains typed response parts:
+
+```csharp
+return HtmxRender
+    .Fragments("contact-list", "contact-count")
+    .Retarget(HtmxTarget.Id("contact-list"))
+    .Reswap(HtmxSwap.OuterHtml)
+    .Trigger(HtmxEvent.AfterSwap(
+        "contacts:changed",
+        new { ContactId = id }));
+```
+
+This borrows Htmx.Net's typed protocol helpers and axum-htmx's typed extractors and response parts. The protocol types remain usable outside component rendering.
+
+## Automatic cache variation
+
+Generated endpoint metadata knows which request fields can select a different representation. Htmxor always uses those facts for the HTTP `Vary` header. The same facts can drive ASP.NET output-cache lookup only on a response class that Htmxor can mechanically prove is safe to store.
+
+The rules are deterministic:
+
+- dual reachability adds `HX-Request`;
+- a target condition adds `HX-Target`;
+- a trigger condition adds `HX-Trigger`;
+- a history-restore branch adds `HX-History-Restore-Request`;
+- existing `Vary` values are merged case-insensitively;
+- user-specific output still uses `private`, `no-store`, or an appropriate application cache policy.
+
+The component does not repeat those headers. The following attribute is illustrative of a future cache opt-in, not a v1 guarantee until the token-free proof below exists:
+
+```razor
+@page "/contacts"
+@attribute [OutputCache(PolicyName = "Contacts.Read")]
+
+<HtmxFragmentElement Id="contact-list" Name="contact-list">
+    ...
+</HtmxFragmentElement>
+```
+
+The generated dual endpoint varies by `HX-Request`. Because selection can use the target id, it also varies by `HX-Target`:
+
+```http
+Vary: HX-Request, HX-Target
+```
+
+That response header and ASP.NET's output-cache key are separate operations. A simple generated endpoint can express the lookup variation with the public builder:
+
+```csharp
+endpoint.CacheOutput(policy => policy
+    .SetVaryByHeader("HX-Request", "HX-Target"));
+```
+
+`SetVaryByHeader` affects the ASP.NET output-cache key; it does not emit the HTTP `Vary` response header. The two operations are deliberately shown separately. See the public [`OutputCachePolicyBuilder` API](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.outputcaching.outputcachepolicybuilder.setvarybyheader?view=aspnetcore-10.0).
+
+For a stable implementation, Htmxor should not place arbitrary attacker-supplied target strings into an unbounded cache key. Its generated `IOutputCachePolicy` first maps headers to a declared representation:
+
+```csharp
+public ValueTask CacheRequestAsync(
+    OutputCacheContext context,
+    CancellationToken cancellationToken)
+{
+    var representation = ContactsRepresentations.TrySelect(
+        context.HttpContext.Request.Headers);
+
+    if (representation is null)
+    {
+        context.AllowCacheLookup = false;
+        context.AllowCacheStorage = false;
+        HtmxorCacheHeaders.RequirePrivateNoStore(
+            context.HttpContext.Response);
+        return ValueTask.CompletedTask;
+    }
+
+    context.CacheVaryByRules.VaryByValues["htmxor"] =
+        representation.CacheKey; // e.g. "normal" or "direct:contact-list"
+
+    return ValueTask.CompletedTask;
+}
+```
+
+The response stage separately merges the declared request-header names into HTTP `Vary`. Unknown target or trigger values disable lookup and storage; they do not create new cache keys.
+
+An arbitrary predicate must declare what it reads:
+
+```razor
+<HtmxFragment Name="search-results"
+              Match="@(request => request.Target?.Value == SearchTarget)"
+              VaryBy="HtmxVary.Target">
+    ...
+</HtmxFragment>
+```
+
+If the dependency cannot be stated, Htmxor should disable shared caching for that representation rather than guess. `Vary` prevents representation collisions. It does not make authenticated or personalized output safe for a shared cache.
+
+Every unsafe-action response is `private, no-store` regardless of copied component cache metadata. A response that contains a hidden or meta antiforgery request token must also never be stored in a shared output cache; the token is tied to the current antiforgery cookie and possibly the current identity.
+
+The stable rule is fail-closed: Razor component output is not stored by default, and an unproved, unknown-selector, or dynamically composed representation receives both ASP.NET `NoCache()` and `Cache-Control: private, no-store`. It is insufficient to disable storage only when the generator happens to find an `AntiforgeryToken`, because an earlier cache lookup could serve a token stored by an unobserved nested component. The same `private, no-store` response prevents intermediary caches from creating raw variants for attacker-supplied target or trigger values.
+
+Shared anonymous caching enters v1 only if a prototype supplies a mechanical, runtime-enforced token-free response class with canonical selector keys. Until then, Htmxor still emits correct HTTP `Vary`, but no component HTML is cacheable by the server, browser, or intermediary.
+
+This adopts Htmx.Net's explicit variation support, django-htmx's cache guidance, and axum-htmx's automatic variation.
+
+## Endpoint policy and request conditions
+
+Standard ASP.NET metadata remains the policy interface:
+
+```razor
+@page "/contacts"
+@attribute [Authorize(Policy = "Contacts.Read")]
+@attribute [EnableRateLimiting("ui")]
+@attribute [RequestSizeLimit(32_768)]
+@attribute [OutputCache(PolicyName = "Contacts.Read")]
+```
+
+Actions can add authorization requirements:
+
+```csharp
+[HtmxDelete("{id:guid}")]
+[Authorize(Policy = "Contacts.Write")]
+private static Task<HtmxRender> DeleteAsync(...) => ...;
+```
+
+Generated HTMX endpoints receive the same component metadata and route-group conventions as the normal endpoint. Authorization policies compose with AND semantics, so the generated delete endpoint requires both `Contacts.Read` and `Contacts.Write`.
+
+“Action metadata is additive” is too broad for metadata whose meaning is override-based. The proposed v1 precedence is explicit:
+
+| Policy | Generated action rule |
+| --- | --- |
+| Authorization | Route-group, component, and action policies all apply |
+| `AllowAnonymous` | It cannot coexist with a protected generated action at route-group, component, or action scope. Source-known conflicts fail the build; route-group conflicts fail startup validation |
+| Antiforgery | Required and explicitly validated for every unsafe verb; no action opt-out in v1 |
+| Rate limiting | Exactly one effective named policy is compiled. Matching group/component declarations are retained; conflicting names fail build/startup validation because ASP.NET rate-limit metadata is override-based. An action cannot replace it or apply `DisableRateLimiting` in v1 |
+| Request size | Htmxor computes the minimum finite value across group, component, and action metadata, appends that effective limit with final precedence, and rejects `DisableRequestSizeLimit` or a requested increase |
+| Output cache | Unsafe actions are always `private, no-store`; an action may make a safe response less cacheable |
+
+Exact `HX-Request` and history-restore values run during routing only to choose an eligible representation candidate. Authentication, authorization, rate limiting, antiforgery, request limits, and binding then run for the selected endpoint. Target, trigger, and named-fragment selection occurs after those gates and cannot change endpoint policy.
+
+The shared route group is the supported place for conventions that must cover both endpoint families. A convention attached only to the `MapRazorComponents` builder does not automatically reach separately generated endpoints. At startup, `MapHtmxorEndpoints` compares security-relevant effective metadata for every normal/direct route family and fails on missing authorization, anonymous override, limiter, host, request-size, or other protected parity. A future composite convention builder may forward conventions to both families; v1 must not silently assume that forwarding happened.
+
+`HX-Request`, `HX-Target`, `HX-Trigger`, fragment names, and action URLs are forgeable input. They may choose among representations that already carry equivalent base policies. They never authorize an action or enable a method.
+
+This is the RazorX idea adapted to Htmxor: ordinary endpoint policies without a per-component Minimal API mapping.
+
+## Unsafe verbs and authentication flows
+
+Every generated POST, PUT, PATCH, and DELETE endpoint requires antiforgery by default. The endpoint validates the token before action invocation. DELETE is not a special case.
+
+Forms use the standard Blazor token:
+
+```razor
+<EditForm hx-post="/contacts" ...>
+    <AntiforgeryToken />
+    ...
+</EditForm>
+```
+
+Non-form controls such as `hx-delete` need the same protection. `HtmxHeadOutlet` can emit the ASP.NET request token in a meta element, and the separately versioned Htmxor browser adapter adds the configured antiforgery header to unsafe same-origin requests. Any full response containing that per-request meta token is marked `private, no-store`. The antiforgery cookie remains `HttpOnly`; Htmxor does not create a second JavaScript-readable token cookie on every response.
+
+Under htmx 2, DELETE parameters are URL encoded by default. Generated DELETE binding therefore reads declared route values first and query values for remaining inputs; it must not assume the htmx 1 form-body behavior. Antiforgery still comes from the configured header and is validated before that binding.
+
+Cookie authentication can opt into HTMX-aware redirects:
+
+```csharp
+builder.Services
+    .AddAuthentication()
+    .AddCookie(options =>
+    {
+        options.LoginPath = "/account/login";
+        options.AccessDeniedPath = "/account/denied";
+
+        options.Events.UseHtmxorRedirects(
+            HtmxorAuthNavigation.FullPage);
+    });
+```
+
+Normal requests retain normal cookie redirects. An exact HTMX request receives `HX-Redirect` to a validated local URL and an explicitly selected non-3xx status, such as 401 or 403, so the login document does not get swapped into a page fragment. htmx does not process response headers from an intercepted 3xx response, as its [`HX-Redirect` contract](https://htmx.org/headers/hx-redirect/) notes. The adapter composes with application cookie events instead of replacing them, and tests multiple cookie schemes as well as login and access-denied paths.
+
+This adopts htmx-spring-boot's unsafe-verb CSRF and authentication-flow handling while retaining ASP.NET authorization and antiforgery.
+
+## Error selection
+
+FastHX's error selector becomes a component-scoped declaration:
+
+```razor
+@attribute [HtmxError(
+    typeof(ContactNotFoundException),
+    typeof(ContactNotFoundFragment),
+    StatusCode = StatusCodes.Status404NotFound)]
+
+@attribute [HtmxError(
+    typeof(ContactValidationException),
+    typeof(ContactValidationFragment),
+    StatusCode = StatusCodes.Status422UnprocessableEntity)]
+```
+
+The error component receives `ProblemDetails` and declared parameters:
+
+```razor
+@* ContactNotFoundFragment.razor *@
+@code {
+    [Parameter, EditorRequired]
+    public required ProblemDetails Problem { get; set; }
+}
+
+<section id="contact-problem" role="alert">
+    <h2>Contact not found</h2>
+    <p>@Problem.Detail</p>
+</section>
+```
+
+Known application failures select declared HTML. Authorization, antiforgery, binding, and request-size failures occur before the selector. Unexpected exceptions continue to ASP.NET's exception handler. The v1-safe case is an action or generated loader outcome known before `RazorComponentResult` begins. Mapping arbitrary component-lifecycle/render exceptions requires a separately proved buffering result and is not implied by `[HtmxError]`.
+
+htmx 2 does not swap 4xx or 5xx bodies by default. Both an `[HtmxError]` mapping and an action's explicit `HtmxRender.HandledError(...)` declare an application-error fragment. Htmxor buffers that result and adds the marker only after the error fragment renders successfully. Calling `.WithStatus(422)` alone does not mark a response as handled.
+
+```http
+HTTP/1.1 422 Unprocessable Entity
+HXOR-Fragment-Response: true
+HX-Retarget: #editor
+```
+
+The small browser adapter changes swap handling only for that server marker:
+
+```javascript
+document.addEventListener("htmx:beforeSwap", event => {
+  const handled = event.detail.xhr
+    .getResponseHeader("HXOR-Fragment-Response") === "true";
+
+  if (handled) {
+    event.detail.shouldSwap = true;
+    event.detail.isError = false;
+  }
+});
+```
+
+An undeclared 404, binding failure, antiforgery failure, or unexpected 500 has no marker and retains htmx's normal no-swap/error behavior. This is narrower than globally configuring every 4xx response to swap. It follows htmx's documented [`responseHandling` and 422 behavior](https://htmx.org/docs/#response-handling) while letting the server distinguish an intentional error fragment from a transport or security failure.
+
+A global fallback remains available at registration:
+
+```csharp
+builder.Services.AddHtmxor(options =>
+    options.Errors.DefaultComponent = typeof(DefaultHtmxProblem));
+```
+
+## Runtime independence and extension contract
+
+Htmxor's server package should neither contain an htmx script nor declare a JavaScript-version dependency. It should not inspect `htmx.version`, reject an unknown browser runtime, or make a tested patch version an installation requirement. The application owns the htmx runtime, its configuration, extensions, load order, CSP, and upgrade schedule.
+
+The default application setup is therefore ordinary application code:
+
+```razor
+<head>
+    <meta name="htmx-config"
+          content='@ApplicationHtmxConfiguration' />
+
+    <HtmxHeadOutlet Nonce="@CspNonce" />
+
+    <script type="module"
+            src="/js/application-htmx.js"
+            nonce="@CspNonce"></script>
+</head>
+```
+
+`HtmxHeadOutlet` has a deliberately narrow role: emit Htmxor-owned metadata such as the antiforgery request token and the handled-fragment marker. It obtains the token with `IAntiforgery.GetAndStoreTokens`, which also establishes the framework's no-cache/no-store response headers; it must not use the non-storing `GetTokens` shortcut. It emits neither htmx nor an `htmx-config` schema.
+
+The application can use any htmx distribution and load native htmx extensions normally:
+
+```javascript
+import htmx from "/vendor/htmx/htmx.esm.js";
+import "/vendor/htmx/extensions/response-targets.js";
+
+import {
+  createHtmxorBridge,
+  antiforgery,
+  handledFragments
+} from "/_content/Htmxor/browser-core.js";
+
+import { adaptHtmx2 } from "/_content/Htmxor/browser-htmx2.js";
+
+const bridge = createHtmxorBridge({
+  plugins: [antiforgery(), handledFragments()]
+});
+
+adaptHtmx2(htmx).connect(bridge);
+```
+
+The names are illustrative, but the ownership boundary is not: `browser-core` contains Htmxor behavior without importing htmx, while the small runtime adapter translates the selected htmx release's public lifecycle events. A future runtime that changes event names or event details needs a new adapter, not a new server package.
+
+The adapter contract should normalize only the lifecycle Htmxor actually needs:
+
+```typescript
+export interface HtmxorRuntimeAdapter {
+  readonly id: string;
+  readonly runtimeVersion?: string; // diagnostics only
+  connect(bridge: HtmxorBrowserBridge): Disposable;
+}
+
+export interface HtmxorBrowserBridge {
+  configureRequest(request: NormalizedRequest): void;
+  inspectResponse(response: NormalizedResponse): SwapDecision;
+  afterSwap(update: NormalizedDomUpdate): void;
+  afterSettle(update: NormalizedDomUpdate): void;
+}
+```
+
+For example, an application could adapt a future release immediately:
+
+```javascript
+const htmxNextAdapter = {
+  id: "league-htmx-next",
+  runtimeVersion: htmx.version,
+
+  connect(bridge) {
+    const disposals = [
+      onHtmxNextRequest(event =>
+        bridge.configureRequest(normalizeNextRequest(event))),
+      onHtmxNextBeforeSwap(event =>
+        applyDecision(event,
+          bridge.inspectResponse(normalizeNextResponse(event))))
+    ];
+
+    return { dispose: () => disposals.forEach(dispose => dispose()) };
+  }
+};
+
+htmxNextAdapter.connect(bridge);
+```
+
+Htmxor should publish a maintained htmx 2 reference adapter and may publish a separate htmx 4 preview adapter. Neither adapter includes htmx or constrains which htmx version the application serves. Optional asset bundles may exist as conveniences, but they are never transitive dependencies of the server or browser-adapter packages.
+
+This split follows the extension points htmx itself exposes. Htmx 2 supports request-header changes through `htmx:configRequest`, swap decisions through `htmx:beforeSwap`, and client extensions through `htmx.defineExtension`. Its [`hx-ext` attribute](https://htmx.org/attributes/hx-ext/) composes extensions in markup. The [htmx 4 preview extension documentation](https://four.htmx.org/docs/extensions/using-extensions) already describes a different registration and event-hook model, which is evidence against freezing Htmxor around one JavaScript API.
+
+### Unknown markup is valid markup
+
+Razor already permits arbitrary attributes, and Htmxor should preserve that property:
+
+```razor
+<button hx-post="/contacts"
+        hx-ext="toast"
+        hx-toast="success"
+        hx-some-future-feature="value">
+    Save
+</button>
+```
+
+Analyzers may understand known attributes and diagnose known-invalid combinations. They must not reject or strip an unknown `hx-*` attribute. Client extensions remain native htmx JavaScript; Htmxor should not wrap every htmx extension API.
+
+### Typed server protocol extensions
+
+New htmx or application extensions may introduce request and response headers. The public server seam should be one declarative registry rather than unrestricted per-request middleware:
+
+```csharp
+builder.Services.AddHtmxor(options =>
+    options.Protocol.Use<ToastProtocol>());
+```
+
+```csharp
+public sealed class ToastProtocol : IHtmxorProtocolExtension
+{
+    public static readonly HtmxorRequestFeature<ToastPreference> Preference =
+        HtmxorRequestFeature.Create<ToastPreference>("toast.preference");
+
+    public static readonly HtmxorResponseFeature<ToastMessage> Show =
+        HtmxorResponseFeature.Create<ToastMessage>("toast.show");
+
+    public void Configure(HtmxorProtocolBuilder protocol)
+    {
+        protocol.RequestHeader(
+            Preference,
+            name: "HX-Toast-Preference",
+            parser: ToastPreference.TryParse,
+            invalidValue: HtmxorInvalidValue.BadRequest,
+            affectsRepresentation: true);
+
+        protocol.ResponseHeader(
+            Show,
+            name: "HX-Toast",
+            formatter: ToastJson.Serialize,
+            kind: HtmxorHeaderKind.Opaque,
+            maxBytes: 4096);
+    }
+}
+```
+
+The component-facing interface stays small:
+
+```csharp
+var preference = Htmx.Request.Get(ToastProtocol.Preference);
+
+return HtmxRender
+    .Fragment("contact-list")
+    .With(
+        ToastProtocol.Show,
+        new ToastMessage("Contact saved", ToastKind.Success));
+```
+
+Registration compiles an immutable feature registry at startup. Parsing and formatting use that registry without reflection or service discovery on each request. A feature marked `affectsRepresentation` automatically adds its owned request header to `Vary`. Custom request values disable shared output caching by default; opting into shared caching requires a bounded canonicalizer with a finite value set.
+
+A validated raw escape hatch can exist for experimentation, but using a raw request value to influence output must force `private, no-store`, and raw response headers still pass through Htmxor's size, newline, protected-header, URL, and conflict validation. The typed registry is the supported path for a reusable extension.
+
+Protocol extensions cannot:
+
+- create a route or HTTP verb;
+- change normal-only, HTMX-only, or dual reachability;
+- remove authorization, antiforgery, rate-limit, host, cache, CSP, or request-size rules;
+- treat an HTMX header or advertised capability as trusted identity;
+- access or mutate `HttpContext` directly;
+- replace the renderer or a primary response body;
+- overwrite a core or already-owned header.
+
+The fixed request order enforces those limits:
+
+1. ASP.NET selects a generated, server-declared route and HTTP verb.
+2. Authentication, authorization, rate limiting, and request-size policies run.
+3. Htmxor validates antiforgery for every unsafe action.
+4. Htmxor parses core and registered request features.
+5. Binding and the component-local action run.
+6. Htmxor builds the immutable render result and formats registered response features.
+7. Htmxor applies final header, URL, cache, and security invariants.
+8. Static Razor rendering and response commitment run.
+
+The browser bridge may add the antiforgery header, but the server remains authoritative: omitting or changing it makes an unsafe request fail before binding or application code. Custom browser JavaScript is application code and cannot be made trustworthy by a Htmxor abstraction.
+
+### A verified htmx 2 profile, not a required version
+
+Htmxor should test and document a high-security htmx 2 profile while leaving its exact configuration in application-owned markup:
+
+```html
+<meta name="htmx-config"
+      content='{
+        "historyRestoreAsHxRequest": false,
+        "reportValidityOfForms": true,
+        "allowNestedOobSwaps": false,
+        "scrollBehavior": "instant",
+        "allowEval": false,
+        "allowScriptTags": false,
+        "includeIndicatorStyles": false
+      }'>
+```
+
+- `historyRestoreAsHxRequest: false` ensures a cache miss requests a complete page. The server matcher also treats `HX-History-Restore-Request: true` as normal-page routing for defense in depth.
+- `reportValidityOfForms: true` restores the browser's visible validity reporting before submission. Server validation remains mandatory.
+- `allowNestedOobSwaps: false` makes only top-level secondary fragments OOB responses. An application may choose different semantics and own the corresponding browser evidence.
+- `allowEval: false`, `allowScriptTags: false`, and external indicator CSS form the strict-CSP profile. An explicit compatibility profile may relax those choices.
+
+Htmxor should not mirror the entire `htmx.config` object into a C# DTO. Otherwise every new htmx option would require a Htmxor release. The adapter and conformance suite, rather than a frozen configuration type, are the compatibility seam.
+
+The generated action binder and analyzer still need runtime-specific evidence. Under the verified htmx 2 profile, DELETE values arrive in the URL by default, current `hx-on:` syntax replaces legacy `hx-on`, and history, OOB, validation, redirects, and extensions receive browser coverage. These requirements come from the official [htmx 1-to-2 migration guide](https://htmx.org/migration-guide-htmx-1/), [events](https://htmx.org/events/), [extension interface](https://htmx.org/extensions/building/), current [configuration and history guidance](https://htmx.org/docs/), and the post-prototype [2.x changelog](https://github.com/bigskysoftware/htmx/blob/master/CHANGELOG.md).
+
+## Blazor Interactive Auto coexistence
+
+The supportable first model gives HTMX and interactive Blazor separate DOM ownership:
+
+```razor
+<body>
+    <div id="htmx-shell"
+         hx-boost="true"
+         hx-target="#htmx-shell"
+         hx-history-elt
+         data-enhance-nav="false">
+        <StaticLeagueSummary />
+    </div>
+
+    <div id="blazor-shell" hx-disable>
+        <Routes @rendermode="InteractiveAuto" />
+    </div>
+
+    <script src="_framework/blazor.web.js"></script>
+</body>
+```
+
+Direct Htmxor endpoints return static SSR and may target only the HTMX-owned region. Blazor owns the interactive root. Htmxor should diagnose statically knowable targets inside that root.
+
+The ownership attributes are part of the safety contract. Without `hx-target`, a boosted request targets `body` and can replace the Blazor shell. `hx-history-elt` limits HTMX snapshots to the stable HTMX island, which must exist on every participating page. `data-enhance-nav="false"` prevents Blazor enhanced navigation from intercepting links inherited from the HTMX island. A history-cache miss still requests the full normal page; htmx restores only the declared history element from it.
+
+The following remains a prototype question rather than a v1 promise:
+
+```razor
+@page "/contacts"
+@rendermode InteractiveAuto
+@attribute [HtmxReachability(HtmxReachabilityMode.Both)]
+```
+
+The normal route should use stock Interactive Auto. The direct route would render the same component through static `RazorComponentResult`. The prototype must prove that the direct response contains no interactive markers, that neither runtime removes DOM owned by the other, and that `hx-boost` and Blazor enhanced navigation do not both own one navigation.
+
+Interactive Auto does not turn an HTMX fragment into a Server or WebAssembly component later. The two routes are separate render paths.
+
+The runtime distinction follows the [Blazor render-mode contract](https://learn.microsoft.com/en-us/aspnet/core/blazor/components/render-modes?view=aspnetcore-10.0), including the rule that an existing Auto component does not later change its selected render mode in place.
+
+## Compatibility as executable evidence
+
+The compatibility matrix records what Htmxor CI has proved. It is not a package dependency, supported-version range, or runtime allowlist:
+
+```json
+{
+  "server": {
+    "htmxor": "1.0.x",
+    "dotnet": "10.0.x",
+    "aspnetCore": "10.0.x"
+  },
+  "browserRuns": [
+    {
+      "htmx": "2.0.10",
+      "adapter": "Htmxor.Browser.Htmx2 1.0.x",
+      "claim": "verified"
+    },
+    {
+      "htmx": "4.0.0-beta.*",
+      "adapter": "Htmxor.Browser.Htmx4.Preview",
+      "claim": "preview"
+    }
+  ]
+}
+```
+
+An exact row means “verified with this runtime and adapter,” not “requires this runtime.” An application may serve a newer or custom htmx build. Htmxor never rejects it based on a claimed client version; it is simply unverified until the application or Htmxor runs the conformance suite.
+
+The conformance kit should contain raw HTTP fixtures for request parsing, selection, variation, response merging, and security ordering; fake-runtime tests for the normalized browser bridge; and Playwright tests against a caller-supplied htmx script. The public runner should cover unsafe requests, handled and unhandled 4xx responses, history restoration, redirects, OOB and preserved nodes, boosted forms, native extensions, and Blazor DOM ownership. A representative invocation might be:
+
+```text
+dotnet test Htmxor.Client.Conformance -- HtmxScript=/vendor/htmx-next.js
+```
+
+Htmxor-maintained rows run that same suite in CI and generate the published evidence table. Applications upgrading ahead of the matrix can run it against their chosen script and adapter, then record the result as externally adapted evidence.
+
+## Source-by-source adoption map
+
+| Source | Proposed Htmxor code or behavior |
+| --- | --- |
+| Htmx.Net | Keep `HtmxContext`; use exact typed request values and immutable typed response parts; calculate `Vary`; default to caller-owned htmx |
+| Rizzy | Return direct responses through public `RazorComponentResult`; retain `HtmxLayout`, inline fragments, `SectionContent`, and ordinary OOB markup |
+| RazorX | Generate ordinary endpoint metadata; let route-group, component, and action policies cover direct endpoints without per-feature mappings |
+| Django 6 / django-htmx | Add `HtmxFragment.Name`; keep fragments inline; parse exact headers; retain CSP-aware guidance and cache variation without owning the runtime |
+| FastHX | Add explicit reachability and component-scoped error selection; keep the renderer behind a small result interface |
+| holm | Discover component routes and local static actions; use explicit verb attributes and deterministic generated endpoint names |
+| htmx-spring-boot | Validate antiforgery on every unsafe verb; adapt authentication redirects; return several named fragments; drive support claims from a compatibility file |
+| axum-htmx | Use typed request/response values; add automatic variation; document every HTMX request value as forgeable representation input |
+| templ | Keep named fragments inline and state exactly which lifecycle and child-component work still runs |
+
+## Decisions still requiring prototypes
+
+The code examples make the desired interface visible, but these implementation questions still need evidence before the names are frozen:
+
+1. Select a supported Razor-aware build seam for component routes, static action methods, literal `hx-*` diagnostics, and fragment names. Prove Razor symbol discovery and same-partial-type access without depending on source-generator ordering.
+2. Prove that generated private static action dispatch can copy parameter attributes and nullability, explicitly validate antiforgery, bind only afterward through public ASP.NET seams, and invoke the method without exposing generated application endpoints.
+3. Define malformed-input and form-validation flow from generated binding into a fresh component `EditContext` and `ValidationMessageStore`; `RazorComponentResult` does not provide that transfer automatically.
+4. Resolve relative actions on components with multiple `@page` routes.
+5. Decide whether custom route constraints can participate in optional typed action references.
+6. Define fragment-name scope, nesting, duplicate diagnostics, and multi-fragment output order.
+7. Define how arbitrary `Match` predicates declare cache dependencies.
+8. Prove same-path stock/direct endpoint tagging and selection with a public matcher and endpoint convention, including startup parity validation for builder-only security conventions.
+9. Prove error selection, status changes, marked 4xx swaps, and streaming behavior before response headers start.
+10. Prove static rendering of a component that also declares `@rendermode InteractiveAuto`.
+11. Prove a mechanically token-free, canonical-selector response class before enabling any server, browser, or intermediary caching for Razor component HTML.
+12. Prove that the typed protocol registry rejects header collisions and malformed or oversized values, derives `Vary`, and cannot run before security policies or mutate endpoint authority.
+13. Publish the browser-adapter conformance runner and prove that an application-owned htmx build can pass without changing or rebuilding `Htmxor.Server`.
+14. Measure normal page, direct whole-component, single-fragment, multi/OOB, form action, and error paths before setting a v1 performance contract.
+
+## Recommendation
+
+Adopt the borrowed ideas through one deep server module, one declarative protocol-extension seam, and one replaceable browser adapter. If the build and binding spikes pass, the application developer should learn component reachability, static local actions, named fragments, and one immutable render result. Htmxor should handle endpoint policies, protocol parsing, antiforgery, cache variation, authentication redirects, and public static rendering. The application should own htmx itself.
+
+The key authoring model remains unchanged: feature routes and output live in `.razor`. The action implementation changes from replaying a renderer-owned callback to invoking a generated, route-bound HTTP handler colocated with that component.

--- a/docs/research/stable-v1-gap-analysis.md
+++ b/docs/research/stable-v1-gap-analysis.md
@@ -1,0 +1,389 @@
+# Htmxor stable v1 gap analysis
+
+Research date: 2026-08-26
+Repository baseline: `d8e09e4da17ab4c74fbea95d8e995137785c8395`
+
+This report compares the prototype with the current stable .NET, Blazor, and htmx contracts. It is a source review, not a penetration test or a runtime benchmark. Claims about current versions and framework behavior use first-party release notes, documentation, or source. Recommendations are separated from confirmed facts.
+
+The review covered the repository's source, tests, samples, documentation, build and release workflows, commit and release history, all 41 GitHub issues, all nine discussions, and the pull requests that established or still affect the architecture. The code audit followed the public API through endpoint discovery, route selection, rendering, form and event dispatch, antiforgery, browser assets, fragments, and response handling. The runtime checks were deliberately narrow: restore and existing tests, a compile probe against .NET 10, and a minimal .NET 10 host startup probe.
+
+## Conclusion
+
+The product idea remains sound: a Razor component can own both its normal full-page representation and an htmx fragment representation. The current implementation should not be promoted in place, however. Its central rendering path replaces Blazor services, copies framework rendering code, and reflects over private framework members. One of those reflection assumptions is already incompatible with .NET 10. The implementation also bundles htmx 1.9.12, while the current stable htmx release is 2.0.10.
+
+The shortest credible route to v1 is to keep standard Blazor page endpoints entirely under the framework, then map explicit htmx fragment endpoints through public ASP.NET Core APIs. `RazorComponentResult` is the current public result type for rendering a Razor component from an endpoint and exposes parameters, status, content type, and a streaming control. It is a promising foundation, but its documented API does not promise Blazor named-form dispatch. That part needs a spike before the v1 endpoint API is fixed. [RazorComponentResult API](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.http.httpresults.razorcomponentresult?view=aspnetcore-10.0)
+
+The four release-blocking themes are:
+
+1. Remove dependencies on private Blazor implementation details.
+2. Remove the embedded htmx dependency, verify the htmx 2.0.10 reference profile, and publish extension/adaptation seams plus a caller-runnable conformance suite.
+3. Close the confirmed antiforgery and event-dispatch gaps and define a fail-closed security contract.
+4. Establish per-request performance and published-application evidence before setting release budgets.
+
+## Current version baseline
+
+| Area | Current upstream stable | Prototype | v1 position |
+| --- | --- | --- | --- |
+| .NET and ASP.NET Core | .NET 10 is the current LTS release. The latest servicing release on the research date is 10.0.11, released 2026-08-11. [.NET 10 lifecycle](https://github.com/dotnet/core/blob/main/release-notes/10.0/README.md) and [August 2026 servicing announcement](https://github.com/dotnet/announcements/issues/436) | Targets `net8.0` and directly references `Microsoft.AspNetCore.Components.Web` 8.0.1. [Project file](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Htmxor.csproj) | Target .NET 10 for v1. Only multi-target .NET 8 if ForTheLeague has a concrete migration need and is willing to carry two framework-specific test matrices. |
+| htmx | 2.0.10 is the stable reference on the research date; htmx 4 remains a prerelease. [htmx installation](https://htmx.org/docs/#installing), [v2.0.10 release](https://github.com/bigskysoftware/htmx/releases/tag/v2.0.10), and [v4.0.0-beta6 prerelease](https://github.com/bigskysoftware/htmx/releases/tag/v4.0.0-beta6) | Embeds 1.9.12. [Bundled script](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/wwwroot/htmx/htmx.min.js) | Bundle and require no htmx version. Verify a separately replaceable adapter against 2.0.10, allow application-owned newer/custom runtimes, and treat htmx 4 evidence as preview until upstream stabilizes. |
+
+The repository has only alpha and beta version tags and its last commit is from September 2024. There is no stable 1.0 baseline to preserve.
+
+## Repository and release baseline
+
+- `main` is at `d8e09e4` and is 36 commits beyond the `v1.0.0-beta.1` tag. The latest published NuGet prerelease is `1.0.0-beta.1.24`; there is no stable package. [Release comparison](https://github.com/egil/Htmxor/compare/v1.0.0-beta.1...main) and [NuGet package](https://www.nuget.org/packages/Htmxor)
+- GitHub contains 41 issues: 16 open and 25 closed. There are also two stale open pull requests, draft [#41](https://github.com/egil/Htmxor/pull/41) for a component result and [#74](https://github.com/egil/Htmxor/pull/74) for the ignored embedded-script switch. There are no milestones or assignees on the open work.
+- The project has no benchmark project, retained per-request performance evidence, `SECURITY.md`, stable API compatibility baseline, or completed changelog. The CI and release workflows target .NET 8 and use several mutable action or tool versions.
+- GitHub security features are enabled, but three high-severity CodeQL findings remain open in the BlazingPizza authentication sample. They may be sample-specific or duplicates, but they require triage before a high-security release. [CodeQL alerts](https://github.com/egil/Htmxor/security/code-scanning)
+- A local run completed 150 non-browser tests. The browser suite could not run because Playwright Chromium is not installed in the environment, so this review does not claim that end-to-end tests are green.
+
+The issue-by-issue disposition is recorded in the appendix. The open issue set is consistent with the code findings: htmx 2, static assets, Blazor coexistence, antiforgery, caching, redirects, duplicate lifecycle work, and streaming remain unresolved.
+
+## What is worth keeping
+
+The prototype already proves several useful parts of the model:
+
+- A component's ordinary `@page` route is also made available to direct htmx requests, while `[HtmxRoute]` can add htmx-only routes. [Component discovery model](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Builder/ComponentInfo.cs)
+- An endpoint selector distinguishes standard and direct responses, and route metadata can constrain method, current URL, target, or trigger. [Selector policy](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Builder/ComponentEndpointMatcherPolicy.cs) and [route contract](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/HtmxRouteAttribute.cs)
+- The public request and response header constants cover the current official htmx header set. [htmx header reference](https://htmx.org/reference/#request_headers)
+- Direct responses support route values, an optional fragment layout, `PageTitle`, response status, redirects, retargeting, reselection, and client events. [Request host](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Endpoints/HtmxorComponentRequestHost.cs), [fragment layout](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Components/HtmxLayoutComponentBase.cs), and [response API](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Http/HtmxResponse.cs)
+
+These behaviors should become acceptance tests around a new implementation. The copied renderer should not become the compatibility contract.
+
+## Gap matrix
+
+| Priority | Confirmed gap | Consequence | v1 gate |
+| --- | --- | --- | --- |
+| P0 | Endpoint discovery reflects a private `ApplicationBuilder` property. The .NET 10.0.11 builder source has no such member. | The current null-forgiving reflection path fails before endpoints can be mapped on .NET 10. | Run standard pages without replacing Blazor's invoker or renderer; map fragments through public APIs. |
+| P0 | Direct endpoints are built in a separate endpoint data source and do not inherit conventions applied to `MapRazorComponents`, including `RequireAuthorization`, rate limiting, CORS, host restrictions, output caching, or arbitrary metadata. | Full and fragment forms of the same page can have different security and operational policies. Component attributes and fallback policies cover only part of the contract. | Generate or map fragment endpoints through an API that preserves the same endpoint conventions, then prove full/direct authorization parity at the HTTP boundary. |
+| P0 | Direct `DELETE` endpoints advertise antiforgery metadata and the client sends a token, but neither ASP.NET Core 10 antiforgery middleware nor Htmxor's fallback treats `DELETE` as a form-validation method. | A `DELETE` can reach the endpoint without antiforgery validation. Cross-site exploitability then depends on the browser, CORS, and client surface, but the server contract is not fail-closed. | Explicitly validate every unsafe htmx verb, including `DELETE`, and add negative integration tests for missing, invalid, and cross-user tokens. |
+| P0 | Component event dispatch accepts a client-supplied 32-bit FNV hash and does not verify that its encoded htmx method and URL match the incoming request. An existing test sends PATCH with the DELETE handler hash and invokes `OnDelete`. | A client can invoke a different rendered handler than the request method indicates. The short deterministic hash is an identifier, not an authorization mechanism. | Remove arbitrary event replay from v1 or bind an opaque, protected action capability to method, normalized route, component/action identity, user context, and expiry. |
+| P0 | htmx history restore is parsed but does not affect routing. htmx defaults `historyRestoreAsHxRequest` to `true`. | A history cache miss can receive a fragment when htmx requires a full document, and caches can mix full and partial representations. | Emit `historyRestoreAsHxRequest=false`, route `HX-History-Restore-Request` to a full page, and apply `Vary: HX-Request` where one URL has two representations. |
+| P1 | The embedded htmx and configuration DTO describe 1.9 behavior. | DELETE parameter placement, same-origin behavior, scroll behavior, validation, extensions, and new configuration cannot be represented reliably. Mirroring future htmx configuration in C# would repeat this coupling. | Remove the embedded artifact and frozen configuration DTO; make configuration application-owned and verify Htmxor through replaceable adapters and conformance tests. |
+| P1 | `HtmxHeadOutlet` implements `IComponent.SetParametersAsync` without applying the `ParameterView`. | `UseEmbeddedHtmx=false` is ignored, so the package still emits bundled htmx 1.9.12 even when the consumer asks to supply a current script. | Narrow the outlet to Htmxor-owned metadata, emit no htmx asset or htmx configuration, and test the contract in a published Production application. |
+| P1 | Routing and rendering depend on copied and reflected internals. | Servicing changes can silently change authentication state, navigation, form mapping, streaming, or resource handling. Trimming is also fragile. | No private reflection or copied internal renderer in the v1 request path. |
+| P1 | Conditional fragments suppress markup while walking an already-rendered component tree. | Excluded components have already run lifecycle and data-loading work, so markup reduction does not imply proportional server-work reduction. | Compose and render the selected fragment directly; prove excluded branches do not resolve or call their data dependencies. |
+| P1 | `HX-Target` matching assumes a target id. htmx also supports relative and extended CSS targets, but only sends the target's id when one exists. | A valid deep interaction can miss a target-constrained endpoint. | Make URL and method the stable identity. Treat htmx headers as optional representation hints, not endpoint authority. |
+| P1 | Boosted requests with a target are classified as direct, but all Htmxor endpoints reject boosted requests. Boolean htmx headers are interpreted by presence, including a literal `false`. | Valid navigation can end with no route candidate, and malformed or false-valued headers can change routing. | Define one truth table for normal, boosted, targeted, and history-restore requests and cover it with endpoint-level tests. |
+| P1 | Route equality is asymmetric, its hash is case-sensitive while equality is not, and every ordinary `@page` is expanded to one shared mutable five-verb default. | Discovery can retain duplicates or drop routes, and pages receive broader unsafe-method exposure than they requested. | Use immutable explicit method metadata with a correct equality contract, deterministic precedence, and GET-only defaults. |
+| P1 | `HtmxAsyncLoad` renders every loader during any direct request and drops `PathBase` and query strings from generated URLs. Optional and custom-constrained route parameters are only partially copied from framework behavior. | A targeted request can execute unrelated loaders or lose route state, while deep routes diverge from ordinary Blazor binding. | Address loaders explicitly and delegate route/query/form binding to public framework contracts rather than maintaining a partial parser. |
+| P1 | There is no per-request benchmark suite or published-app matrix. | Performance claims cannot be evaluated and regressions cannot be caught. | Record baseline latency, throughput, allocations, and response size against stock static SSR and a public-result implementation. |
+| P2 | Core htmx updates `<title>`, not arbitrary head metadata. | Pages that expect canonical links, styles, or other head elements to merge will behave differently during htmx navigation. | Promise title updates only, or version and test the official head-support extension as an explicit opt-in. |
+
+## Blazor compatibility and endpoint architecture
+
+Blazor static server-side rendering produces HTML in the response and does not retain an interactive component instance after the request. Routing, authorization, and authentication for static SSR run through normal ASP.NET Core request processing. [Blazor render modes](https://learn.microsoft.com/en-us/aspnet/core/blazor/components/render-modes?view=aspnetcore-10.0)
+
+Htmxor currently alters that request processing globally. `AddHtmx` removes or replaces `IRoutingStateProvider`, `IRazorComponentEndpointInvoker`, the internal `EndpointHtmlRenderer`, the cascading `HttpContext` supplier, and `NavigationManager`. [Service replacement code](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/DependencyInjection/HtmxorApplicationBuilderExtensions.cs) The replacement renderer then discovers the internal `HttpContextFormDataProvider` by name and invokes non-public methods. [Renderer reflection](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Rendering/HtmxorRenderer.cs)
+
+Direct endpoints are also built in a new endpoint data source from discovered component types rather than from the conventions accumulated on `RazorComponentsEndpointConventionBuilder`. [Endpoint registration](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Builder/HtmxorComponentEndpointRouteBuilderExtensions.cs) and [direct endpoint construction](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Builder/ComponentEndpointDataSource.cs) Component attributes are copied, but builder-level calls such as `RequireAuthorization`, rate limiting, CORS, host restrictions, output caching, and arbitrary metadata do not automatically reach the direct endpoint. A v1 implementation must make policy parity structural rather than relying on application authors to duplicate it.
+
+This is no longer only a maintenance risk. Endpoint discovery calls `GetProperty("ApplicationBuilder", NonPublic)!` on `RazorComponentsEndpointConventionBuilder`. [Current reflection path](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Builder/HtmxorComponentEndpointRouteBuilderExtensions.cs) The tagged .NET 10.0.11 implementation has internal endpoint-builder state but no `ApplicationBuilder` member, so the lookup returns null and the next call dereferences it. [ASP.NET Core 10.0.11 builder source](https://github.com/dotnet/aspnetcore/blob/v10.0.11/src/Components/Endpoints/src/Builder/RazorComponentsEndpointConventionBuilder.cs) A clean local .NET 10 host referencing the built package compiled successfully and then reproduced this exact `NullReferenceException` at startup in `GetDiscoveredComponents`. This confirms that the first blocker is runtime compatibility, not a theoretical source risk.
+
+The copied renderer also freezes old framework behavior. The .NET 10 endpoint renderer now owns resource collection, authentication-state listeners, state restoration, navigation and not-found handling, and streaming bookkeeping. [ASP.NET Core 10.0.11 endpoint renderer](https://github.com/dotnet/aspnetcore/blob/v10.0.11/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.cs) Its form-data provider remains internal. [ASP.NET Core 10.0.11 form-data provider](https://github.com/dotnet/aspnetcore/blob/v10.0.11/src/Components/Endpoints/src/FormMapping/HttpContextFormDataProvider.cs) Copying those behaviors into Htmxor creates an undocumented framework fork.
+
+The recommended v1 architecture is:
+
+1. Leave `MapRazorComponents<App>()` and its services unchanged for every standard page request.
+2. Map htmx fragment endpoints explicitly. A source generator can turn `[HtmxRoute]` declarations into public endpoint registrations without runtime discovery.
+3. Render fragment components with `RazorComponentResult` or another public result contract. Keep authorization and other endpoint metadata on the generated endpoint.
+4. Select full page versus fragment using a stable URL/method contract. If the same URL serves both, use an explicit public endpoint-selector policy and cache variation. Never consider `HX-*` headers proof of identity or permission.
+5. Prefer explicit HTTP actions and form handlers over replaying arbitrary component event-handler ids from `HXOR-Event-Handler-Id`. The current event replay is tightly coupled to renderer internals and has a confirmed method-confusion defect. [Client event header](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/wwwroot/htmxor.js)
+
+There is a compatibility-first fallback: return the normal full document and use htmx `hx-select` to choose the fragment. htmx explicitly supports full-document responses with `hx-select`. [Requests and responses](https://htmx.org/docs/#requests) This avoids a private renderer but still pays for full application and layout rendering on each request, so it should be a baseline rather than the intended fast path.
+
+### Uncertain architecture points
+
+- `RazorComponentResult` clearly supports direct rendering. It is not documented as an entry point for Blazor's named static-SSR form dispatch. A spike must prove form binding, validation, antiforgery, authorization, status codes, navigation, and streaming before adopting it as the only renderer.
+- A public `IEndpointSelectorPolicy` can distinguish duplicate route candidates, but the long-term stability of using duplicate page and fragment endpoints on the same route should be validated against .NET 10 routing tests. Separate fragment URLs are simpler and remain the safe fallback.
+- The best registration shape, explicit fluent mapping versus generated `[HtmxRoute]` mappings, is an API design decision. Either can avoid private discovery.
+
+## Client-runtime decoupling and the htmx 2 reference profile
+
+htmx 2 removes extensions from the core distribution and changes several defaults. The official migration guide calls out separately distributed extensions, a required SSE migration, URL parameters for `DELETE`, same-origin-only requests, instant scroll behavior, and the `hx-on:*` event syntax. [htmx 1 to 2 migration guide](https://htmx.org/migration-guide-htmx-1/)
+
+The prototype's `HtmxConfig` mirrors the 1.9 configuration. Its comments say `methodsThatUseUrlParams` defaults to GET, `scrollBehavior` defaults to smooth, and `selfRequestsOnly` defaults to false, while its own C# default forces same-origin requests. [Prototype configuration](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/HtmxConfig.cs) In htmx 2.0.10 the corresponding defaults are `['get', 'delete']`, `instant`, and `true`. The current configuration also lacks `inlineStyleNonce`, `disableInheritance`, `responseHandling`, `allowNestedOobSwaps`, and `historyRestoreAsHxRequest`. htmx's validation guidance additionally recommends enabling `reportValidityOfForms`. [Current htmx configuration](https://htmx.org/docs/#config)
+
+Required migration work:
+
+- Remove the embedded artifact from the server package. The application owns the htmx script, version, extensions, configuration, CSP, and upgrade schedule.
+- Repair and narrow `HtmxHeadOutlet`. Its manual `SetParametersAsync` currently ignores the supplied `ParameterView`, so `UseEmbeddedHtmx=false` never changes the property and the old embedded script is still emitted. The v1 outlet should emit only Htmxor-owned metadata such as the antiforgery token and handled-fragment marker. [Head outlet implementation](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Components/HtmxHeadOutlet.cs)
+- Retire the serialized catch-all C# configuration DTO. Publish a documented htmx 2 high-security profile as application-owned `<meta name="htmx-config">` markup so a new upstream option does not require a Htmxor release.
+- Split the browser bridge into version-neutral Htmxor behavior and a small replaceable htmx lifecycle adapter. Verify the maintained adapter against 2.0.10, but do not include or version-gate the runtime.
+- Add a declarative typed server protocol registry for future request and response headers. It must own parsing, size limits, protected-header conflicts, URL validation, automatic `Vary`, and cache safety without exposing route or security mutation hooks.
+- Preserve unknown `hx-*` attributes and native `hx-ext` usage. An analyzer may diagnose known attributes but must not reject future ones.
+- Cover DELETE query-parameter behavior in the verified htmx 2 adapter suite.
+- Set `historyRestoreAsHxRequest=false` whenever `HX-Request` selects fragments. htmx says this should always be disabled for partial/full response selection and expects a complete page after a history cache miss. [htmx history contract](https://htmx.org/docs/#history)
+- Add `Vary: HX-Request` to cacheable dual-representation responses. htmx documents this requirement for servers that return a full page without the header and a fragment with it. [htmx caching guidance](https://htmx.org/docs/#caching)
+- Stop loading `event-header.js` unconditionally. Native htmx extensions remain application-owned. The current extension adds a `Triggering-Event` request header that is not consumed by this repository, so removal is preferable unless a supported use case is found. [Current head outlet](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Components/HtmxHeadOutlet.cs)
+- Test every official request and response header. The names are currently complete, but the `HX-Request` comment saying it is always true is no longer a safe server assumption during correctly configured history restoration. [htmx headers](https://htmx.org/reference/#request_headers)
+
+Compatibility claims should say “verified with htmx 2.0.10 and this adapter,” not “requires htmx 2.0.10.” Unknown and newer versions remain allowed. A public conformance runner should execute the same unsafe-request, history, redirect, handled-error, OOB, extension, and Blazor DOM-ownership tests against an application-supplied script and adapter.
+
+## Deep routes and full-page composition
+
+The v1 contract should define three cases independently:
+
+| Request | Required result |
+| --- | --- |
+| Browser GET to a public route | A complete, linkable, refreshable, authorized HTML document. |
+| htmx GET to the same public route | The intended component fragment, or a full document from which `hx-select` can reliably select it. |
+| htmx request to a fragment-only route | A component fragment with the same authorization, antiforgery, validation, and error semantics as the owning page. A normal browser request should either return a deliberate full-page host or a deliberate 404, not an accidental renderer failure. |
+
+Current route selection can constrain a route by `HX-Target`, but htmx only sends the target element's id if one exists. At the same time, `hx-target` supports `this`, `closest`, `next`, `previous`, and `find`, which are useful precisely because they do not require ids. [htmx targeting](https://htmx.org/docs/#targets) A route keyed primarily by target headers is therefore incomplete. URLs and HTTP methods should identify the server capability; target and trigger headers can refine representation after authorization.
+
+For components nested below a page, v1 should require an explicit fragment route or generated mapping. Reusing every `@page` route as a direct component route is convenient and should remain available, but arbitrary child-component discovery should not be inferred from renderer internals.
+
+Three current correctness defects reinforce the need for one explicit routing contract:
+
+- A boosted request with an explicit target is classified as direct, after which the standard candidate and every Htmxor candidate reject it. Boolean htmx headers are interpreted by presence rather than the value `true`. [Request classification](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Http/HtmxRequest.cs), [endpoint metadata](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Builder/EndpointMetadata.cs), and [selector](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Builder/ComponentEndpointMatcherPolicy.cs)
+- `HtmxRouteAttribute.Equals` treats nulls as one-sided wildcards while its hash is case-sensitive, despite case-insensitive equality. Its public mutable default also grants GET, POST, PUT, PATCH, and DELETE to every converted `@page`. [Route attribute](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/HtmxRouteAttribute.cs) A stable v1 should default ordinary pages to GET and require explicit unsafe methods.
+- During any direct request, every `HtmxAsyncLoad` renders its child, and its generated URL drops `PathBase` and the query string. The request host also maintains a partial copy of route-constraint conversion. [Async loader](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Components/HtmxAsyncLoad.cs) and [route parameter host](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Endpoints/HtmxorComponentRequestHost.cs) The public framework should own binding, while each loader gets an explicit address.
+
+## Security assessment
+
+### Confirmed antiforgery defect
+
+`HtmxRouteAttribute` permits GET, POST, PUT, PATCH, and DELETE by default. Every generated endpoint receives `RequireAntiforgeryTokenAttribute`, and the browser helper attaches a request token to all methods except GET, HEAD, OPTIONS, and TRACE. [Route methods](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/HtmxRouteAttribute.cs), [endpoint metadata](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Builder/ComponentEndpointDataSource.cs), and [browser token helper](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/wwwroot/htmxor.js)
+
+The server-side checks do not match that contract. ASP.NET Core 10's antiforgery middleware only treats POST, PUT, and PATCH as valid form methods. [ASP.NET Core form-method helper](https://github.com/dotnet/aspnetcore/blob/v10.0.11/src/Shared/HttpExtensions.cs) Htmxor's fallback uses the same three methods. [Htmxor request validation](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Endpoints/HtmxorComponentEndpointInvoker.cs) As a result, DELETE requests are not validated even though the client sends a token and the endpoint advertises antiforgery metadata. This is a release blocker.
+
+The fallback expression also applies its exception-handler exclusion only to PATCH because `&&` binds more tightly than `||`. POST and PUT can still enter form dispatch during exception handling. This is a correctness gap that should receive a regression test.
+
+The v1 security contract should state that all state-changing verbs require antiforgery validation, authentication and authorization are re-evaluated server-side on every request, and GET is side-effect free. Microsoft warns that GET requests must not change state because antiforgery protection does not cover them. [ASP.NET Core antiforgery guidance](https://learn.microsoft.com/en-us/aspnet/core/security/anti-request-forgery?view=aspnetcore-10.0)
+
+### Confirmed event-dispatch defect
+
+For `@onget`, `@onpost`, and related handlers, the renderer computes a 32-bit FNV-1a hash of the rendered `hx-{method}={url}` attribute and emits that value as `hxor-eventid`. [Hash and emitted attribute](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Rendering/HtmxorRenderer.HtmlWriting.cs) The browser copies it into `HXOR-Event-Handler-Id`. On the next request, the server looks up the supplied hash and dispatches the associated Blazor handler, but it does not compare the hash's source method or URL with the actual request method or normalized path. [Dispatch implementation](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Rendering/HtmxorRenderer.HtmxorEventDispatch.cs)
+
+The existing `Delete_method_htmxor_event_handler` test sends a PATCH request with the DELETE button's hash and asserts that `OnDelete` runs. [Method-confusion test](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/test/Htmxor.Tests/EventHandlerTest.cs) Its passing expectation proves the server does not bind handler identity to the incoming method. A deterministic 32-bit hash also cannot serve as authenticity or authorization evidence.
+
+The safest v1 decision is to remove this callback-replay feature and use explicit HTTP action endpoints. If it remains, the action token must be opaque and tamper-protected, short-lived, and bound at least to HTTP method, normalized endpoint or route, component/action identity, and the relevant user or authorization context. The server must still perform antiforgery and authorization checks independently.
+
+### Token transport and fail-closed behavior
+
+Blazor static SSR forms use named forms, `[SupplyParameterFromForm]`, and antiforgery integration. Form names must be unique, mapping limits are configurable, and separate input models reduce overposting. [Blazor forms](https://learn.microsoft.com/en-us/aspnet/core/blazor/forms/?view=aspnetcore-10.0) and [form binding](https://learn.microsoft.com/en-us/aspnet/core/blazor/forms/binding?view=aspnetcore-10.0)
+
+Htmxor currently emits a JavaScript-readable antiforgery request-token cookie on every response. The cookie uses `SameSite=Strict` but does not explicitly set `Secure` or `Path`, and the JavaScript dereferences the cookie lookup without handling a missing token. [Token-cookie middleware](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Antiforgery/HtmxorAntiforgeryMiddleware.cs) htmx recommends ordinary hidden framework form tokens when available, with `hx-headers` as another supported transport. [htmx CSRF guidance](https://htmx.org/docs/#csrf-prevention)
+
+Prefer Blazor's hidden form token for forms. If a header token remains necessary for non-form verbs, issue it deliberately, set cookie scope and transport properties explicitly, avoid rotating it on every unrelated response, and fail closed when it is missing. Test authenticated and anonymous requests, token rotation, multiple tabs, reverse-proxy HTTPS, and every unsafe method.
+
+### Browser-side hardening
+
+htmx supplies layered controls for raw or sensitive HTML: `hx-disable`, `hx-history=false`, `historyCacheSize=0`, `selfRequestsOnly`, `allowScriptTags=false`, `allowEval=false`, URL validation, and CSP. Disabling eval also disables trigger filters, `hx-on:`, and JavaScript-valued `hx-vals` and `hx-headers`, so this must be an explicit compatibility choice. [htmx security tools](https://htmx.org/docs/#security)
+
+Provide a documented high-security profile rather than silently changing every htmx default. A sensible profile starts with same-origin requests, no evaluated expressions, no scripts in swapped content, no sensitive local-history cache, CSP-compatible indicator styles or a style nonce, and nested out-of-band swaps disabled unless required. These values are a proposed policy, not an upstream mandate.
+
+Other v1 security gates:
+
+- Treat every `HX-*` and `HXOR-*` header as attacker-controlled. Header-based routing may select a representation only after the endpoint's authorization policy is established.
+- Preserve all component authorization metadata on generated fragment endpoints and test equivalent outcomes between the full page and fragment.
+- Bound form collection size, recursion depth, collection size, and error count. Use input DTOs rather than binding domain entities. [Blazor static SSR security guidance](https://learn.microsoft.com/en-us/aspnet/core/blazor/security/static-server-side-rendering?view=aspnetcore-10.0)
+- Encode untrusted output and isolate any raw HTML with a sanitizer and `hx-disable`. htmx's security guidance warns that untrusted raw attributes can inject htmx behavior. [htmx web security basics](https://htmx.org/essays/web-security-basics-with-htmx/)
+- Add local-only redirect helpers for `HX-Location`, `HX-Redirect`, `HX-Push-Url`, and `HX-Replace-Url`, or name unrestricted variants explicitly. The current API accepts arbitrary strings.
+- Test cache-control and `Vary` behavior so authenticated fragments cannot be served across users or confused with full pages.
+
+## Head, history, and streaming
+
+Core htmx extracts a response `<title>` and updates `document.title`. It does not merge the rest of `<head>`. The official `head-support` extension exists for merging head elements and is currently distributed separately. [Official head-support extension](https://htmx.org/extensions/head-support/)
+
+The prototype's fragment layout includes Blazor `HeadOutlet`, which is enough to put `PageTitle` output in the response. This supports a narrow v1 promise: title changes work during fragment requests. Full metadata merging should either be a non-goal or an application-owned extension exercised at an exact version in tests for stylesheet deduplication, canonical links, scripts, and boosted navigation.
+
+The current renderer writes an initial buffered response and contains comments about streaming updates, but it does not call the framework's streaming update loop. Its branch also appears to await request-event quiescence before writing. This suggests that direct rendering is effectively buffered, but that conclusion is uncertain until a component with `[StreamRendering]` is exercised over a real response. Blazor's current streaming contract sends placeholder content and later updates in the same response. [Blazor streaming rendering](https://learn.microsoft.com/en-us/aspnet/core/blazor/components/rendering?view=aspnetcore-10.0#streaming-rendering)
+
+For v1, choose one explicit contract:
+
+- Buffer fragments and set `PreventStreamingRendering=true`. This is simpler and makes response timing predictable.
+- Support framework streaming end to end through a public result API and test proxy buffering, status codes, cancellation, and htmx swap behavior.
+
+Do not advertise streaming until the second path is proven.
+
+## Trimming and publishing
+
+The package does not declare itself trimmable, while endpoint discovery and rendering use runtime reflection over private types and members. Blazor trimming guidance warns that reflection can produce publish-time warnings and runtime failures and recommends testing published output regularly. [Blazor trimming guidance](https://learn.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/configure-trimmer?view=aspnetcore-10.0)
+
+Stable v1 must make one honest choice:
+
+- Support trimming by replacing private and unbounded reflection with explicit or generated registrations, annotating the remaining public reflection, and running a `PublishTrimmed` smoke app in CI.
+- Declare trimming unsupported and test a normal framework-dependent and self-contained publish.
+
+The first choice aligns better with source-generated endpoint mapping. Native AOT should not be promised as part of this work without a separate supported-hosting investigation.
+
+## Per-request performance plan
+
+No benchmark project or load-test harness exists in the repository. The current direct path creates a scoped renderer, renders a fresh component tree, builds event-handler state, and writes through a 16 KiB pooled stream writer. Some reflection occurs at startup or type initialization, but copied rendering and event dispatch affect the request path. Source inspection cannot quantify the net cost.
+
+The current conditional-fragment mechanism is an output filter, not an execution filter. `ShouldGenerateMarkup` is consulted while the renderer walks an existing render tree and toggles a conditional writer. [Conditional component state](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Rendering/HtmxorComponentState.cs) and [HTML writer](https://github.com/egil/Htmxor/blob/d8e09e4da17ab4c74fbea95d8e995137785c8395/src/Htmxor/Rendering/HtmxorRenderer.HtmlWriting.cs) Component construction, parameters, lifecycle methods, and data calls have already happened. Therefore a smaller response is not evidence of lower server work. The new architecture should render the selected fragment as the root or explicit child composition, and an integration test with counting data dependencies should prove that excluded page branches never execute.
+
+Build a benchmark sample with production settings and compare:
+
+1. Stock Blazor static SSR full-page GET.
+2. Stock full-page GET plus client-side `hx-select` compatibility path.
+3. Htmxor direct fragment GET through the proposed public endpoint.
+4. Current prototype direct GET, while it still runs on its supported framework, as historical evidence.
+5. Valid and invalid POST forms.
+6. Valid and invalid DELETE requests after the antiforgery fix.
+7. A full page with several data-loading branches versus one directly composed fragment, verifying both response cost and which dependencies executed.
+
+Measure cold start separately from steady state. For each steady-state scenario capture throughput, mean, p50, p95 and p99 latency, allocations per operation, response bytes, and error rate at increasing concurrency. Include a small fragment, a realistic ForTheLeague match/card fragment, an authorized route, route and query parameters, and a slow streaming candidate. Run the packaged Release build behind the same server and logging settings.
+
+Do not invent an absolute latency target before this baseline exists. The v1 gate should first be no material regression against the public `RazorComponentResult` fragment baseline, with a project-owned budget agreed from measured ForTheLeague traffic and payloads.
+
+## Proposed v1 scope
+
+### Supported
+
+- .NET 10 LTS; no required htmx version. The maintained reference adapter is verified against htmx 2.0.10, and applications may supply newer or custom runtimes.
+- Static SSR full pages owned by Blazor.
+- Explicit or generated component fragment endpoints using public ASP.NET Core contracts.
+- Direct fragment composition that does not execute unrelated page branches.
+- GET, POST, PUT, PATCH, and DELETE with fail-closed validation for unsafe verbs.
+- Route and query parameters, authorization metadata, antiforgery, validation errors, status codes, cancellation, htmx request context, and the current official request and response headers.
+- Same-route full and fragment representations when cache and history behavior is correct.
+- `PageTitle` updates.
+- A documented high-security configuration profile.
+- Published-app smoke tests and repeatable per-request benchmarks.
+
+### Deferred unless a spike proves them cheaply
+
+- Arbitrary Blazor event-callback replay from an htmx header.
+- Private Blazor renderer replacement.
+- Transparent discovery of arbitrary nested components without an explicit route declaration.
+- Full `<head>` merging in core.
+- Streaming fragment updates.
+- Native AOT.
+- WebSocket and SSE integration beyond documenting compatible official htmx extensions.
+
+## ForTheLeague adoption recommendation
+
+Do not add the current Htmxor package to ForTheLeague production code. The .NET 10 startup failure, policy-propagation gap, and request-dispatch defects make that a no-go even for a limited rollout.
+
+The concept is still worth a tracer-bullet spike after roadmap stage 1 produces a public-API endpoint path. Start with one public, cacheable read experience that has both a normal deep link and a small refreshable leaf component, such as a match or ranking card. Compare stock Blazor static SSR, the full-document `hx-select` fallback, and the explicit fragment endpoint. Require the fragment path to avoid unrelated page data work, emit no per-user cookie on the public GET, and produce an unambiguous cache/history contract.
+
+Treat authenticated mutation as a separate adoption gate. A representative form or action must prove authorization parity, invalid-token rejection for every supported unsafe verb, redirect and validation behavior, and no event-handler method confusion. This sequence tests the architectural value without making ForTheLeague the security laboratory for an unfinished package.
+
+## Roadmap to stable v1
+
+### 0. Reproduction and decisions
+
+- Add a minimal .NET 10 sample that records the current endpoint-discovery failure.
+- Freeze the endpoint shape: separate fragment routes by default, with same-route negotiation as a tested option.
+- Spike `RazorComponentResult` for GET, named POST form binding, authorization, navigation, and streaming.
+- Decide whether v1 supports trimming and whether .NET 8 compatibility is needed for a ForTheLeague migration window.
+
+Exit gate: an architecture decision backed by runnable spikes, with no reliance on undocumented members.
+
+### 1. Public endpoint foundation
+
+- Upgrade the library and tests to .NET 10.
+- Stop replacing Blazor's standard renderer, invoker, routing-state provider, and navigation manager.
+- Implement explicit endpoint mappings, then add source generation if attribute ergonomics are required.
+- Port existing route, layout, request-context, and response-header behaviors as acceptance tests.
+
+Exit gate: normal Blazor pages behave identically with and without Htmxor registered, and fragment endpoints use public framework contracts only.
+
+### 2. Browser-runtime independence and htmx 2 evidence
+
+- Remove embedded htmx and make its script, configuration, extensions, and upgrade schedule application-owned.
+- Build the version-neutral browser core, replaceable htmx 2 adapter, and declarative typed server protocol registry.
+- Implement the full-page history-restore path and cache variation outside extension control.
+- Publish a conformance runner for an application-supplied script and adapter.
+- Test deep links, refresh, back/forward cache miss, boosted navigation, `hx-select`, out-of-band swaps, target elements without ids, custom extensions, and all headers against the htmx 2.0.10 reference row.
+
+Exit gate: the reference row passes in supported browsers, a caller-owned runtime passes through the public runner without rebuilding `Htmxor.Server`, unknown `hx-*` attributes survive unchanged, and no 1.x compatibility extension is needed for documented v1 behavior.
+
+### 3. Security closure
+
+- Validate antiforgery on every unsafe verb, including DELETE.
+- Prove authorization parity between full and fragment endpoints.
+- Replace or harden the token-cookie transport and add missing-token behavior.
+- Add local redirect validation, form-mapping limits, cache tests, malicious-header tests, CSP tests, and raw-HTML guidance.
+- Remove component event replay or prove action tokens are bound to method, route, identity, and expiry. Add the current PATCH-to-DELETE case as a negative HTTP-boundary test.
+- Run dependency, static-analysis, and application security review against the packaged sample.
+
+Exit gate: the security matrix fails closed and the DELETE regression test is present at the HTTP boundary.
+
+### 4. Performance and publish evidence
+
+- Add the benchmark and concurrency harness described above.
+- Measure current and proposed paths, then set project-owned budgets.
+- Test cancellation, large forms, exceptions, and slow components.
+- Prove direct fragments do not execute excluded component lifecycle or data work.
+- Add normal publish and, if supported, trimmed publish smoke tests.
+
+Exit gate: repeatable results meet the agreed ForTheLeague budget without correctness loss, and the published sample passes on the exact release artifacts.
+
+### 5. Release hardening
+
+- Finish the incomplete usage documentation for routing, layouts, forms, conditional rendering, security, caching, history, and errors.
+- Define public API compatibility and package-validation baselines.
+- Test the exact NuGet package in a clean consumer application.
+- Publish an RC, gather a real ForTheLeague integration cycle, resolve RC findings, then tag v1.
+
+Exit gate: no P0 or P1 gaps remain, all evidence was produced from the release candidate's exact commit and package, and the documented full-page and fragment scenarios are covered end to end.
+
+## Issue inventory and disposition
+
+This appendix prevents unresolved tracker work from disappearing into a new roadmap. It records all 41 issues as of the research date. “Close” means close only after the stated documentation or regression evidence exists.
+
+### Open issues
+
+| Issue | Current finding | v1 disposition |
+| --- | --- | --- |
+| [#11: htmx v2](https://github.com/egil/Htmxor/issues/11) | Still fully applicable; the 1 to 2 migration affects more than the script file. | Block v1 on the verified 2.0.10 reference row and caller-owned-runtime conformance suite, not on a package dependency. |
+| [#15: browser logs](https://github.com/egil/Htmxor/issues/15) | Event volume and serialization remain unresolved. | Defer; use server HTTP tracing and correlation for v1. |
+| [#16: streaming](https://github.com/egil/Htmxor/issues/16) | The current pipeline waits for quiescence and htmx does not natively consume Blazor streaming updates. | Explicitly defer unless the public-result spike proves a bounded contract. |
+| [#18: response headers](https://github.com/egil/Htmxor/issues/18) | A declarative extension point is useful but unfinished. | Freeze the typed request/response feature registry and protected-header rules before API freeze. |
+| [#30: event callback association](https://github.com/egil/Htmxor/issues/30) | The event id is ambiguous and is now confirmed not to be bound to method or route. | P0 if callback replay remains; otherwise remove it from v1. |
+| [#40: empty action URLs](https://github.com/egil/Htmxor/issues/40) | Explicit empty strings already mean current URL. | Document and close. |
+| [#48: community standards](https://github.com/egil/Htmxor/issues/48) | Security and contribution policies are missing. | Complete before stable release, especially `SECURITY.md`. |
+| [#50: output caching](https://github.com/egil/Htmxor/issues/50) | Full and fragment responses need correct variance; response-wide token cookies conflict with public caching. | Security and ForTheLeague adoption gate. |
+| [#56: CSRF token placement](https://github.com/egil/Htmxor/issues/56) | The readable-cookie approach remains unresolved and DELETE validation is broken. | P0 threat model and negative HTTP tests. |
+| [#57: standard Blazor coexistence](https://github.com/egil/Htmxor/issues/57) | Global service replacement prevents safe gradual adoption. | Architecture gate: standard Blazor must remain unchanged. |
+| [#58: htmx extensions](https://github.com/egil/Htmxor/issues/58) | htmx 2 distributes extensions separately; the htmx 4 preview already changes the extension/event model. | Keep native extensions application-owned; define the browser-adapter contract, unknown-attribute behavior, and conformance runner. |
+| [#64: redirects](https://github.com/egil/Htmxor/issues/64) | Identity-flow navigation diverges under the custom navigation manager. | Cover local/external redirects, status, history, and nested paths. |
+| [#67: duplicate initialization](https://github.com/egil/Htmxor/issues/67) | Duplicate `OnInitializedAsync` remains unexplained in an AWS Lambda scenario. | Reproduce before performance claims; prevent duplicate data work. |
+| [#69: `hx-vals`](https://github.com/egil/Htmxor/issues/69) | Attribute capture already supports the basic custom-component case. | Document; add a JSON helper only if it makes encoding safer. |
+| [#72: static files in Production](https://github.com/egil/Htmxor/issues/72) | The suggested publish-output explanation has no maintainer verification. | Published Production integration test. |
+| [#75: static asset fingerprinting](https://github.com/egil/Htmxor/issues/75) | The copied renderer misses current framework resource behavior. | Release blocker and further evidence for removing the renderer fork. |
+
+### Closed issues and decisions to carry forward
+
+| Issue | Historical result | v1 treatment |
+| --- | --- | --- |
+| [#1](https://github.com/egil/Htmxor/issues/1) | Full versus fragment conditional output became `HtmxFragment`. | Preserve the behavior contract, not the renderer implementation. |
+| [#2](https://github.com/egil/Htmxor/issues/2) | Added request context and typed htmx headers. | Revalidate every header against htmx 2 and CORS/cache behavior. |
+| [#3](https://github.com/egil/Htmxor/issues/3) | Added the first antiforgery-cookie approach amid acknowledged uncertainty. | Treat as superseded by #56, not completed security evidence. |
+| [#4](https://github.com/egil/Htmxor/issues/4) | Chose a custom router, endpoint, invoker, and renderer. | Reverse the private-framework ownership while retaining its acceptance scenarios. |
+| [#5](https://github.com/egil/Htmxor/issues/5) | Used a fragment layout and `HeadOutlet` for titles. | Promise title updates only unless head merging is explicitly versioned and tested. |
+| [#6](https://github.com/egil/Htmxor/issues/6) | Introduced the route attribute that became `HtmxRoute`. | Review the API after the public endpoint spike. |
+| [#7](https://github.com/egil/Htmxor/issues/7) | Added custom route discovery. | Replace private runtime discovery with explicit or generated public mapping. |
+| [#9](https://github.com/egil/Htmxor/issues/9) | Added the custom endpoint invoker. | Replace it or sharply isolate it; compare behavior with stock Blazor. |
+| [#13](https://github.com/egil/Htmxor/issues/13) | Preferred sections/layouts over a dedicated OOB service. | Validate the pattern against htmx 2 before documenting it. |
+| [#14](https://github.com/egil/Htmxor/issues/14) | Recorded the beta checklist. | Do not reuse it as v1 evidence; it treated unresolved antiforgery as complete. |
+| [#17](https://github.com/egil/Htmxor/issues/17) | Considered basic JSON/JavaScript quoting sufficient. | Revisit under CSP, disabled eval, and malicious-input tests. |
+| [#19](https://github.com/egil/Htmxor/issues/19) | Mapped `NavigationManager` actions to htmx headers. | Retain as redirect/history regression scenarios, not a reason to replace navigation globally. |
+| [#22](https://github.com/egil/Htmxor/issues/22) | Fixed duplicate sidebar output in the sample. | Keep the scenario as a rendering regression. |
+| [#25](https://github.com/egil/Htmxor/issues/25) | Established multi-fragment output filtering and acknowledged hidden lifecycle work. | Preserve UX, replace output-only pruning with direct composition. |
+| [#26](https://github.com/egil/Htmxor/issues/26) | Defined boosted routing behavior. | Re-specify it with the full htmx 2 routing truth table. |
+| [#27](https://github.com/egil/Htmxor/issues/27) | Folded multiple-fragment ambiguity into #25. | Keep a focused multiple-fragment endpoint test. |
+| [#33](https://github.com/egil/Htmxor/issues/33) | Established `Htmxor`, `Htmx`, and `hx` naming. | Carry into the public API review. |
+| [#45](https://github.com/egil/Htmxor/issues/45) | Automatic antiforgery markup was closed as not planned. | Superseded by #56; the security requirement remains open. |
+| [#46](https://github.com/egil/Htmxor/issues/46) | Moved event ids into `hxor-eventid`. | The method-confusion finding reopens the underlying trust problem. |
+| [#51](https://github.com/egil/Htmxor/issues/51) | Fixed swap-enum JSON casing. | Retain protocol serialization tests. |
+| [#53](https://github.com/egil/Htmxor/issues/53) | Used lowercase enum member names to survive Razor attribute erasure. | Review all values against htmx 2 before API freeze. |
+| [#60](https://github.com/egil/Htmxor/issues/60) | Defined consumer-owned htmx via `UseEmbeddedHtmx=false`. | Replace the broken switch with unconditional application ownership; Htmxor should have no embedded runtime to disable. |
+| [#61](https://github.com/egil/Htmxor/issues/61) | Deferred package splitting. | Revisit only if static-only boundaries or client references require it. |
+| [#65](https://github.com/egil/Htmxor/issues/65) | Demonstrated `[SupplyParameterFromForm]` for active search. | Convert into supported form-binding documentation and tests. |
+| [#70](https://github.com/egil/Htmxor/issues/70) | Worked around Production 404s by disabling embedded htmx. | Not root-cause evidence; #72, #74, and #75 remain active. |
+
+The discussions reinforce the same direction. [#39](https://github.com/egil/Htmxor/discussions/39) treats independently addressable fragments as routable components, [#42](https://github.com/egil/Htmxor/discussions/42) asks for gradual coexistence with other Blazor render modes, [#47](https://github.com/egil/Htmxor/discussions/47) reports confusing route boundaries and post-swap behavior, and [#73](https://github.com/egil/Htmxor/discussions/73) records the maintenance stop. The remaining discussions cover release announcements, page JavaScript, fragment lifecycle cost, AWS antiforgery/Data Protection behavior, and rejected static fragment methods; none changes the P0/P1 ordering above.
+
+## Open questions
+
+1. Does ForTheLeague need same-URL full and fragment endpoints, or are explicit `/fragments/...` URLs acceptable? The latter reduces routing and cache complexity.
+2. Are PUT, PATCH, and DELETE important public API requirements, or can v1 use POST actions with explicit intent? Keeping them is reasonable, but every verb needs a defined binding and antiforgery contract.
+3. Is full head merging required, or is title-only behavior enough?
+4. Is streaming useful for a real ForTheLeague fragment, or should v1 buffer fragments deliberately?
+5. Is trimmed publish a release requirement?
+6. Which representative ForTheLeague pages and concurrency levels define the performance budget?

--- a/docs/roadmap/v1/README.md
+++ b/docs/roadmap/v1/README.md
@@ -1,0 +1,83 @@
+# Htmxor stable v1 tracker proposal
+
+Status: review draft only. Nothing in this directory has been published to GitHub.
+
+The agreed product and engineering target is [the Htmxor v1 goal](./goal.md).
+The remaining files are tracker drafts and must stay consistent with that goal.
+Use the [v1 orchestrator brief](./orchestrator-brief.md) to track proved progress
+and select one implementation slice at a time.
+
+This packet prepares the first tracker changes for a stable Htmxor v1 without
+prematurely turning architecture hypotheses into implementation tickets.
+
+## Proposed first publication
+
+After review and explicit approval, publish only:
+
+1. the `Htmxor v1` milestone;
+2. the stable-v1 parent issue;
+3. issue 01, which proves the stock Blazor execution seam and captures its
+   executable compatibility baseline;
+4. issue 02, which proves or bounds lifecycle-preserving unsafe-verb dispatch; and
+5. the approved migration comments on existing open issues.
+
+Do not publish the later implementation slices until issues 01 and 02 record the
+target-framework, execution, and custom-action decisions. Their boundaries depend
+on whether Htmxor can delegate through the stock component endpoint invoker, how
+much .NET 11 is used, and which gaps require generated code or an upstream
+ASP.NET Core change.
+
+## Draft files
+
+| Draft | Purpose |
+| --- | --- |
+| [V1 goal](./goal.md) | Agreed product and engineering target |
+| [Orchestrator brief](./orchestrator-brief.md) | Agent input for progress tracking and next-slice selection |
+| [Progress record](./progress.md) | Last reviewed evidence, active work, and next candidate |
+| [Milestone](./proposed-milestone.md) | Stable-v1 outcome and release gates |
+| [Parent issue](./proposed-parent-issue.md) | Product contract, scope, sequencing, and later issue map |
+| [Issue 01](./proposed-issue-01-stock-invoker-spike.md) | Executable stock-invoker and target-framework decision |
+| [Issue 02](./proposed-issue-02-unsafe-verbs-spike.md) | Lifecycle-preserving unsafe-verb decision |
+| [Existing issue comments](./proposed-existing-issue-comments.md) | Proposed disposition without losing issue history or ownership |
+| [Open pull request comments](./proposed-open-pull-request-comments.md) | Proposed disposition for stale PRs #41 and #74 |
+
+## Inputs
+
+- [Stable v1 gap analysis](../../research/stable-v1-gap-analysis.md)
+- [Blazor static SSR progressive enhancement](../../research/blazor-static-ssr-progressive-enhancement.md)
+- [.NET 11 Blazor and ASP.NET Core opportunities](../../research/dotnet-11-blazor-aspnetcore-opportunities.md)
+- [HTMX backend framework comparison](../../research/htmx-backend-framework-comparison.md)
+- [Htmxor v1 interface sketch](../../research/htmxor-v1-interface-sketch.md)
+
+## Provisional implementation slices
+
+These are deliberately titles and outcomes, not ready-for-agent issues. Issues 01
+and 02 must settle their shared execution and action boundaries first.
+
+| ID | Type | Proposed outcome | Blocked by |
+| --- | --- | --- | --- |
+| 03 | HITL | Prove .NET 11 static-SSR validation when the first validatable form arrives in an HTMX swap | 01 |
+| 04 | HITL | Prove request-safe fragment caching with .NET 11 `CacheView` | 01 |
+| 05 | HITL | Freeze the convention-first route, action, fragment, and extension contract | 01-04 |
+| 06 | AFK | Preserve stock Blazor behavior when Htmxor is installed | 05 |
+| 07 | AFK | Generate normal-only, HTMX-only, and dual component GET routes | 06 |
+| 08 | AFK | Return one selected component fragment without rendering excluded branches | 07 |
+| 09 | AFK | Progressively enhance a stock `EditForm` POST | 03, 08 |
+| 10 | AFK | Generate secure PUT, PATCH, and DELETE component actions | 02, 08 |
+| 11 | AFK | Support caller-owned HTMX runtimes and a bounded protocol/analyzer extension seam | 06-08 |
+| 12 | AFK | Make full/fragment caching, history, errors, redirects, and authentication flows correct | 04, 09-11 |
+| 13 | AFK | Coexist with Interactive Server, WebAssembly, Auto, and enhanced navigation | 07, 09, 11 |
+| 14 | HITL | Set the v1 request-cost budget from repeatable measurements | 09-13 |
+| 15 | HITL | Prove the exact NuGet release candidate in clean and ForTheLeague consumers | 14 |
+
+## Review questions
+
+1. Is a decision gate before implementation the right publication boundary?
+2. Is unsafe-verb lifecycle dispatch the correct second architecture gate, or
+   should it be deferred until the stock GET/POST path is accepted?
+3. Does the provisional slicing keep each later issue narrow enough to be
+   independently assigned?
+4. Should ForTheLeague validation block Htmxor v1, or only block adopting it in
+   ForTheLeague?
+5. Are any existing issues separately owned and therefore inappropriate to fold
+   under the parent issue?

--- a/docs/roadmap/v1/goal.md
+++ b/docs/roadmap/v1/goal.md
@@ -1,0 +1,134 @@
+# Htmxor v1 goal
+
+Status: agreed product and engineering target.
+
+Htmxor v1 lets a Blazor developer add HTMX behavior to static server-rendered
+Razor components without creating a parallel controller or Minimal API layer.
+The `.razor` component owns its route, request handling, lifecycle, and output.
+
+Adding Htmxor to an existing Blazor static SSR application must not change pages
+that have not opted into HTMX behavior. Components built for stock static SSR,
+including third-party components, should keep working. A developer can then add
+HTMX one component or one interaction at a time.
+
+## Developer model
+
+A component can be available through normal Blazor routing, only to HTMX
+requests, or through both paths.
+
+- `@page` owns the normal Blazor route. By convention, it also makes the same
+  component available to a direct HTMX GET. A component can opt out and remain
+  normal-only.
+- A component without `@page` can declare an HTMX-only route in the `.razor`
+  file. Application code does not add a matching endpoint elsewhere.
+- GET is the only implicit HTTP method. Htmxor infers POST from stock Blazor form
+  declarations and infers POST, PUT, PATCH, or DELETE from statically
+  discoverable `@onpost`, `@onput`, `@onpatch`, or `@ondelete` bindings. `hx-*`
+  attributes describe how requests are initiated and may be checked for
+  consistency, but they do not expose server methods. Ambiguous or dynamic
+  handler bindings require a narrow explicit declaration and should produce a
+  useful build diagnostic.
+- Request handling runs on the component instance created for that request.
+  Route and query values, dependency injection, lifecycle methods, form state,
+  authentication state, and rendering all remain available. Static handler
+  methods that behave like Minimal API endpoints are not the v1 model.
+
+The common case should need no Htmxor-specific route or method configuration.
+Explicit configuration exists for exceptions, not as routine ceremony.
+
+## Full pages and fragments
+
+A normal request follows the stock Blazor page and layout path. A direct HTMX
+request can return the component output, one named fragment, several fragments,
+or out-of-band content declared by the component.
+
+`HtmxFragment` is the one fragment concept. It can render its child content
+without a wrapper. If the developer supplies element, identifier, or HTML
+attributes, the fragment wraps its child content and emits those values. There
+is no separate `HtmxFragmentElement` concept in v1.
+
+Fragment selection must have clear execution semantics. The component and any
+required ancestors may run their normal lifecycle, but Htmxor should not render
+excluded child branches below a known selection boundary. Tests and benchmarks
+must verify every claim that fragment selection avoids work.
+
+## Blazor remains in charge
+
+Htmxor adds another HTTP representation of a Razor component. It does not add a
+second component, form, validation, authorization, antiforgery, navigation, or
+rendering runtime.
+
+Stock `EditForm`, `Input*`, `DataAnnotationsValidator`, validation messages,
+`[SupplyParameterFromForm]`, named forms, and their lifecycle callbacks must work
+on progressively enhanced requests. Authorization metadata and antiforgery
+requirements must behave the same on normal and HTMX paths.
+
+Normal pages may contain Interactive Server, WebAssembly, or Auto components.
+A direct HTMX response is static SSR. Htmxor does not claim that a detached
+fragment can hydrate into an interactive component. The documentation must make
+DOM and navigation ownership clear when HTMX and interactive Blazor share a
+page.
+
+Htmxor should use supported ASP.NET Core and Blazor extension points. It must not
+depend on copied renderer code, private reflection, or global replacement of the
+stock renderer, endpoint invoker, routing state, navigation manager, or form
+runtime. If a public API is intended mainly for framework infrastructure, Htmxor
+must isolate it behind a replaceable internal boundary and test it on every
+supported .NET version.
+
+## The application owns HTMX
+
+Htmxor v1 does not require or distribute one specific HTMX runtime. The
+application chooses the script, version, extensions, content security policy,
+and upgrade schedule.
+
+The server integration must understand the stable HTTP protocol it needs and
+provide bounded hooks for new request headers, response headers, and extension
+behavior. An analyzer may validate values against a developer-selected HTMX
+profile. It must not reject unknown attributes, extension syntax, or newer
+values merely because Htmxor does not know them yet.
+
+## Security and HTTP behavior
+
+HTMX request headers are untrusted request data. HTMX-only routing is a
+reachability choice, not an authorization boundary.
+
+Every generated or adapted endpoint must retain the effective authorization,
+antiforgery, host, rate-limit, and other security metadata of the component
+route. Unsafe methods fail closed. The normalized route, HTTP method, and action
+identity are bound together, so information captured for one action cannot
+invoke another action or another method.
+
+Antiforgery validation runs before body binding or component callbacks for every
+unsafe method. Full-page and fragment responses must set correct cache variation,
+including HTMX and authentication-dependent inputs. Redirects, errors, history
+restoration, boosted requests, and response headers must retain their HTTP and
+browser meaning.
+
+## Performance and release standard
+
+Htmxor must publish repeatable cold, warm, and concurrent request measurements
+against stock Blazor static SSR. The measurements must include elapsed time,
+allocations, response bytes, and work skipped by fragment selection. V1 needs an
+explicit request-cost budget based on those results.
+
+The exact release-candidate package must pass the supported .NET compatibility
+matrix, security tests, browser conformance tests using application-supplied
+HTMX scripts, package validation, and a clean Production publish and consumer
+test. Project-reference tests alone are not release evidence.
+
+## Outside v1
+
+V1 does not include an Htmxor-owned HTMX browser bundle, hydration of detached
+HTMX fragments, streaming fragment updates, Native AOT support, or transparent
+runtime action discovery. These can be considered later without changing the
+component-owned route and lifecycle model.
+
+## Completion test
+
+V1 is complete when a developer can add Htmxor to a stock Blazor static SSR
+application, leave existing pages and forms unchanged, and progressively add
+component-owned HTMX routes, actions, and fragments without writing endpoint
+boilerplate or giving up Blazor behavior. The result must be secure by default,
+independent of the application's HTMX version, supported on the declared .NET
+versions, and within the published request-cost budget.

--- a/docs/roadmap/v1/orchestrator-brief.md
+++ b/docs/roadmap/v1/orchestrator-brief.md
@@ -1,0 +1,114 @@
+# Htmxor v1 orchestrator brief
+
+Use this brief as input to the agent responsible for moving Htmxor toward v1.
+
+## Objective
+
+Deliver [the agreed Htmxor v1 goal](./goal.md) one verified slice at a time.
+Keep the goal stable. Plan only far enough to choose and complete the next
+slice.
+
+## Sources of truth
+
+Read these in order:
+
+1. [The v1 goal](./goal.md) defines the product and engineering target.
+2. [The progress record](./progress.md) states the last reviewed position. Check
+   it against the repository before relying on it.
+3. The current repository and executable tests define what exists now.
+4. The research documents under `docs/research` explain known gaps and possible
+   approaches. Treat unproved approaches as hypotheses.
+5. The proposed milestone, parent issue, and issue drafts in this directory are
+   planning notes. They do not override the goal or current evidence.
+6. Once work moves to GitHub, live issue state and merged commits define delivery
+   progress. Recheck them instead of relying on an old summary.
+
+## Operating rule
+
+Keep one implementation slice in progress unless two slices are independent and
+the user approves parallel work. A slice must make one useful part of the v1
+goal observably true. Infrastructure belongs in the first slice that needs it.
+
+Do not decompose the whole v1 goal into implementation-ready issues in advance.
+Later work depends on what the current slice proves about Blazor and ASP.NET
+Core. Keep a short list of candidate next slices, then select one after reviewing
+the latest evidence.
+
+## Loop
+
+For each slice:
+
+1. Inspect the branch, commit, working tree, tests, open work, and relevant
+   framework contracts.
+2. State the protected behavior as: `When <scenario>, Htmxor <observable
+   outcome>.`
+3. Explain why this is the most important unfinished slice and which v1 risk it
+   removes.
+4. Choose the narrowest test boundary that includes the risk. Framework routing,
+   rendering, forms, security, browser behavior, packaging, and performance need
+   real boundaries rather than mocked substitutes.
+5. Record meaningful failing evidence before changing behavior. A compilation
+   error or missing dependency is not behavioral evidence.
+6. Implement the smallest coherent change that satisfies the protected
+   behavior. Do not pull later v1 features into the slice.
+7. Run the focused tests, then the broader applicable checks. Record the exact
+   commit and commands.
+8. Review the result against the v1 goal. Mark only proved behavior complete.
+9. Update the progress record and recommend one next slice.
+
+## Progress record
+
+Keep a concise record with these fields:
+
+- Current commit and supported framework/runtime under test.
+- Proven v1 behavior, with executable evidence.
+- Current slice and owner.
+- Known defects or failed experiments that affect the next decision.
+- Deferred v1 behavior and why it is deferred.
+- The recommended next slice, its protected behavior, and the evidence needed.
+- A human decision needed before work can continue, if any.
+
+Do not report research, code written, or tests added as completed behavior. State
+what a consumer can now do and cite the evidence that proves it.
+
+## Decision rules
+
+Prefer the next slice that does the most to reduce one of these risks:
+
+- Htmxor cannot run on the intended Blazor version through supported APIs.
+- Adding Htmxor changes stock Blazor behavior.
+- A request can bypass route, method, authorization, or antiforgery intent.
+- The component-owned route and lifecycle model cannot express a required use
+  case without endpoint boilerplate.
+- Fragment handling performs or transfers work it claims to avoid.
+- The application cannot choose and upgrade its own HTMX runtime.
+- Package, browser, cache, or performance behavior differs from project-reference
+  tests.
+
+Choose a thin end-to-end behavior over a broad internal refactor. Prefer a slice
+that leaves reusable verification behind.
+
+## Guardrails
+
+- Do not introduce application-authored controllers or Minimal API endpoints for
+  component routes.
+- Do not replace component instance callbacks with static endpoint handlers.
+- Do not copy private Blazor renderer code or use new private reflection.
+- Do not treat HTMX headers as authorization evidence.
+- Do not bind Htmxor to one embedded HTMX version.
+- Do not claim support for a .NET version, browser path, package, or performance
+  budget that was not executed.
+- Do not publish issues, pull requests, packages, or releases without the user's
+  approval.
+- Stop for a human decision when evidence requires changing the v1 goal, public
+  developer model, supported target framework, or security posture.
+
+## Cycle output
+
+At the end of each cycle, report:
+
+1. What consumer behavior became true.
+2. The commit and executable evidence.
+3. What remains unproved.
+4. The one recommended next slice and why it comes next.
+5. Any decision that needs the user.

--- a/docs/roadmap/v1/progress.md
+++ b/docs/roadmap/v1/progress.md
@@ -1,0 +1,64 @@
+# Htmxor v1 progress
+
+Last updated: 2026-08-26
+
+## Repository state
+
+- Baseline commit: `d8e09e4da17ab4c74fbea95d8e995137785c8395`
+- V1 implementation slices completed: none
+- Current implementation slice: none
+- Agreed target: [Htmxor v1 goal](./goal.md)
+
+## Proven current behavior
+
+The existing .NET 8 test suite passes 152 tests when its Playwright Chromium
+runtime is installed. It contains 150 unit, component, and hosted HTTP cases and
+two browser cases. The suite proves several prototype behaviors, including a
+normal and HTMX representation on one route, route-value binding, one selected
+fragment response, response-header construction, and two browser interactions.
+
+These are prototype characterization results. They do not prove the v1 goal.
+
+## Known blockers and defects
+
+- Every project and CI job targets .NET 8. The current private component
+  discovery path fails when used by a .NET 10 application.
+- A test sends PATCH with the DELETE callback identifier and expects the DELETE
+  callback to run. Route, method, and action identity are not safely bound.
+- Antiforgery validation covers POST, PUT, and PATCH in the custom invoker but
+  omits DELETE.
+- Existing browser tests use the embedded HTMX 1.9.12 script. They do not prove
+  application-owned HTMX compatibility.
+- The test application contains stock Blazor form and validation examples that
+  no test exercises.
+- No test covers Interactive Auto coexistence, cache variation, a packed-package
+  Production publish, or a request-cost budget.
+
+## Next candidate slice
+
+Protected behavior:
+
+> When a .NET 10 Blazor application adds Htmxor and maps one `@page` component,
+> the application starts, a normal GET follows the stock Blazor path, and a
+> direct HTMX GET returns the component representation without a controller,
+> Minimal API handler, or per-component endpoint declaration in application
+> code.
+
+This is a candidate, not an active commitment. Before starting it, the
+orchestrator must verify the current repository and framework APIs and confirm
+that no newer evidence makes another slice more urgent.
+
+## Decision expected after the slice
+
+The evidence should identify the supported endpoint execution path and whether
+.NET 10 can be the v1 baseline. If supported public APIs cannot preserve the
+component-owned route and stock normal request, stop and ask whether to require
+a newer .NET version or pursue an upstream ASP.NET Core change.
+
+## Deferred work
+
+Forms, unsafe methods, source generation, fragment optimization, caller-owned
+HTMX conformance, cache behavior, interactive islands, package verification,
+and performance budgets remain part of the v1 goal. Do not turn them into
+implementation-ready work until the current execution evidence makes their
+boundaries clear.

--- a/docs/roadmap/v1/proposed-existing-issue-comments.md
+++ b/docs/roadmap/v1/proposed-existing-issue-comments.md
@@ -1,0 +1,181 @@
+# Proposed comments for existing open issues
+
+Status: review draft only. Do not post these comments, change milestones, or close
+issues until the stable-v1 parent and owning child issues have real GitHub URLs.
+
+Replace placeholders such as `{parent}` and `{issue-11}` immediately before
+publication. Preserve any separately assigned owner and ask before changing an
+issue's labels, assignees, or milestone.
+
+## #11: htmx v2
+
+> The stable-v1 research confirms this remains release-blocking, but the desired
+> outcome is broader than replacing the embedded script. Htmxor should stop owning
+> the browser runtime, publish a tested HTMX 2 reference profile, and provide a
+> conformance runner and extension seam for application-supplied versions.
+>
+> Proposed owner: `{issue-11}` under `{parent}`. Keep this issue open until that
+> compatibility row passes; do not add a hard server-package dependency on a
+> specific HTMX version.
+
+## #15: browser logs
+
+> Proposed stable-v1 disposition: defer browser-log transport. V1 will provide
+> normal server-side HTTP tracing/correlation and browser integration hooks, but
+> it will not define event volume, serialization, privacy, or delivery semantics
+> for automatic browser-log forwarding.
+>
+> Keep this issue open outside the v1 milestone unless we agree on a bounded
+> contract. Parent context: `{parent}`.
+
+## #16: streaming
+
+> Proposed stable-v1 disposition: defer streaming fragment updates. Blazor
+> streaming SSR and HTMX fragment swapping do not currently form one supported
+> protocol, and the stock endpoint path must first prove its buffering and
+> response-completion behavior.
+>
+> Keep this issue open outside the v1 milestone. `{issue-01}` will record any
+> newly supported bounded case; otherwise v1 documents quiescent fragment
+> responses. Parent context: `{parent}`.
+
+## #18: response headers
+
+> This remains part of v1, but it should be implemented as a version-neutral,
+> typed request/response feature registry with protected-header rules. It should
+> not require Htmxor to release a new server package for every new HTMX header.
+>
+> Proposed owner: `{issue-11}` under `{parent}`. Close this issue only when the
+> public extension contract and HTTP-boundary coverage exist.
+
+## #30: event callback association
+
+> The research reproduced a more serious form of this problem: an action token is
+> not reliably bound to its HTTP method and route, so a PATCH request can select a
+> DELETE callback. Stable v1 should remove render-time callback replay and compile
+> statically discoverable component actions into method-bound endpoint metadata.
+>
+> Baseline owner: `{issue-02}`. Proposed fix owner: `{issue-10}` under `{parent}`.
+> Keep this issue open until the negative HTTP-boundary regression proves that an
+> action cannot be replayed under another route or verb.
+
+## #40: empty action URLs
+
+> The desired convention remains that an explicitly empty HTMX action URL means
+> the current route. Stable v1 should preserve that behavior, document it for
+> ordinary and nested routes, and cover it in the progressive-form/browser
+> compatibility slice.
+>
+> Proposed owners: `{issue-09}` and `{issue-10}` under `{parent}`. Close this issue
+> only after the documentation and route-level regressions exist.
+
+## #48: community standards
+
+> This remains a stable-release gate. The release-candidate slice should add the
+> security policy, supported-version policy, contribution guidance, and a clear
+> route for reporting vulnerabilities before v1 is tagged.
+>
+> Proposed owner: `{issue-15}` under `{parent}`. Preserve this issue until those
+> files are present in the exact release candidate.
+
+## #50: output caching
+
+> This remains a v1 and ForTheLeague adoption gate. Full and fragment
+> representations must vary correctly, anonymous cacheable GETs must not receive
+> an unnecessary per-user token cookie, and .NET 11 `CacheView` integration must
+> not cache request-dependent fragment selection. `CacheView` does not replace
+> HTTP `Vary` or output-cache policy. Because live cache holes reject
+> `RenderFragment`/`ChildContent` parameters, an outer cache should fail loudly
+> around `HtmxFragment`; a `CacheView` may instead cache stable content inside the
+> selected fragment.
+>
+> Proposed owner: `{issue-12}` under `{parent}`. Keep this issue open until cache
+> correctness and request-cost evidence pass at the HTTP boundary.
+
+## #56: CSRF token placement
+
+> Stable v1 should replace the readable response-wide cookie design with a
+> documented threat model and supported ASP.NET Core antiforgery/CSRF seams. Every
+> generated unsafe method must opt into validation and fail closed before
+> component code; the high-security profile must include synchronized-token
+> coverage even if .NET 11 automatic cross-origin protection is also used.
+>
+> Spike owner: `{issue-02}`. Proposed implementation owner: `{issue-10}` under
+> `{parent}`. Keep this issue open through security review.
+
+## #57: standard Blazor coexistence
+
+> This is now a top-level v1 contract: registering Htmxor must not alter an
+> ordinary Blazor page or form. Htmxor should reuse stock Blazor services and add
+> generated representations only for components that opt in by convention or
+> explicit metadata.
+>
+> Architecture owner: `{issue-01}`; implementation owners: `{issue-06}` and
+> `{issue-13}` under `{parent}`. Keep this issue open until
+> the zero-break integration suite passes.
+
+## #58: htmx extensions
+
+> HTMX extensions remain application-owned. Stable v1 should define a replaceable
+> browser adapter, typed server protocol hooks, pass-through behavior for unknown
+> `hx-*` markup, and a conformance runner. An analyzer may validate against a
+> selected known HTMX profile, but it must allow an application to teach it about
+> newer or custom extension values.
+>
+> Proposed owner: `{issue-11}` under `{parent}`. Keep this issue open until a
+> custom extension can be demonstrated without rebuilding Htmxor.Server.
+
+## #64: redirects
+
+> Redirects belong to the stock component lifecycle and the version-neutral HTMX
+> response layer, not a globally replaced `NavigationManager`. The v1 matrix must
+> cover local and external redirects, nested paths, status codes, history, normal
+> no-JavaScript form submission, and HTMX requests.
+>
+> Architecture owner: `{issue-01}`; proposed behavior owners: `{issue-09}` and
+> `{issue-12}` under `{parent}`. Keep this issue open until those browser and HTTP
+> cases pass.
+
+## #67: duplicate initialization
+
+> Duplicate component initialization and data loading must be reproduced before
+> v1 performance claims are accepted. The baseline should retain the AWS Lambda
+> scenario's causal details where practical and compare it with the selected
+> stock Blazor execution path.
+>
+> Reproduction and execution owner: `{issue-01}`; any remaining performance work
+> belongs to `{issue-14}`. Keep this issue open
+> until the duplicate work is either fixed or proven external to Htmxor with a
+> minimal authentic fixture.
+
+## #69: `hx-vals`
+
+> Stable v1 should preserve arbitrary valid `hx-*` attributes and document the
+> existing `hx-vals` component case. A helper is justified only if it materially
+> improves safe JSON encoding; it must not become a closed enum or a server
+> dependency on one HTMX release.
+>
+> Proposed owner: `{issue-11}` under `{parent}`. Close this issue after the
+> pass-through regression and documentation exist, or split a narrowly scoped
+> safe-encoding helper if the evidence warrants it.
+
+## #72: static files in Production
+
+> The previous publish-output explanation is not sufficient release evidence.
+> Stable v1 requires a clean Production publish and package-consumer test that
+> loads the application-owned HTMX asset and all framework static assets from the
+> exact release-candidate package.
+>
+> Baseline owner: `{issue-01}`; release owner: `{issue-15}` under `{parent}`. Keep
+> this issue open until the packaged Production smoke passes.
+
+## #75: static asset fingerprinting
+
+> This remains a release blocker and evidence against copying the framework
+> renderer. The selected execution seam must preserve Blazor's resource
+> collection and fingerprinted asset behavior, and the clean package consumer
+> must verify it after publish.
+>
+> Architecture owner: `{issue-01}`; release owner: `{issue-15}` under `{parent}`.
+> Keep this issue open until both the supported framework path and packaged smoke
+> are green.

--- a/docs/roadmap/v1/proposed-issue-01-stock-invoker-spike.md
+++ b/docs/roadmap/v1/proposed-issue-01-stock-invoker-spike.md
@@ -1,0 +1,117 @@
+# Proposed issue 01
+
+Status: review draft only.
+
+## Title
+
+`spike: execute Htmxor requests through Blazor's stock endpoint invoker`
+
+## Triage
+
+- Type: HITL for the final target-framework and execution decision; evidence
+  gathering and prototype work are AFK.
+- Proposed state after publication: needs spike
+- Parent: proposed stable-v1 parent issue
+
+## What to build
+
+Build a disposable vertical request path for one routed Razor component. The same
+component must handle a normal GET, a direct HTMX GET, one selected fragment, and
+a stock named `EditForm` POST. For an existing `@page`, compare wrapping the stock
+endpoint through public endpoint conventions with creating a separate generated
+endpoint. The candidate should use public
+`IRazorComponentEndpointInvoker`, `RootComponentMetadata`, and
+`ComponentTypeMetadata` so Blazor continues to own routing state, lifecycle, form
+mapping, validation, antiforgery, navigation, streaming, persistence completion,
+and framework assets.
+
+Compare that candidate with the current Htmxor pipeline and with a wrapper
+rendered through `RazorComponentResult`. The comparison is not an invitation to
+expose either framework API in application Razor code. Its purpose is to select a
+replaceable internal Htmxor executor and the minimum supported target framework.
+
+Use the .NET 11 public attribute-driven cascading-value registration seam to
+prototype Htmxor request context without editing a renderer's internal supplier
+collection. Assess the infrastructure-oriented component endpoint builder helper
+for an HTMX-only route and for the narrow route-builder access it actually
+provides; do not treat it as component discovery or convention propagation.
+
+## Acceptance criteria
+
+- [ ] The spike maps a component-owned route without an application-authored
+      controller or per-component Minimal API handler.
+- [ ] A direct GET runs through the stock component endpoint invoker without
+      replacing Blazor services or reflecting over private members.
+- [ ] For a dual `@page` route, a public final endpoint convention identifies the
+      stock page through public component metadata. A normal request runs the
+      original delegate unchanged; a direct request changes only the bounded
+      metadata/root representation needed by the stock delegate.
+- [ ] For an HTMX-only component, a generated endpoint is mapped on the exact
+      route builder obtained from the Razor component builder. Route-group prefix
+      and conventions are preserved, while conventions attached only to the
+      Razor-components builder are recorded as a distinct gap.
+- [ ] Route and query binding, authorization metadata, endpoint-group conventions,
+      navigation, redirects, status codes, and the normal page route match a stock
+      Razor component endpoint.
+- [ ] A named `EditForm` POST proves valid, invalid, malformed, missing, and
+      repeated values, `[SupplyParameterFromForm]`, antiforgery, exact callback
+      selection, and rerendered validation output.
+- [ ] The selected-fragment case records which component lifecycle and data work
+      still runs and proves that excluded child branches below the selection
+      boundary do not run when the candidate claims that optimization.
+- [ ] The `RazorComponentResult` comparison records behavior for named form
+      initialization, Session/TempData completion, persistent component state,
+      browser initializers, streaming, redirects, and static assets. Missing
+      behavior is recorded rather than copied from a private renderer.
+- [ ] Htmxor request context reaches the component through the .NET 11 public
+      cascading-value registration seam without global service replacement.
+- [ ] The public component endpoint builder helper is tested for route-builder
+      access, and the result explicitly records that it does not expose discovered
+      components or automatically propagate later conventions unless evidence
+      proves otherwise.
+- [ ] A normal route with Auto applied at the root is compared with a direct static
+      response. A component carrying its own definition-level
+      `@rendermode InteractiveAuto` is tested separately because the stock renderer
+      has no public per-invocation switch to ignore that boundary.
+- [ ] The current .NET 10 startup/discovery failure, duplicate lifecycle work,
+      Production asset behavior, and fingerprinted framework assets are captured
+      as versioned comparison fixtures.
+- [ ] .NET 10 and the inspected .NET 11 preview are compared. APIs and behaviors
+      are marked shipped, preview, deliberately infrastructure oriented,
+      internal, open/draft, or inferred.
+- [ ] The result recommends a v1 target-framework baseline, one internal request
+      execution path, and a fallback or upstream request for every blocking gap.
+- [ ] No production library behavior is introduced by the spike.
+- [ ] A human accepts the execution and target-framework decision before the
+      convention/public-API issue becomes ready for agents.
+
+## Verification contract
+
+- **Protected behavior:** When Htmxor handles another representation of a routed
+  component request, stock Blazor still owns the component lifecycle and its
+  normal GET/POST framework behavior.
+- **Risk and evidence:** Framework drift and false form/rendering parity; hosted
+  integration tests execute real ASP.NET Core routing, dependency injection,
+  middleware, component endpoint invocation, form mapping, rendering, and static
+  web assets on the compared frameworks.
+- **Observation seam:** HTTP requests and responses from the mapped endpoints,
+  plus a deterministic component lifecycle/data probe when avoided work is the
+  protected behavior.
+- **Boundary fidelity:** Use the real .NET 10 and installed .NET 11 preview Blazor
+  services and endpoint implementations. Replace only application data with a
+  deterministic probe; do not replace routing, rendering, form, antiforgery,
+  persistence, or asset services.
+- **Meaningful red:** The current private endpoint-discovery path reproduces its
+  .NET 10 failure, and the result-only candidate fails any stock endpoint parity
+  checks for behavior it genuinely omits. A green candidate must execute the real
+  protected framework path.
+- **Success evidence:** One supported candidate passes the bounded GET/POST and
+  fragment comparison, its remaining gaps have explicit owners, and the chosen
+  executor can change internally without changing application Razor call sites.
+- **Residual risk:** This spike does not solve non-POST callback dispatch, the
+  first-validatable-form HTMX boot edge, all `CacheView` isolation cases, the full
+  source generator, browser-runtime conformance, or release performance budgets.
+
+## Blocked by
+
+None - can start immediately.

--- a/docs/roadmap/v1/proposed-issue-02-unsafe-verbs-spike.md
+++ b/docs/roadmap/v1/proposed-issue-02-unsafe-verbs-spike.md
@@ -1,0 +1,107 @@
+# Proposed issue 02
+
+Status: review draft only.
+
+## Title
+
+`spike: bind PUT, PATCH, and DELETE to live component instances`
+
+## Triage
+
+- Type: HITL for the supported verb/action-scope decision; evidence gathering and
+  prototype work are AFK.
+- Proposed state after publication: needs spike
+- Parent: proposed stable-v1 parent issue
+
+## What to build
+
+Prove whether Htmxor can compile `@onput`, `@onpatch`, and `@ondelete` Razor event
+declarations into method- and route-bound handlers that run on the component
+instance created by the supported Blazor request lifecycle.
+
+The developer-facing model remains Razor event syntax. Do not replace callbacks
+with static methods that are Minimal API handlers placed inside a `.razor` file.
+Do not discover actions by rendering a component, scanning a runtime render tree,
+or trusting a client-supplied callback hash.
+
+The spike should test how far a source generator can infer server intent from
+`@on*` method groups in the page and statically reachable child components.
+Literal `hx-*` attributes may be checked against that intent for consistency,
+but they must not expand the server method allow-list. Dynamic handler
+expressions, lambdas, generic or dynamic child composition, and multiple page
+routes must receive explicit supported semantics or actionable build
+diagnostics.
+
+Evaluate the .NET 11 public cascading subscription API as a possible way for
+generated code to register the actual component instance. Do not assume instance
+observation also supplies a supported pre-response async dispatch or rerender
+serialization hook; prove those separately.
+
+## Acceptance criteria
+
+- [ ] The spike confirms and records the stock component endpoint invoker's
+      current POST boundary on .NET 10 and the inspected .NET 11 preview.
+- [ ] At least one PUT, PATCH, or DELETE request invokes a method group on the live
+      component instance after route, query, request, authentication, and normal
+      component lifecycle state have been supplied.
+- [ ] Authorization and antiforgery/CSRF validation finish before form/body binding
+      or application callback code for every supported unsafe verb.
+- [ ] Normalized route and HTTP method are part of action identity. A PATCH request
+      carrying information associated with a DELETE action cannot invoke the
+      DELETE callback.
+- [ ] A component with several actions and several `@page` routes dispatches only
+      the statically matching route, method, and callback.
+- [ ] Statically discoverable `@onpost`, `@onput`, `@onpatch`, and `@ondelete`
+      method-group bindings demonstrate the intended inferred allow-list. Literal
+      `hx-*` attributes are checked for mismatches without granting another
+      method. GET remains the only default when no unsafe handler intent is
+      provable.
+- [ ] Page-local and statically reachable child-component declarations are tested.
+      The result states where graph inference stops and what narrow override is
+      required for dynamic or third-party composition.
+- [ ] Lambdas, computed attribute values, missing callbacks, duplicate matches, and
+      ambiguous routes produce deterministic supported behavior or build
+      diagnostics rather than a broad runtime method allowance.
+- [ ] The .NET 11 cascading subscription candidate records whether it can observe
+      the correct live component instance and whether it can dispatch and render
+      the action response before the stock endpoint writes output. Its
+      renderer-implementation-detail status is included in the support decision.
+- [ ] The candidate uses no static local endpoint method, private renderer access,
+      runtime callback discovery, or globally replaced Blazor service.
+- [ ] If no supported framework path preserves instance lifecycle, the issue
+      produces an upstream-ready ASP.NET Core seam proposal and a human decision
+      to reduce v1's custom unsafe-verb scope rather than ship an undocumented
+      renderer fork.
+- [ ] No production library behavior is introduced by the spike.
+
+## Verification contract
+
+- **Protected behavior:** When a Razor component declares one unsafe HTMX action,
+  only the matching HTTP method and route can invoke that callback, and it runs
+  with the component's normal request lifecycle state after security succeeds.
+- **Risk and evidence:** Method confusion, route confusion, callback replay, and
+  bypassed framework lifecycle/security; hosted HTTP integration tests exercise
+  real routing, authentication/authorization, antiforgery/CSRF, binding, component
+  construction, and generated dispatch.
+- **Observation seam:** An actual unsafe HTTP request followed by the component's
+  public response or durable test-visible outcome. Build diagnostics are observed
+  through generator/analyzer compilation tests for statically ambiguous cases.
+- **Boundary fidelity:** Keep ASP.NET Core routing, security middleware, request
+  binding, and Blazor component execution real. Use deterministic application
+  state and identities; do not mock the security or dispatch boundary being
+  proved.
+- **Meaningful red:** The current PATCH-with-DELETE-identifier request invokes the
+  wrong callback at the starting revision. Reversing the proposed method/route
+  binding must make the negative HTTP test fail for that same reason.
+- **Success evidence:** One supported instance-dispatch design passes the positive
+  and negative verb matrix and has compile-time behavior for every analyzed Razor
+  declaration shape, or the maintainer accepts a reduced v1 verb contract backed
+  by an upstream proposal.
+- **Residual risk:** This spike does not implement the production source generator,
+  complete form-validation UI, caller-owned HTMX adapter, cache/history policy, or
+  release security review.
+
+## Blocked by
+
+- Proposed issue 01 must first select the supported stock GET/POST execution path
+  and component-instance lifecycle boundary.

--- a/docs/roadmap/v1/proposed-milestone.md
+++ b/docs/roadmap/v1/proposed-milestone.md
@@ -1,0 +1,72 @@
+# Proposed milestone: Htmxor v1
+
+Status: review draft only.
+
+The milestone implements [the agreed Htmxor v1 goal](./goal.md). If this tracker
+draft conflicts with the goal, the goal wins.
+
+## Title
+
+`Htmxor v1`
+
+## Description
+
+Deliver a stable, secure, convention-over-configuration integration between
+Blazor static server-side rendering and an application-owned HTMX runtime.
+
+The v1 differentiator is preserved: a developer owns routes and request behavior
+in `.razor` components. They do not create a parallel controller or Minimal API
+endpoint for every component. A component can be reachable as a normal Blazor
+page, only by an HTMX request, or by both. The same component can return a full
+page or selected server-declared fragments while retaining normal Blazor
+lifecycle, forms, validation, authorization, and antiforgery behavior.
+
+## Exit gates
+
+- Ordinary Blazor static-SSR pages and forms behave the same after Htmxor is
+  registered when they have not opted into HTMX behavior.
+- Htmxor uses supported ASP.NET Core and Blazor extension points on its supported
+  target frameworks. Any deliberately used infrastructure API is isolated,
+  documented, version-tested, and replaceable.
+- Component routes and statically discoverable actions are generated or mapped
+  without application-authored endpoint boilerplate and without render-time
+  callback discovery.
+- Normal-only, HTMX-only, and dual reachability have safe conventions and
+  explicit overrides.
+- Full responses, one selected fragment, multiple fragments, and out-of-band
+  updates have executable HTTP-boundary coverage.
+- Stock `EditForm`, built-in input and validation components, and representative
+  third-party static-SSR components work without a separate Htmxor form runtime.
+- Unsafe methods are allow-listed from component intent and fail closed for
+  authorization and CSRF. A request cannot replay an action under another route
+  or HTTP method.
+- Applications own the HTMX script and may upgrade it independently. The server
+  has version-neutral request/response hooks, while analyzers validate against a
+  selectable known-feature profile without rejecting future extension markup.
+- Full and fragment representations have correct cache and history variation.
+  Public anonymous GETs do not acquire an unnecessary per-user token cookie.
+- Repeatable benchmarks cover cold and warm requests, concurrent requests,
+  response bytes, allocations, and excluded fragment work against stock Blazor
+  and full-document baselines.
+- Static HTMX regions coexist with Interactive Server, WebAssembly, and Auto
+  islands under a documented single-owner rule for navigation and DOM updates.
+- The exact release-candidate package passes package validation, Production
+  publish smoke tests, security review, and a clean consumer integration.
+
+## Explicitly outside the initial v1 commitment
+
+- Htmxor-owned or pinned distribution of the HTMX browser runtime.
+- Treating HTMX-only reachability as an authorization boundary.
+- Transparent action discovery that cannot be proved statically.
+- Replacement of Blazor's renderer, endpoint invoker, navigation manager, or
+  form runtime with copied private framework code.
+- Hydrating a detached HTMX fragment as an Interactive Auto component.
+- Streaming HTMX fragment updates, Native AOT, browser-log transport, and full
+  document-head merging unless a bounded spike proves them without delaying the
+  core release.
+
+## Schedule
+
+Do not assign a due date until the public execution-seam spike selects the
+supported target framework and identifies any required upstream ASP.NET Core
+work.

--- a/docs/roadmap/v1/proposed-open-pull-request-comments.md
+++ b/docs/roadmap/v1/proposed-open-pull-request-comments.md
@@ -1,0 +1,36 @@
+# Proposed comments for open pull requests
+
+Status: review draft only. Both pull requests were still open when checked on
+2026-08-26. Do not post, close, rebase, or otherwise modify them without explicit
+approval.
+
+## PR #41: `feat: Add HtmxorComponentResult and HtmxorHtmlRenderer`
+
+> The stable-v1 research confirms the problem this draft was exploring, but it
+> does not yet support merging a custom component result and renderer as the v1
+> execution boundary. The current ASP.NET Core comparison shows that a generic
+> `RazorComponentResult` path does not perform all routed-component endpoint work,
+> including named form initialization and some request-completion behavior. A
+> copied renderer would also preserve the private-framework maintenance burden v1
+> is intended to remove.
+>
+> Proposed next step: keep this PR unchanged while `{issue-01}` compares its
+> behavior with a generated endpoint that delegates through Blazor's stock
+> component endpoint invoker. Reuse useful tests or design discoveries with
+> attribution. After the decision, either narrow the PR to the accepted internal
+> seam or close it as superseded with a link to the spike evidence. Do not merge
+> or ask the author to rebase before that decision.
+
+## PR #74: `fix UseEmbeddedHtmx being ignored`
+
+> This fixes a real inconsistency in the prototype option, but the stable-v1
+> direction removes the premise of the option: applications always own the HTMX
+> script and Htmxor publishes compatibility evidence and adapter hooks instead of
+> embedding a runtime that can be disabled.
+>
+> Proposed next step: preserve the PR discussion as evidence for the Production
+> static-asset regression in issues #72 and #75. Once `{issue-11}` exists for the
+> caller-owned runtime and `{issue-15}` owns the exact-package Production smoke,
+> close this PR as superseded rather than merge a switch that the v1 package
+> should no longer expose. Do not discard any independent header-property fix; if
+> one exists, split it into a narrowly scoped issue or PR after review.

--- a/docs/roadmap/v1/proposed-parent-issue.md
+++ b/docs/roadmap/v1/proposed-parent-issue.md
@@ -1,0 +1,124 @@
+# Proposed parent issue
+
+Status: review draft only.
+
+This issue tracks [the agreed Htmxor v1 goal](./goal.md). The goal is the source
+of truth for product and engineering scope.
+
+## Title
+
+`Htmxor stable v1: idiomatic Blazor routes with version-independent HTMX`
+
+## Why
+
+The prototype established a valuable developer model: a `.razor` component owns
+its route, can participate in an ordinary Blazor page load, and can return only
+the region an HTMX request needs. It also accumulated framework-private routing
+and rendering dependencies, globally replaced standard Blazor services, bundled
+an old HTMX runtime, exposed unsafe HTTP methods too broadly, and did not close
+the performance or security evidence needed for a stable release.
+
+Stable v1 should retain the product idea and replace the prototype architecture.
+
+## Product contract
+
+- Route ownership remains in `.razor` files. Applications do not define one
+  controller or Minimal API handler per component.
+- Convention is preferred over configuration. `@page`, standard Blazor form
+  declarations, `hx-*` attributes, and statically discoverable `@on*` handlers
+  provide intent; explicit metadata is required only when the safe default
+  cannot be inferred or must be overridden.
+- `@page` supplies the normal route and, by default, the matching direct HTMX GET
+  route. An explicit declaration opts a page out of direct HTMX reachability.
+  `[HtmxRoute]` on a component without `@page` supplies an HTMX-only route.
+- GET is the only implicit HTTP method. Statically discoverable standard forms
+  and `@onpost`, `@onput`, `@onpatch`, or `@ondelete` bindings provide server-side
+  intent for unsafe methods. `hx-*` attributes describe request initiation and
+  may be checked for consistency, but they do not expose server methods.
+  Ambiguous or dynamic handler bindings require a diagnostic and a narrow
+  explicit override.
+- A component can be normal-only, HTMX-only, or available through both paths.
+- A normal request uses the normal Blazor page and layout path. An HTMX request
+  may receive the whole component response or one or more declared fragments.
+- `HtmxFragmentElement` does not remain a second concept. Optional element,
+  identifier, and unmatched attributes belong on `HtmxFragment`, which wraps its
+  child content only when requested.
+- Component instance lifecycle remains in play. V1 does not replace actions with
+  static methods that amount to colocated Minimal API handlers.
+- Stock static-SSR components remain stock components. Htmxor adds another HTTP
+  representation; it does not create another form, validation, authorization,
+  antiforgery, navigation, or rendering runtime.
+- Full Blazor pages may contain Interactive Server, WebAssembly, or Auto islands.
+  Direct HTMX responses are honest static SSR and never claim to hydrate a
+  detached interactive fragment.
+- The application owns the HTMX browser runtime and upgrade cadence. Htmxor
+  supplies a tested compatibility profile and replaceable protocol hooks, not a
+  hard runtime version dependency.
+- Analyzers can reject or warn on values that are invalid for a selected known
+  HTMX profile. Unknown `hx-*` attributes, newer values, and registered extension
+  syntax remain valid so the analyzer does not become an accidental runtime
+  version lock.
+
+## Work sequence
+
+### Gate 1: establish evidence
+
+1. Capture a repeatable stock-Blazor and current-prototype baseline, including
+   the known startup, lifecycle, form, static-asset, and cache cases while proving
+   a direct endpoint through the stock Blazor invoker.
+2. Prove whether generated PUT, PATCH, and DELETE handlers can invoke the live
+   component instance through supported framework seams while remaining bound to
+   the declared route and HTTP method.
+
+Only these two issues should be made ready for agents initially.
+
+### Gate 2: tracer-bullet implementation
+
+After the execution decision, break the following outcomes into reviewed,
+independently assignable issues:
+
+1. generated component-owned routes and all three reachability modes;
+2. progressively enhanced stock Blazor forms and static-SSR components;
+3. full, selected, multiple, and out-of-band fragment rendering;
+4. lifecycle-preserving unsafe-verb actions with fail-closed security;
+5. caller-owned HTMX runtime and extensible request/response protocol;
+6. correct caching, history, and measured per-request work;
+7. coexistence with interactive render modes and enhanced navigation; and
+8. package, publish, documentation, security, and consumer evidence.
+
+### Gate 3: release validation
+
+Publish an RC from the exact verified package. Complete a bounded consumer cycle,
+including a separately owned ForTheLeague tracer bullet if that project is to
+block stable release. Resolve RC findings before tagging v1.
+
+## Acceptance criteria
+
+- [ ] Every milestone exit gate is owned by a child issue or explicitly deferred
+      with rationale and a future owner.
+- [ ] The first architecture decision is backed by an executable comparison, not
+      only an interface proposal.
+- [ ] Every behavior-changing child issue carries a verification contract with a
+      meaningful failure and success observation.
+- [ ] Existing open issues receive a disposition comment that links to the exact
+      owning child issue or records why they remain deferred.
+- [ ] Existing issues are not closed until their promised behavior, documentation,
+      or regression evidence exists.
+- [ ] No child issue introduces per-component controller or Minimal API ceremony
+      into application code.
+- [ ] Stable-v1 evidence is produced from the exact release-candidate commit and
+      package.
+
+## Blocked by
+
+None - this parent can be created after review.
+
+## Research inputs
+
+- Stable v1 gap analysis
+- Blazor static SSR progressive-enhancement analysis
+- .NET 11 Blazor and ASP.NET Core opportunity analysis
+- HTMX backend framework comparison
+- Htmxor v1 interface sketch
+
+These should be linked to their repository paths when the issue is published.


### PR DESCRIPTION
## Summary

- Capture the Blazor, HTMX, backend-framework, security, progressive-enhancement, compatibility, and performance research behind v1.
- Define the agreed component-owned and convention-first v1 goal.
- Add an orchestrator brief and progress record for choosing one verified slice at a time.
- Preserve proposed tracker drafts for review without treating later slices as implementation-ready.

## Why

Htmxor needs a stable product and engineering target before the prototype architecture changes. The goal keeps routes and request handling in Razor components, preserves stock Blazor behavior, makes the application own its HTMX runtime, and requires secure method binding plus measured request cost.

## Verification

- Relative Markdown links resolve.
- `git diff --check` passes.
- Documentation-only change; no product tests were required.