### PR TITLE
feat: route direct HTMX GETs through stock Blazor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,9 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: |
+          8.0.x
+          10.0.x
 
     - name: Restore local tools
       run: dotnet tool restore --tool-manifest .config/dotnet-tools.json
@@ -141,7 +143,9 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: |
+          8.0.x
+          10.0.x
 
     - name: Restore local tools
       run: dotnet tool restore --tool-manifest .config/dotnet-tools.json
@@ -213,7 +217,9 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: |
+          8.0.x
+          10.0.x
 
     - run: dotnet build --configuration Release
 

--- a/Htmxor.sln
+++ b/Htmxor.sln
@@ -35,6 +35,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MinimalHtmxorApp", "samples
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HtmxorExamples", "samples\HtmxorExamples\HtmxorExamples.csproj", "{2B36AAB9-AD16-4D46-8FB5-D78EDC003F90}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Htmxor.AspNetCore10.Tests", "test\Htmxor.AspNetCore10.Tests\Htmxor.AspNetCore10.Tests.csproj", "{29758C0F-8B99-4557-92A3-A34EF6A8C4CD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -73,6 +75,10 @@ Global
 		{2B36AAB9-AD16-4D46-8FB5-D78EDC003F90}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2B36AAB9-AD16-4D46-8FB5-D78EDC003F90}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2B36AAB9-AD16-4D46-8FB5-D78EDC003F90}.Release|Any CPU.Build.0 = Release|Any CPU
