### PR TITLE
fix: preserve every Blazor route constraint type for direct HTMX GETs

### DIFF
--- a/docs/roadmap/v1/progress.md
+++ b/docs/roadmap/v1/progress.md
@@ -6,9 +6,10 @@ Last updated: 2026-08-27
 
 - Baseline commit for the first v1 slice: `66139317b9edae1fff2ff73fa5175381ee3487b1`.
 - Verified implementation commit for issue #78: `8dcca3c0749cf53e310b1dff9dc22612b0d5e8f5`.
+- Verified implementation commit for issue #81: `0c3fec1b8c3425ef37c2d93a5fa131f3b0c2a649`.
 - Framework boundary under test: a real ASP.NET Core 10 and Blazor static SSR test host consuming the project-referenced `net8.0` Htmxor library.
-- V1 implementation slices proved on this tree: issue #78, stock `@page` routing with a direct HTMX GET.
-- Current implementation slice after #78: none. Recheck PR #80 and `origin/main` before starting the next slice.
+- V1 implementation slices proved on this tree: issue #78, stock `@page` routing with a direct HTMX GET; issue #81, every documented .NET 10 Blazor component-route constraint plus typed optional presence and absence.
+- Current implementation slice after #81: none. Recheck issue #81, branch publication state, and `origin/main` before starting the next slice.
 
 ## Proven v1 behavior
 
@@ -39,35 +40,75 @@ or replace stock routing, rendering, navigation, or endpoint-invoker services.
 The old prototype remains internal to the legacy test application for behavior
 that later slices have not replaced.
 
+Protected behavior for issue #81:
+
+> When a direct HTMX GET selects a stock `@page` component whose route uses any
+> route constraint supported by Blazor on .NET 10, Htmxor supplies the same typed
+> route values, query value, and request-scoped dependency as stock Blazor and
+> initializes one component instance without another route or application
+> endpoint.
+
+The proved constraint and parameter-type set is:
+
+- `bool` to `System.Boolean`;
+- `datetime` to `System.DateTime`;
+- `decimal` to `System.Decimal`;
+- `double` to `System.Double`;
+- `float` to `System.Single`;
+- `guid` to `System.Guid`;
+- `int` to `System.Int32`;
+- `long` to `System.Int64`;
+- `nonfile` to `System.String`.
+
+The hosted matrix proves representative valid typed output and rejected-input
+parity for every constraint, including rejection of the file-like
+`document.txt` by `nonfile`. A constrained optional `int` has matching present
+and absent behavior. Every successful normal and direct request retains the
+query value, request-scoped service value, and initialization count `1`. Each
+component-owned route template has one endpoint. Normal responses retain the
+stock application shell and direct responses omit it.
+
+The direct host passes the endpoint-selected `RouteData` through the stock
+public `Router`. Its endpoint-supplied route-data path performs Blazor's
+constrained-value processing and returns the selected component without another
+route match. The existing endpoint routing, query supplier, dependency
+injection, lifecycle, and static SSR renderer remain in charge. The supported
+path neither copies nor extends the legacy hand-written conversion switch.
+
 ## Executable evidence
 
 - Meaningful red at `66139317b9edae1fff2ff73fa5175381ee3487b1`: the new .NET 10 hosted test discovered and executed one test, then failed during real application startup with the expected `NullReferenceException` in the obsolete private-reflection component discovery path.
 - Focused proof at `8dcca3c0749cf53e310b1dff9dc22612b0d5e8f5`: `dotnet test test/Htmxor.AspNetCore10.Tests/Htmxor.AspNetCore10.Tests.csproj --configuration Release --no-restore --blame-hang --blame-hang-timeout 5min` discovered and executed 1 test; 1 passed, 0 failed, 0 skipped.
 - Broader proof at the same clean commit: `dotnet run --project eng/Htmxor.Quality/Htmxor.Quality.csproj -- check --profile fast` passed 102 quality tests, 1 .NET 10 hosted test, and 150 existing non-browser tests. Total: 253 passed, 0 failed, 0 skipped, 0 errors, and 0 timeouts. The Release build produced 0 warnings and 0 errors.
 - Mutation testing was not run. Issue #78 makes it optional diagnostic evidence for this proof of concept.