+		{29758C0F-8B99-4557-92A3-A34EF6A8C4CD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{29758C0F-8B99-4557-92A3-A34EF6A8C4CD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{29758C0F-8B99-4557-92A3-A34EF6A8C4CD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{29758C0F-8B99-4557-92A3-A34EF6A8C4CD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -86,6 +92,7 @@ Global
 		{59324821-EF01-40F6-9674-81094C4229A7} = {8D4A2D7D-532C-4B68-B5D0-17873D49FB0D}
 		{3A90B20F-9E9B-454D-9EF9-72B10D4D1F54} = {8D4A2D7D-532C-4B68-B5D0-17873D49FB0D}
 		{2B36AAB9-AD16-4D46-8FB5-D78EDC003F90} = {8D4A2D7D-532C-4B68-B5D0-17873D49FB0D}
+		{29758C0F-8B99-4557-92A3-A34EF6A8C4CD} = {BB63193F-EEC0-4EE6-B89E-9B4E1983E2FF}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {430F7B4E-864E-44B7-84A0-A903E7386E3B}

--- a/docs/roadmap/v1/progress.md
+++ b/docs/roadmap/v1/progress.md
@@ -1,64 +1,73 @@
 # Htmxor v1 progress
 
-Last updated: 2026-08-26
+Last updated: 2026-08-27
 
 ## Repository state
 
-- Baseline commit: `d8e09e4da17ab4c74fbea95d8e995137785c8395`
-- V1 implementation slices completed: none
-- Current implementation slice: none
-- Agreed target: [Htmxor v1 goal](./goal.md)
+- Baseline commit for the first v1 slice: `66139317b9edae1fff2ff73fa5175381ee3487b1`.
+- Verified implementation commit for issue #78: `8dcca3c0749cf53e310b1dff9dc22612b0d5e8f5`.
+- Framework boundary under test: a real ASP.NET Core 10 and Blazor static SSR test host consuming the project-referenced `net8.0` Htmxor library.
+- V1 implementation slices proved on this tree: issue #78, stock `@page` routing with a direct HTMX GET.
+- Current implementation slice after #78: none. Recheck PR #80 and `origin/main` before starting the next slice.
 
-## Proven current behavior
-
-The existing .NET 8 test suite passes 152 tests when its Playwright Chromium
-runtime is installed. It contains 150 unit, component, and hosted HTTP cases and
-two browser cases. The suite proves several prototype behaviors, including a
-normal and HTMX representation on one route, route-value binding, one selected
-fragment response, response-header construction, and two browser interactions.
-
-These are prototype characterization results. They do not prove the v1 goal.
-
-## Known blockers and defects
-
-- Every project and CI job targets .NET 8. The current private component
-  discovery path fails when used by a .NET 10 application.
-- A test sends PATCH with the DELETE callback identifier and expects the DELETE
-  callback to run. Route, method, and action identity are not safely bound.
-- Antiforgery validation covers POST, PUT, and PATCH in the custom invoker but
-  omits DELETE.
-- Existing browser tests use the embedded HTMX 1.9.12 script. They do not prove
-  application-owned HTMX compatibility.
-- The test application contains stock Blazor form and validation examples that
-  no test exercises.
-- No test covers Interactive Auto coexistence, cache variation, a packed-package
-  Production publish, or a request-cost budget.
-
-## Next candidate slice
+## Proven v1 behavior
 
 Protected behavior:
 
-> When a .NET 10 Blazor application adds Htmxor and maps one `@page` component,
-> the application starts, a normal GET follows the stock Blazor path, and a
-> direct HTMX GET returns the component representation without a controller,
-> Minimal API handler, or per-component endpoint declaration in application
-> code.
+> When a .NET 10 Blazor static SSR application adds Htmxor and maps one `@page`
+> component, Htmxor preserves the normal stock full-page GET and returns the
+> endpoint-selected component for a direct HTMX GET without a parallel
+> application endpoint.
 
-This is a candidate, not an active commitment. Before starting it, the
-orchestrator must verify the current repository and framework APIs and confirm
-that no newer evidence makes another slice more urgent.
+The hosted test proves that one `.razor` file owns the route, the application
+starts, and exactly one component endpoint represents that page. A normal GET
+uses the stock Blazor shell. A direct HTMX GET to the same route returns the
+page component without that shell. Both responses retain application-supplied
+endpoint metadata.
 
-## Decision expected after the slice
+The public integration captures the stock Razor Components request delegate in
+a final endpoint convention. Normal requests call it unchanged. For a direct
+HTMX GET, Htmxor gives that delegate a request-local copy of the selected route
+endpoint, preserving its route pattern, order, display name, and ordered
+metadata while replacing only its root component metadata. The internal direct
+host renders the `RouteData` already selected by the stock invoker, so it does
+not perform a second routing pass.
 
-The evidence should identify the supported endpoint execution path and whether
-.NET 10 can be the v1 baseline. If supported public APIs cannot preserve the
-component-owned route and stock normal request, stop and ask whether to require
-a newer .NET version or pursue an upstream ASP.NET Core change.
+The new public path does not use private reflection, copy Blazor renderer code,
+add a controller or Minimal API handler, declare a duplicate application route,
+or replace stock routing, rendering, navigation, or endpoint-invoker services.
+The old prototype remains internal to the legacy test application for behavior
+that later slices have not replaced.
 
-## Deferred work
+## Executable evidence
 
-Forms, unsafe methods, source generation, fragment optimization, caller-owned
-HTMX conformance, cache behavior, interactive islands, package verification,
-and performance budgets remain part of the v1 goal. Do not turn them into
-implementation-ready work until the current execution evidence makes their
-boundaries clear.
+- Meaningful red at `66139317b9edae1fff2ff73fa5175381ee3487b1`: the new .NET 10 hosted test discovered and executed one test, then failed during real application startup with the expected `NullReferenceException` in the obsolete private-reflection component discovery path.
+- Focused proof at `8dcca3c0749cf53e310b1dff9dc22612b0d5e8f5`: `dotnet test test/Htmxor.AspNetCore10.Tests/Htmxor.AspNetCore10.Tests.csproj --configuration Release --no-restore --blame-hang --blame-hang-timeout 5min` discovered and executed 1 test; 1 passed, 0 failed, 0 skipped.
+- Broader proof at the same clean commit: `dotnet run --project eng/Htmxor.Quality/Htmxor.Quality.csproj -- check --profile fast` passed 102 quality tests, 1 .NET 10 hosted test, and 150 existing non-browser tests. Total: 253 passed, 0 failed, 0 skipped, 0 errors, and 0 timeouts. The Release build produced 0 warnings and 0 errors.
+- Mutation testing was not run. Issue #78 makes it optional diagnostic evidence for this proof of concept.
+
+## Remaining limits
+
+- This is a project-reference proof, not packed-package or release-candidate evidence.
+- The test does not exercise route or query parameters, layouts, forms, unsafe methods, authorization, antiforgery enforcement, caching, concurrency, enhanced navigation, interactive render modes, browser behavior, application-selected HTMX runtimes, or performance.
+- The legacy test application still uses internal private-reflection discovery and global service replacements. Later slices must replace the behavior they cover instead of extending that prototype.
+- HTMX-only component routes and component-owned actions have not moved to the new public path.
+
+## Recommended next slice
+
+Protected behavior:
+
+> When a direct HTMX GET selects a stock `@page` component with route and query
+> values and an injected service, Htmxor supplies those values to the selected
+> component and runs its normal lifecycle once without a second routing pass or
+> a parallel application endpoint.
+
+This comes next because issue #78 established a small host that renders the
+stock invoker's `RouteData` directly. Route values, query values, dependency
+injection, and lifecycle execution are the nearest unproved parts of that seam.
+A .NET 10 hosted integration test should observe the rendered values and a
+request-scoped lifecycle sentinel through normal and direct GETs. Authorization,
+forms, unsafe methods, fragments, browser conformance, packaging, and performance
+remain later slices.
+
+No new implementation issue has been published for this candidate.

--- a/eng/Htmxor.Quality/QualityPlan.cs
+++ b/eng/Htmxor.Quality/QualityPlan.cs
@@ -54,6 +54,7 @@ internal static class QualityPlanFactory
 		var tests = new[]
 		{
 			Test(repositoryRoot, resultsDirectory, "test/Htmxor.Quality.Tests/Htmxor.Quality.Tests.csproj", "quality", null, collectCoverage: false),
+			Test(repositoryRoot, resultsDirectory, "test/Htmxor.AspNetCore10.Tests/Htmxor.AspNetCore10.Tests.csproj", "aspnetcore10", null, collectCoverage: false),
 			Test(repositoryRoot, resultsDirectory, "test/Htmxor.Tests/Htmxor.Tests.csproj", "htmxor", filter, collectCoverage),
 		};
 		return new(CommonPreparation(repositoryRoot), tests, null);

--- a/src/Htmxor/Builder/HtmxorComponentEndpointRouteBuilderExtensions.cs
+++ b/src/Htmxor/Builder/HtmxorComponentEndpointRouteBuilderExtensions.cs
@@ -1,6 +1,10 @@
 using System.Reflection;
 using Htmxor.Builder;
+using Htmxor.Endpoints;
+using Htmxor.Http;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Endpoints;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 
 #pragma warning disable IDE0130
@@ -9,7 +13,21 @@ namespace Microsoft.AspNetCore.Builder;
 
 public static class HtmxorComponentEndpointRouteBuilderExtensions
 {
+	private static readonly RootComponentMetadata DirectRootComponent = new(typeof(HtmxorDirectRenderHost));
+
 	public static RazorComponentsEndpointConventionBuilder AddHtmxorComponentEndpoints(
+		this RazorComponentsEndpointConventionBuilder builder,
+		IEndpointRouteBuilder endpoints)
+	{
+		ArgumentNullException.ThrowIfNull(builder);
+		ArgumentNullException.ThrowIfNull(endpoints);
+		builder.Finally(ConfigureEndpoint);
+
+		return builder;
+	}
+
+	// The legacy test application retains duplicate prototype endpoints until their deferred behavior is replaced.
+	internal static RazorComponentsEndpointConventionBuilder AddLegacyHtmxorComponentEndpoints(
 		this RazorComponentsEndpointConventionBuilder builder,
 		IEndpointRouteBuilder endpoints)
 	{
@@ -19,6 +37,58 @@ public static class HtmxorComponentEndpointRouteBuilderExtensions
 		endpoints.DataSources.Add(new ComponentEndpointDataSource(componentTypes));
 
 		return builder;
+	}
+
+	private static void ConfigureEndpoint(EndpointBuilder endpointBuilder)
+	{
+		if (endpointBuilder is not RouteEndpointBuilder ||
+			endpointBuilder.RequestDelegate is not { } stockRequestDelegate ||
+			!endpointBuilder.Metadata.OfType<ComponentTypeMetadata>().Any() ||
+			!endpointBuilder.Metadata.OfType<RootComponentMetadata>().Any())
+		{
+			return;
+		}
+
+		endpointBuilder.RequestDelegate = context => InvokeEndpoint(context, stockRequestDelegate);
+	}
+
+	private static async Task InvokeEndpoint(HttpContext context, RequestDelegate stockRequestDelegate)
+	{
+		if (!HttpMethods.IsGet(context.Request.Method) ||
+			context.GetHtmxContext().Request.RoutingMode is not RoutingMode.Direct)
+		{
+			await stockRequestDelegate(context);
+			return;
+		}
+
+		var selectedEndpoint = context.GetEndpoint() as RouteEndpoint
+			?? throw new InvalidOperationException("A routed Razor component endpoint must be selected before invocation.");
+		// The stock invoker reads its root component from the selected endpoint.
+		// Change only this request's view of that endpoint.
+		context.SetEndpoint(CreateDirectEndpoint(selectedEndpoint));
+		try
+		{
+			await stockRequestDelegate(context);
+		}
+		finally
+		{
+			context.SetEndpoint(selectedEndpoint);
+		}
+	}
+
+	private static RouteEndpoint CreateDirectEndpoint(RouteEndpoint selectedEndpoint)
+	{
+		var requestDelegate = selectedEndpoint.RequestDelegate
+			?? throw new InvalidOperationException("A routed Razor component endpoint must have a request delegate.");
+		var metadata = selectedEndpoint.Metadata
+			.Select(item => item is RootComponentMetadata ? DirectRootComponent : item)
+			.ToArray();
+		return new RouteEndpoint(
+			requestDelegate,
+			selectedEndpoint.RoutePattern,
+			selectedEndpoint.Order,
+			new EndpointMetadataCollection(metadata),
+			selectedEndpoint.DisplayName);
 	}
 
 	// Instead of reimplementing the discovery logic from Blazor with all the configuration options it provides,

--- a/src/Htmxor/DependencyInjection/HtmxorApplicationBuilderExtensions.cs
+++ b/src/Htmxor/DependencyInjection/HtmxorApplicationBuilderExtensions.cs
@@ -35,6 +35,32 @@ public static class HtmxorApplicationBuilderExtensions
 	{
 		ArgumentNullException.ThrowIfNull(razorComponentsBuilder);
 		var services = razorComponentsBuilder.Services;
+		services.AddHttpContextAccessor();
+		services.AddSingleton(serviceProvider =>
+		{
+			var config = new HtmxConfig
+			{
+				Antiforgery = new HtmxorAntiforgeryOptions(serviceProvider.GetRequiredService<IOptions<AntiforgeryOptions>>()),
+			};
+			configureHtmx?.Invoke(config);
+			return config;
+		});
+		services.AddScoped(serviceProvider =>
+		{
+			var httpContext = serviceProvider.GetRequiredService<IHttpContextAccessor>().HttpContext
+				?? throw new InvalidOperationException("HtmxContext is only available during an HTTP request.");
+			return httpContext.GetHtmxContext();
+		});
+		services.AddCascadingValue(serviceProvider => serviceProvider.GetRequiredService<HtmxContext>());
+
+		return razorComponentsBuilder;
+	}
+
+	// The legacy test application retains the prototype pipeline while its deferred behaviors are characterized.
+	internal static IRazorComponentsBuilder AddLegacyHtmx(this IRazorComponentsBuilder razorComponentsBuilder, Action<HtmxConfig>? configureHtmx = null)
+	{
+		AddHtmx(razorComponentsBuilder, configureHtmx);
+		var services = razorComponentsBuilder.Services;
 
 		// Override routing
 		services.TryAddEnumerable(ServiceDescriptor.Singleton<MatcherPolicy, ComponentEndpointMatcherPolicy>());
@@ -66,19 +92,6 @@ public static class HtmxorApplicationBuilderExtensions
 
 		services.Remove(services.Single(x => x.ServiceType == typeof(NavigationManager)));
 		services.AddScoped<NavigationManager, HtmxorNavigationManager>();
-
-		// Add Htmxor services
-		services.AddSingleton(x =>
-		{
-			var config = new HtmxConfig
-			{
-				Antiforgery = new HtmxorAntiforgeryOptions(x.GetRequiredService<IOptions<AntiforgeryOptions>>()),
-			};
-			configureHtmx?.Invoke(config);
-			return config;
-		});
-		services.AddScoped(srv => srv.GetRequiredService<HtmxorRenderer>().HttpContext!.GetHtmxContext());
-		services.AddCascadingValue(sp => sp.GetRequiredService<HtmxContext>());
 
 		return razorComponentsBuilder;
 	}

--- a/src/Htmxor/Endpoints/HtmxorDirectRenderHost.cs
+++ b/src/Htmxor/Endpoints/HtmxorDirectRenderHost.cs
@@ -13,14 +13,6 @@ internal sealed class HtmxorDirectRenderHost : ComponentBase
 	{
 		var routeData = RoutingStateProvider.RouteData
 			?? throw new InvalidOperationException("The stock Razor component invoker did not initialize route data.");
-		builder.OpenComponent<Router>(0);
-		builder.AddComponentParameter(1, nameof(Router.AppAssembly), routeData.PageType.Assembly);
-		builder.AddComponentParameter(2, nameof(Router.Found), (RenderFragment<RouteData>)RenderRoute);
-		builder.CloseComponent();
-	}
-
-	private static RenderFragment RenderRoute(RouteData routeData) => builder =>
-	{
 		builder.OpenComponent<DynamicComponent>(0);
 		builder.AddComponentParameter(1, nameof(DynamicComponent.Type), routeData.PageType);
 		builder.AddComponentParameter(
@@ -28,5 +20,5 @@ internal sealed class HtmxorDirectRenderHost : ComponentBase
 			nameof(DynamicComponent.Parameters),
 			routeData.RouteValues.ToDictionary(pair => pair.Key, pair => pair.Value));
 		builder.CloseComponent();
-	};
+	}
 }

--- a/src/Htmxor/Endpoints/HtmxorDirectRenderHost.cs
+++ b/src/Htmxor/Endpoints/HtmxorDirectRenderHost.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.AspNetCore.Components.Routing;
+
+namespace Htmxor.Endpoints;
+
+internal sealed class HtmxorDirectRenderHost : ComponentBase
+{
+	[Inject]
+	private IRoutingStateProvider RoutingStateProvider { get; set; } = default!;
+
+	protected override void BuildRenderTree(RenderTreeBuilder builder)
+	{
+		var routeData = RoutingStateProvider.RouteData
+			?? throw new InvalidOperationException("The stock Razor component invoker did not initialize route data.");
+		builder.OpenComponent<Router>(0);
+		builder.AddComponentParameter(1, nameof(Router.AppAssembly), routeData.PageType.Assembly);
+		builder.AddComponentParameter(2, nameof(Router.Found), (RenderFragment<RouteData>)RenderRoute);
+		builder.CloseComponent();
+	}
+
+	private static RenderFragment RenderRoute(RouteData routeData) => builder =>
+	{
+		builder.OpenComponent<DynamicComponent>(0);
+		builder.AddComponentParameter(1, nameof(DynamicComponent.Type), routeData.PageType);
+		builder.AddComponentParameter(
+			2,
+			nameof(DynamicComponent.Parameters),
+			routeData.RouteValues.ToDictionary(pair => pair.Key, pair => pair.Value));
+		builder.CloseComponent();
+	};
+}

--- a/src/Htmxor/Htmxor.csproj
+++ b/src/Htmxor/Htmxor.csproj
@@ -73,6 +73,7 @@
 
 	<ItemGroup>
 		<InternalsVisibleTo Include="$(AssemblyName).Tests" />
+		<InternalsVisibleTo Include="Htmxor.TestApp" />
 		<Using Include="System.Diagnostics.CodeAnalysis" />
 	</ItemGroup>
 

--- a/test/Htmxor.AspNetCore10.Tests/Htmxor.AspNetCore10.Tests.csproj
+++ b/test/Htmxor.AspNetCore10.Tests/Htmxor.AspNetCore10.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk.Razor">
+
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
+		<CodeMetricsProfile>tests</CodeMetricsProfile>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+		<RootNamespace>Htmxor.AspNetCore10</RootNamespace>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.11" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+		<PackageReference Include="xunit" Version="2.8.0" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Htmxor\Htmxor.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/test/Htmxor.AspNetCore10.Tests/Issue78App.razor
+++ b/test/Htmxor.AspNetCore10.Tests/Issue78App.razor
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<body data-stock-shell>
+    <Router AppAssembly="typeof(Issue78App).Assembly">
+        <Found Context="routeData">
+            <RouteView RouteData="routeData" />
+        </Found>
+    </Router>
+</body>
+</html>

--- a/test/Htmxor.AspNetCore10.Tests/Issue78Page.razor
+++ b/test/Htmxor.AspNetCore10.Tests/Issue78Page.razor
@@ -1,0 +1,12 @@
+@page "/issue-78"
+
+<h1 data-issue-78-page>Stock route page</h1>
+<p data-route-metadata="@RouteMetadata">@RouteMetadata</p>
+
+@code {
+    [CascadingParameter]
+    private HttpContext HttpContext { get; set; } = default!;
+
+    private string? RouteMetadata
+        => HttpContext.GetEndpoint()?.Metadata.GetMetadata<RouteSentinelMetadata>()?.Value;
+}

--- a/test/Htmxor.AspNetCore10.Tests/Issue78RoutingTests.cs
+++ b/test/Htmxor.AspNetCore10.Tests/Issue78RoutingTests.cs
@@ -1,0 +1,79 @@
+using System.Net;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Components.Endpoints;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Htmxor.AspNetCore10;
+
+public sealed class Issue78RoutingTests : IAsyncLifetime
+{
+	private WebApplication app = default!;
+	private HttpClient client = default!;
+
+	public async Task InitializeAsync()
+	{
+		var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+		{
+			ApplicationName = typeof(Issue78RoutingTests).Assembly.GetName().Name,
+			EnvironmentName = Environments.Development,
+		});
+		builder.WebHost.UseTestServer();
+		builder.Services.AddRazorComponents().AddHtmx();
+
+		app = builder.Build();
+		app.UseAntiforgery();
+		app.MapRazorComponents<Issue78App>()
+			.WithMetadata(RouteSentinelMetadata.Instance)
+			.AddHtmxorComponentEndpoints(app);
+
+		await app.StartAsync();
+		client = app.GetTestClient();
+	}
+
+	[Fact]
+	public async Task StockPage_normal_and_htmx_gets_use_one_component_route()
+	{
+		var pageEndpoints = ((IEndpointRouteBuilder)app).DataSources
+			.SelectMany(dataSource => dataSource.Endpoints)
+			.OfType<RouteEndpoint>()
+			.Where(endpoint => endpoint.Metadata.GetMetadata<ComponentTypeMetadata>()?.Type == typeof(Issue78Page));
+		Assert.Single(pageEndpoints);
+
+		using var normalResponse = await client.GetAsync("/issue-78");
+		var normalBody = await normalResponse.Content.ReadAsStringAsync();
+		Assert.Equal(HttpStatusCode.OK, normalResponse.StatusCode);
+		Assert.Contains("<html", normalBody, StringComparison.OrdinalIgnoreCase);
+		Assert.Contains("data-stock-shell", normalBody, StringComparison.Ordinal);
+		Assert.Contains("data-issue-78-page", normalBody, StringComparison.Ordinal);
+		Assert.Contains("data-route-metadata=\"preserved\"", normalBody, StringComparison.Ordinal);
+
+		using var htmxRequest = new HttpRequestMessage(HttpMethod.Get, "/issue-78");
+		htmxRequest.Headers.Add("HX-Request", "true");
+		using var htmxResponse = await client.SendAsync(htmxRequest);
+		var htmxBody = await htmxResponse.Content.ReadAsStringAsync();
+		Assert.Equal(HttpStatusCode.OK, htmxResponse.StatusCode);
+		Assert.Contains("data-issue-78-page", htmxBody, StringComparison.Ordinal);
+		Assert.Contains("data-route-metadata=\"preserved\"", htmxBody, StringComparison.Ordinal);
+		Assert.DoesNotContain("<html", htmxBody, StringComparison.OrdinalIgnoreCase);
+		Assert.DoesNotContain("data-stock-shell", htmxBody, StringComparison.Ordinal);
+	}
+
+	public async Task DisposeAsync()
+	{
+		client?.Dispose();
+		if (app is not null)
+		{
+			await app.DisposeAsync();
+		}
+	}
+}
+
+internal sealed record RouteSentinelMetadata(string Value)
+{
+	public static RouteSentinelMetadata Instance { get; } = new("preserved");
+}

--- a/test/Htmxor.AspNetCore10.Tests/_Imports.razor
+++ b/test/Htmxor.AspNetCore10.Tests/_Imports.razor
@@ -1,0 +1,4 @@
+@namespace Htmxor.AspNetCore10
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Http

--- a/test/Htmxor.AspNetCore10.Tests/_Usings.cs
+++ b/test/Htmxor.AspNetCore10.Tests/_Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/test/Htmxor.Quality.Tests/QualityCommandTests.cs
+++ b/test/Htmxor.Quality.Tests/QualityCommandTests.cs
@@ -98,8 +98,10 @@ public sealed class QualityCommandTests
 			"summary.json");
 		using var summary = JsonDocument.Parse(File.ReadAllText(summaryPath));
 		var testRuns = summary.RootElement.GetProperty("testRuns").EnumerateArray().ToArray();
-		Assert.Equal(2, testRuns.Length);
+		Assert.Equal(3, testRuns.Length);
 		Assert.All(testRuns, run => Assert.Equal(1, run.GetProperty("total").GetInt32()));
+		var aspNetCore10 = Assert.Single(testRuns, run => run.GetProperty("project").GetString() == "test/Htmxor.AspNetCore10.Tests/Htmxor.AspNetCore10.Tests.csproj");
+		Assert.False(aspNetCore10.GetProperty("coverageRequired").GetBoolean());
 		var htmxor = Assert.Single(testRuns, run => run.GetProperty("project").GetString() == "test/Htmxor.Tests/Htmxor.Tests.csproj");
 		Assert.True(htmxor.GetProperty("coverageRequired").GetBoolean());
 		Assert.Equal(JsonValueKind.Null, htmxor.GetProperty("coverageReport").ValueKind);

--- a/test/Htmxor.Quality.Tests/QualityPlanTests.cs
+++ b/test/Htmxor.Quality.Tests/QualityPlanTests.cs
@@ -13,7 +13,8 @@ public sealed class QualityPlanTests
 		var plan = Create(QualityAction.Check, QualityProfile.Fast);
 
 		AssertCommonPreparation(plan.Preparation);
-		Assert.Equal(2, plan.Tests.Count);
+		Assert.Equal(3, plan.Tests.Count);
+		AssertAspNetCore10Boundary(plan);
 		var htmxor = Assert.Single(plan.Tests, test => test.Project == "test/Htmxor.Tests/Htmxor.Tests.csproj");
 		Assert.Equal(
 			[
@@ -44,7 +45,8 @@ public sealed class QualityPlanTests
 		var plan = Create(QualityAction.Check, QualityProfile.Full);
 
 		AssertCommonPreparation(plan.Preparation);
-		Assert.Equal(2, plan.Tests.Count);
+		Assert.Equal(3, plan.Tests.Count);
+		AssertAspNetCore10Boundary(plan);
 		var htmxor = Assert.Single(plan.Tests, test => test.Project == "test/Htmxor.Tests/Htmxor.Tests.csproj");
 		Assert.Equal(
 			[
@@ -112,6 +114,14 @@ public sealed class QualityPlanTests
 
 	private QualityPlan Create(QualityAction action, QualityProfile profile) =>
 		QualityPlanFactory.Create(repositoryRoot, resultsDirectory, new(action, profile));
+
+	private void AssertAspNetCore10Boundary(QualityPlan plan)
+	{
+		var test = Assert.Single(plan.Tests, test => test.Project == "test/Htmxor.AspNetCore10.Tests/Htmxor.AspNetCore10.Tests.csproj");
+		Assert.DoesNotContain("--collect", test.Command.Arguments);
+		Assert.DoesNotContain("--filter", test.Command.Arguments);
+		Assert.False(test.RequiresCoverage);
+	}
 
 	private void AssertCommonPreparation(IReadOnlyList<ProcessCommand> commands)
 	{

--- a/test/Htmxor.TestApp/Program.cs
+++ b/test/Htmxor.TestApp/Program.cs
@@ -1,7 +1,7 @@
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
-builder.Services.AddRazorComponents().AddHtmx();
+builder.Services.AddRazorComponents().AddLegacyHtmx();
 builder.Services.AddSingleton<TimeProvider>(TimeProvider.System);
 
 var app = builder.Build();
@@ -11,6 +11,6 @@ app.UseAntiforgery()
    .UseHtmxAntiforgery();
 
 app.MapRazorComponents<Htmxor.TestApp.App>()
-   .AddHtmxorComponentEndpoints(app);
+   .AddLegacyHtmxorComponentEndpoints(app);
 
 app.Run();


### PR DESCRIPTION
Closes #78.

## What changed

- Add a .NET 10 hosted fixture that maps one stock `@page` component through `MapRazorComponents()` plus Htmxor.
- Keep normal GET requests on the captured stock Blazor request delegate.
- For a direct HTMX GET, give that delegate a request-local copy of the selected route endpoint. Preserve its route pattern, order, display name, and ordered metadata while replacing only the root component metadata.
- Render the `RouteData` already selected by the stock invoker. The direct host does not run a second `Router` pass.
- Keep the legacy prototype registration internal for existing characterization coverage. The new public path does not replace stock routing, rendering, navigation, or endpoint-invoker services.
- Add the .NET 10 proof to the repository fast and full profiles and CI SDK setup.
- Update the committed v1 progress record with the proved seam, residual risks, and one unpublished next candidate.

## Why

This is the first v1 tracer bullet. Later routing, forms, security, and fragment work depends on knowing that Htmxor can extend stock Blazor static SSR through supported .NET 10 APIs. Keeping the minimal implementation and hosted test in the repository gives later changes an executable regression boundary. Documentation snippets would not provide that protection.

## Protected behavior

When a .NET 10 Blazor static SSR application adds Htmxor and maps one `@page` component, Htmxor preserves the normal full-page GET and returns the endpoint-selected component for a direct HTMX GET without a controller, Minimal API handler, or duplicate application route.

## Review correction

Copilot identified that the first version rendered a second `<Router>` after endpoint routing had already selected the component. Commit `8dcca3c0749cf53e310b1dff9dc22612b0d5e8f5` removes that second decision and renders `IRoutingStateProvider.RouteData` directly. The existing green POC was the behavior-preserving baseline; no speculative route-edge behavior or tests were added beyond #78.

## Verification

Meaningful red was recorded on base `66139317b9edae1fff2ff73fa5175381ee3487b1`. The new hosted test discovered and ran one test, then failed during real application startup in the obsolete private-reflection component-discovery path.

Exact reviewed head: `dfa49920e499e5bf5306e76af8a781cfd3a4cc28`.

- Focused .NET 10 hosted proof: 1 discovered and executed, 1 passed, 0 failed, 0 skipped.
- `dotnet run --project eng/Htmxor.Quality/Htmxor.Quality.csproj -- check --profile fast`: valid at a clean exact head.
- Fast profile: 102 quality tests, 1 .NET 10 hosted test, and 150 existing non-browser tests passed. Total: 253 passed, 0 failed, 0 skipped, 0 errors, 0 timeouts.
- Release build: 0 warnings and 0 errors.
- Separate Standards and Spec re-reviews completed at the exact head with no findings.

## Deliberate limits

This POC does not prove HTMX-only routes, route or query parameters, forms, unsafe methods, authorization parity, antiforgery enforcement, layouts, caching, concurrency, browser behavior, interactive modes, package consumption, performance, or HTMX runtime compatibility. Mutation testing is optional for #78 and was not run. Those areas remain later v1 work rather than reasons to expand this slice.