+- Meaningful red for the complete issue #81 matrix at `29cecb64a8bf9466c3bd7c2dfdb9874d347edcb0`: `dotnet test test/Htmxor.AspNetCore10.Tests/Htmxor.AspNetCore10.Tests.csproj --configuration Release --no-restore --blame-hang --blame-hang-timeout 5min` discovered and executed 21 tests; 12 passed, 9 failed, 0 skipped. Direct GETs returned `500` for all eight typed constraints and for a present optional `int`, while their normal GETs returned `200`. The `nonfile` valid case, all nine rejected-input parity cases, optional absence, and the issue #78 route test passed before the production change.
+- Focused proof at clean implementation commit `0c3fec1b8c3425ef37c2d93a5fa131f3b0c2a649`: the same command discovered and executed 21 tests; 21 passed, 0 failed, 0 skipped.
+- Broader proof at the same clean implementation commit: `dotnet run --project eng/Htmxor.Quality/Htmxor.Quality.csproj -- check --profile fast` passed 102 quality tests, 21 .NET 10 hosted tests, and 150 existing non-browser tests. Total: 273 discovered, 273 executed, 273 passed, 0 failed, 0 skipped, 0 errors, and 0 timeouts. The Release build produced 0 warnings and 0 errors.
+- Mutation testing was not run. Issue #81 makes it optional diagnostic evidence for this proof of concept.
 
 ## Remaining limits
 
 - This is a project-reference proof, not packed-package or release-candidate evidence.
-- The test does not exercise route or query parameters, layouts, forms, unsafe methods, authorization, antiforgery enforcement, caching, concurrency, enhanced navigation, interactive render modes, browser behavior, application-selected HTMX runtimes, or performance.
+- The matrix uses one representative valid and rejected value per documented constraint. It does not exhaust textual representations, undocumented custom conversion constraints, catch-all routes, or unconstrained routes.
+- The direct path is proved on ASP.NET Core 10 only. The supported framework matrix and packed-package consumption remain unproved.
+- The test does not exercise layouts, forms, unsafe methods, authorization, antiforgery enforcement, caching, concurrency, enhanced navigation, interactive render modes, browser behavior, application-selected HTMX runtimes, or performance.
 - The legacy test application still uses internal private-reflection discovery and global service replacements. Later slices must replace the behavior they cover instead of extending that prototype.
 - HTMX-only component routes and component-owned actions have not moved to the new public path.
 
 ## Recommended next slice
 
-Protected behavior:
+Protected behavior for the recommended next slice:
 
-> When a direct HTMX GET selects a stock `@page` component with route and query
-> values and an injected service, Htmxor supplies those values to the selected
-> component and runs its normal lifecycle once without a second routing pass or
-> a parallel application endpoint.
+> When a stock `@page` component requires an authorization policy, Htmxor
+> enforces the same policy and supplies the same authenticated user on normal
+> and direct GETs without treating HTMX request headers as authorization
+> evidence.
 
-This comes next because issue #78 established a small host that renders the
-stock invoker's `RouteData` directly. Route values, query values, dependency
-injection, and lifecycle execution are the nearest unproved parts of that seam.
-A .NET 10 hosted integration test should observe the rendered values and a
-request-scoped lifecycle sentinel through normal and direct GETs. Authorization,
-forms, unsafe methods, fragments, browser conformance, packaging, and performance
-remain later slices.
+This comes next because the request-local endpoint copy retains authorization
+metadata structurally, but no test proves policy enforcement or authentication
+state on the direct path. A .NET 10 hosted integration test should use real
+authentication and authorization middleware, one component policy, and normal
+and direct HTTP requests. Forms, unsafe methods, antiforgery, fragments, browser
+conformance, packaging, and performance remain later slices.
 
 No new implementation issue has been published for this candidate.

--- a/src/Htmxor/Endpoints/HtmxorDirectRenderHost.cs
+++ b/src/Htmxor/Endpoints/HtmxorDirectRenderHost.cs
@@ -13,6 +13,15 @@ internal sealed class HtmxorDirectRenderHost : ComponentBase
 	{
 		var routeData = RoutingStateProvider.RouteData
 			?? throw new InvalidOperationException("The stock Razor component invoker did not initialize route data.");
+		// Router consumes the endpoint-selected RouteData and processes its values without matching the route again.
+		builder.OpenComponent<Router>(0);
+		builder.AddComponentParameter(1, nameof(Router.AppAssembly), routeData.PageType.Assembly);
+		builder.AddComponentParameter(2, nameof(Router.Found), (RenderFragment<RouteData>)RenderRoute);
+		builder.CloseComponent();
+	}
+
+	private static RenderFragment RenderRoute(RouteData routeData) => builder =>
+	{
 		builder.OpenComponent<DynamicComponent>(0);
 		builder.AddComponentParameter(1, nameof(DynamicComponent.Type), routeData.PageType);
 		builder.AddComponentParameter(
@@ -20,5 +29,5 @@ internal sealed class HtmxorDirectRenderHost : ComponentBase
 			nameof(DynamicComponent.Parameters),
 			routeData.RouteValues.ToDictionary(pair => pair.Key, pair => pair.Value));
 		builder.CloseComponent();
-	}
+	};
 }

--- a/test/Htmxor.AspNetCore10.Tests/Issue78RoutingTests.cs
+++ b/test/Htmxor.AspNetCore10.Tests/Issue78RoutingTests.cs
@@ -24,6 +24,7 @@ public sealed class Issue78RoutingTests : IAsyncLifetime
 		});
 		builder.WebHost.UseTestServer();
 		builder.Services.AddRazorComponents().AddHtmx();
+		builder.Services.AddScoped(_ => new Issue81RequestProbe("from-di"));
 
 		app = builder.Build();
 		app.UseAntiforgery();
@@ -63,6 +64,32 @@ public sealed class Issue78RoutingTests : IAsyncLifetime
 		Assert.DoesNotContain("data-stock-shell", htmxBody, StringComparison.Ordinal);
 	}
 
+	[Fact]
+	public async Task Bound_stock_page_normal_and_htmx_gets_receive_the_same_request_values_once()
+	{
+		var pageEndpoints = ((IEndpointRouteBuilder)app).DataSources
+			.SelectMany(dataSource => dataSource.Endpoints)
+			.OfType<RouteEndpoint>()
+			.Where(endpoint => endpoint.Metadata.GetMetadata<ComponentTypeMetadata>()?.Type == typeof(Issue81Page));
+		Assert.Single(pageEndpoints);
+
+		using var normalResponse = await client.GetAsync("/issue-81/42?query=from-query");
+		var normalBody = await normalResponse.Content.ReadAsStringAsync();
+		Assert.Equal(HttpStatusCode.OK, normalResponse.StatusCode);
+		Assert.Contains("<html", normalBody, StringComparison.OrdinalIgnoreCase);
+		Assert.Contains("data-stock-shell", normalBody, StringComparison.Ordinal);
+		Assert.Contains("data-issue-81-values>42|from-query|from-di|1</p>", normalBody, StringComparison.Ordinal);
+
+		using var htmxRequest = new HttpRequestMessage(HttpMethod.Get, "/issue-81/42?query=from-query");
+		htmxRequest.Headers.Add("HX-Request", "true");
+		using var htmxResponse = await client.SendAsync(htmxRequest);
+		var htmxBody = await htmxResponse.Content.ReadAsStringAsync();
+		Assert.Equal(HttpStatusCode.OK, htmxResponse.StatusCode);
+		Assert.Contains("data-issue-81-values>42|from-query|from-di|1</p>", htmxBody, StringComparison.Ordinal);
+		Assert.DoesNotContain("<html", htmxBody, StringComparison.OrdinalIgnoreCase);
+		Assert.DoesNotContain("data-stock-shell", htmxBody, StringComparison.Ordinal);
+	}
+
 	public async Task DisposeAsync()
 	{
 		client?.Dispose();
@@ -76,4 +103,13 @@ public sealed class Issue78RoutingTests : IAsyncLifetime
 internal sealed record RouteSentinelMetadata(string Value)
 {
 	public static RouteSentinelMetadata Instance { get; } = new("preserved");
+}
+
+internal sealed class Issue81RequestProbe(string value)
+{
+	private int initializationCount;
+
+	public string Value { get; } = value;
+
+	public int RecordInitialization() => ++initializationCount;
 }

--- a/test/Htmxor.AspNetCore10.Tests/Issue78RoutingTests.cs
+++ b/test/Htmxor.AspNetCore10.Tests/Issue78RoutingTests.cs
@@ -64,28 +64,94 @@ public sealed class Issue78RoutingTests : IAsyncLifetime
 		Assert.DoesNotContain("data-stock-shell", htmxBody, StringComparison.Ordinal);
 	}
 
-	[Fact]
-	public async Task Bound_stock_page_normal_and_htmx_gets_receive_the_same_request_values_once()
+	[Theory]
+	[InlineData("/issue-81/bool/{BoolValue:bool}", "/issue-81/bool/true", "System.Boolean", "True")]
+	[InlineData("/issue-81/datetime/{DateTimeValue:datetime}", "/issue-81/datetime/2026-08-27", "System.DateTime", "2026-08-27T00:00:00.0000000")]
+	[InlineData("/issue-81/decimal/{DecimalValue:decimal}", "/issue-81/decimal/123.45", "System.Decimal", "123.45")]
+	[InlineData("/issue-81/double/{DoubleValue:double}", "/issue-81/double/123.5", "System.Double", "123.5")]
+	[InlineData("/issue-81/float/{FloatValue:float}", "/issue-81/float/123.5", "System.Single", "123.5")]
+	[InlineData("/issue-81/guid/{GuidValue:guid}", "/issue-81/guid/01234567-89ab-cdef-0123-456789abcdef", "System.Guid", "01234567-89ab-cdef-0123-456789abcdef")]
+	[InlineData("/issue-81/int/{IntValue:int}", "/issue-81/int/-42", "System.Int32", "-42")]
+	[InlineData("/issue-81/long/{LongValue:long}", "/issue-81/long/9223372036854775806", "System.Int64", "9223372036854775806")]
+	[InlineData("/issue-81/nonfile/{NonFileValue:nonfile}", "/issue-81/nonfile/notes", "System.String", "notes")]
+	public async Task Stock_route_constraint_normal_and_htmx_gets_bind_the_same_value_once(
+		string routeTemplate,
+		string requestPath,
+		string clrType,
+		string expectedValue)
+	{
+		AssertSingleComponentRoute(routeTemplate);
+		await AssertSuccessfulNormalAndHtmxResponses(
+			requestPath,
+			$"data-route-type=\"{clrType}\">{expectedValue}</span>");
+	}
+
+	[Theory]
+	[InlineData("/issue-81/bool/{BoolValue:bool}", "/issue-81/bool/not-bool")]
+	[InlineData("/issue-81/datetime/{DateTimeValue:datetime}", "/issue-81/datetime/not-a-date")]
+	[InlineData("/issue-81/decimal/{DecimalValue:decimal}", "/issue-81/decimal/not-decimal")]
+	[InlineData("/issue-81/double/{DoubleValue:double}", "/issue-81/double/not-double")]
+	[InlineData("/issue-81/float/{FloatValue:float}", "/issue-81/float/not-float")]
+	[InlineData("/issue-81/guid/{GuidValue:guid}", "/issue-81/guid/not-a-guid")]
+	[InlineData("/issue-81/int/{IntValue:int}", "/issue-81/int/not-an-int")]
+	[InlineData("/issue-81/long/{LongValue:long}", "/issue-81/long/not-a-long")]
+	[InlineData("/issue-81/nonfile/{NonFileValue:nonfile}", "/issue-81/nonfile/document.txt")]
+	public async Task Stock_route_constraint_normal_and_htmx_gets_reject_the_same_value(
+		string routeTemplate,
+		string requestPath)
+	{
+		AssertSingleComponentRoute(routeTemplate);
+
+		using var normalResponse = await client.GetAsync(requestPath);
+		using var htmxRequest = new HttpRequestMessage(HttpMethod.Get, requestPath);
+		htmxRequest.Headers.Add("HX-Request", "true");
+		using var htmxResponse = await client.SendAsync(htmxRequest);
+
+		Assert.Equal(HttpStatusCode.NotFound, normalResponse.StatusCode);
+		Assert.Equal(normalResponse.StatusCode, htmxResponse.StatusCode);
+	}
+
+	[Theory]
+	[InlineData("/issue-81/optional", "absent", "absent")]
+	[InlineData("/issue-81/optional/-42", "System.Int32", "-42")]
+	public async Task Optional_typed_route_value_normal_and_htmx_gets_match(
+		string requestPath,
+		string clrType,
+		string expectedValue)
+	{
+		AssertSingleComponentRoute("/issue-81/optional/{OptionalIntValue:int?}");
+		await AssertSuccessfulNormalAndHtmxResponses(
+			requestPath,
+			$"data-optional-route-type=\"{clrType}\">{expectedValue}</span>");
+	}
+
+	private void AssertSingleComponentRoute(string routeTemplate)
 	{
 		var pageEndpoints = ((IEndpointRouteBuilder)app).DataSources
 			.SelectMany(dataSource => dataSource.Endpoints)
 			.OfType<RouteEndpoint>()
 			.Where(endpoint => endpoint.Metadata.GetMetadata<ComponentTypeMetadata>()?.Type == typeof(Issue81Page));
-		Assert.Single(pageEndpoints);
+		Assert.Single(pageEndpoints.Where(endpoint =>
+			string.Equals(endpoint.RoutePattern.RawText, routeTemplate, StringComparison.OrdinalIgnoreCase)));
+	}
 
-		using var normalResponse = await client.GetAsync("/issue-81/42?query=from-query");
+	private async Task AssertSuccessfulNormalAndHtmxResponses(string requestPath, string expectedRouteValue)
+	{
+		using var normalResponse = await client.GetAsync($"{requestPath}?query=from-query");
 		var normalBody = await normalResponse.Content.ReadAsStringAsync();
 		Assert.Equal(HttpStatusCode.OK, normalResponse.StatusCode);
 		Assert.Contains("<html", normalBody, StringComparison.OrdinalIgnoreCase);
 		Assert.Contains("data-stock-shell", normalBody, StringComparison.Ordinal);
-		Assert.Contains("data-issue-81-values>42|from-query|from-di|1</p>", normalBody, StringComparison.Ordinal);
+		Assert.Contains(expectedRouteValue, normalBody, StringComparison.Ordinal);
+		Assert.Contains("data-request-values>from-query|from-di|1</span>", normalBody, StringComparison.Ordinal);
 
-		using var htmxRequest = new HttpRequestMessage(HttpMethod.Get, "/issue-81/42?query=from-query");
+		using var htmxRequest = new HttpRequestMessage(HttpMethod.Get, $"{requestPath}?query=from-query");
 		htmxRequest.Headers.Add("HX-Request", "true");
 		using var htmxResponse = await client.SendAsync(htmxRequest);
 		var htmxBody = await htmxResponse.Content.ReadAsStringAsync();
 		Assert.Equal(HttpStatusCode.OK, htmxResponse.StatusCode);
-		Assert.Contains("data-issue-81-values>42|from-query|from-di|1</p>", htmxBody, StringComparison.Ordinal);
+		Assert.Contains(expectedRouteValue, htmxBody, StringComparison.Ordinal);
+		Assert.Contains("data-request-values>from-query|from-di|1</span>", htmxBody, StringComparison.Ordinal);
 		Assert.DoesNotContain("<html", htmxBody, StringComparison.OrdinalIgnoreCase);
 		Assert.DoesNotContain("data-stock-shell", htmxBody, StringComparison.Ordinal);
 	}

--- a/test/Htmxor.AspNetCore10.Tests/Issue81Page.razor
+++ b/test/Htmxor.AspNetCore10.Tests/Issue81Page.razor
@@ -1,0 +1,20 @@
+@page "/issue-81/{routeValue:int}"
+@inject Issue81RequestProbe RequestProbe
+
+<p data-issue-81-values>@RouteValue|@QueryValue|@RequestProbe.Value|@InitializationCount</p>
+
+@code {
+    [Parameter]
+    public int RouteValue { get; set; }
+
+    [Parameter]
+    [SupplyParameterFromQuery(Name = "query")]
+    public string? QueryValue { get; set; }
+
+    private int InitializationCount { get; set; }
+
+    protected override void OnInitialized()
+    {
+        InitializationCount = RequestProbe.RecordInitialization();
+    }
+}

--- a/test/Htmxor.AspNetCore10.Tests/Issue81Page.razor
+++ b/test/Htmxor.AspNetCore10.Tests/Issue81Page.razor
@@ -1,11 +1,60 @@
-@page "/issue-81/{routeValue:int}"
+@page "/issue-81/bool/{BoolValue:bool}"
+@page "/issue-81/datetime/{DateTimeValue:datetime}"
+@page "/issue-81/decimal/{DecimalValue:decimal}"
+@page "/issue-81/double/{DoubleValue:double}"
+@page "/issue-81/float/{FloatValue:float}"
+@page "/issue-81/guid/{GuidValue:guid}"
+@page "/issue-81/int/{IntValue:int}"
+@page "/issue-81/long/{LongValue:long}"
+@page "/issue-81/nonfile/{NonFileValue:nonfile}"
+@page "/issue-81/optional/{OptionalIntValue:int?}"
 @inject Issue81RequestProbe RequestProbe
+@using System.Globalization
 
-<p data-issue-81-values>@RouteValue|@QueryValue|@RequestProbe.Value|@InitializationCount</p>
+<p data-issue-81-values>
+    <span data-route-type="@BoolValue?.GetType().FullName">@BoolValue?.ToString()</span>
+    <span data-route-type="@DateTimeValue?.GetType().FullName">@DateTimeValue?.ToString("O", CultureInfo.InvariantCulture)</span>
+    <span data-route-type="@DecimalValue?.GetType().FullName">@DecimalValue?.ToString(CultureInfo.InvariantCulture)</span>
+    <span data-route-type="@DoubleValue?.GetType().FullName">@DoubleValue?.ToString("R", CultureInfo.InvariantCulture)</span>
+    <span data-route-type="@FloatValue?.GetType().FullName">@FloatValue?.ToString("R", CultureInfo.InvariantCulture)</span>
+    <span data-route-type="@GuidValue?.GetType().FullName">@GuidValue?.ToString("D")</span>
+    <span data-route-type="@IntValue?.GetType().FullName">@IntValue?.ToString(CultureInfo.InvariantCulture)</span>
+    <span data-route-type="@LongValue?.GetType().FullName">@LongValue?.ToString(CultureInfo.InvariantCulture)</span>
+    <span data-route-type="@NonFileValue?.GetType().FullName">@NonFileValue</span>
+    <span data-optional-route-type="@(OptionalIntValue?.GetType().FullName ?? "absent")">@(OptionalIntValue?.ToString(CultureInfo.InvariantCulture) ?? "absent")</span>
+    <span data-request-values>@QueryValue|@RequestProbe.Value|@InitializationCount</span>
+</p>
 
 @code {
     [Parameter]
-    public int RouteValue { get; set; }
+    public bool? BoolValue { get; set; }
+
+    [Parameter]
+    public DateTime? DateTimeValue { get; set; }
+
+    [Parameter]
+    public decimal? DecimalValue { get; set; }
+
+    [Parameter]
+    public double? DoubleValue { get; set; }
+
+    [Parameter]
+    public float? FloatValue { get; set; }
+
+    [Parameter]
+    public Guid? GuidValue { get; set; }
+
+    [Parameter]
+    public int? IntValue { get; set; }
+
+    [Parameter]
+    public long? LongValue { get; set; }
+
+    [Parameter]
+    public string? NonFileValue { get; set; }
+
+    [Parameter]
+    public int? OptionalIntValue { get; set; }
 
     [Parameter]
     [SupplyParameterFromQuery(Name = "query")]


### PR DESCRIPTION
Closes #81

## Why

The direct HTMX render host passed endpoint route values straight to `DynamicComponent`. Stock Blazor converted constrained route values before component parameter assignment, but the direct path did not. A normal constrained `int` request rendered successfully while the equivalent direct request passed a `string` to the component and returned `500`.

This change keeps conversion, query supply, dependency injection, component lifecycle, routing, and static SSR under stock ASP.NET Core and Blazor ownership.

## What changed

- Pass the endpoint-selected `RouteData` through Blazor's public `Router` component. Its endpoint-supplied route-data path processes constrained values and returns the selected component without running route matching again.
- Add a real ASP.NET Core 10 TestServer matrix for `bool`, `datetime`, `decimal`, `double`, `float`, `guid`, `int`, `long`, and `nonfile`.
- Prove representative valid typed output and rejected-input parity for every constraint, including a file-like `nonfile` rejection.
- Prove present and absent optional `int` behavior, query binding, request-scoped dependency injection, one initialization per successful request, one component-owned endpoint per route, stock normal shells, and shell-free direct responses.
- Record the supported set, evidence, limits, and recommended next slice in the v1 progress document.

## Decisions

- Delegate constrained-value processing to the supported public framework path. The change does not copy or extend the legacy hand-written conversion switch.
- Keep the stock Razor Components endpoint invoker, routing, query supplier, dependency injection, lifecycle, and renderer real in the hosted tests.
- Do not add controllers, Minimal API handlers, static component actions, private reflection, duplicate application endpoints, global framework-service replacement, or an HTMX-version dependency.

## Evidence

Meaningful red at `29cecb64a8bf9466c3bd7c2dfdb9874d347edcb0`:

```text
dotnet test test/Htmxor.AspNetCore10.Tests/Htmxor.AspNetCore10.Tests.csproj --configuration Release --no-restore --blame-hang --blame-hang-timeout 5min --logger "console;verbosity=minimal"
21 discovered, 21 executed, 12 passed, 9 failed, 0 skipped
```

All eight typed direct routes and the present optional `int` route returned `500`; their normal requests returned `200`. The valid `nonfile` case, all rejected-input cases, optional absence, and the issue #78 regression passed before the production change.

Exact reviewed HEAD `d377a87b46752385583008ff660731b45d52f9c4`:

```text
dotnet test test/Htmxor.AspNetCore10.Tests/Htmxor.AspNetCore10.Tests.csproj --configuration Release --no-restore --blame-hang --blame-hang-timeout 5min --logger "console;verbosity=minimal"
21 discovered, 21 executed, 21 passed, 0 failed, 0 skipped

dotnet run --project eng/Htmxor.Quality/Htmxor.Quality.csproj -- check --profile fast
273 discovered, 273 executed, 273 passed, 0 failed, 0 skipped, 0 errors, 0 timeouts
Release build: 0 warnings, 0 errors
```

- Independent Standards review: pass, 0 findings.
- Independent Spec review: pass, 0 findings.

## Residual risks

- The matrix does not exhaust valid textual representations, undocumented custom conversion constraints, catch-all routes, or unconstrained routes.
- Only ASP.NET Core 10 project-reference consumption on Windows was exercised. The supported framework matrix, Linux, browser behavior, and packed-package consumption remain unproved.
- Layouts, forms, unsafe methods, authorization, antiforgery enforcement, caching, concurrency, enhanced navigation, interactive render modes, application-selected HTMX runtimes, and performance remain later slices.
- Mutation testing was optional for this proof of concept and was not run.
