### PR TITLE
test: prove direct GET authorization parity

### DIFF
--- a/docs/roadmap/v1/progress.md
+++ b/docs/roadmap/v1/progress.md
@@ -7,9 +7,10 @@ Last updated: 2026-08-27
 - Baseline commit for the first v1 slice: `66139317b9edae1fff2ff73fa5175381ee3487b1`.
 - Verified implementation commit for issue #78: `8dcca3c0749cf53e310b1dff9dc22612b0d5e8f5`.
 - Verified implementation commit for issue #81: `0c3fec1b8c3425ef37c2d93a5fa131f3b0c2a649`.
+- Verified evidence commit for issue #83: `46f5b5324c64bff111a8e9bbb38ea812c22067ef`.
 - Framework boundary under test: a real ASP.NET Core 10 and Blazor static SSR test host consuming the project-referenced `net8.0` Htmxor library.
-- V1 implementation slices proved on this tree: issue #78, stock `@page` routing with a direct HTMX GET; issue #81, every documented .NET 10 Blazor component-route constraint plus typed optional presence and absence.
-- Current implementation slice after #81: none. Recheck issue #81, branch publication state, and `origin/main` before starting the next slice.
+- V1 slices proved on this tree: issue #78, stock `@page` routing with a direct HTMX GET; issue #81, every documented .NET 10 Blazor component-route constraint plus typed optional presence and absence; issue #83, authorization-policy and authenticated-user parity for normal and direct GETs.
+- Current implementation slice after #83: none. Recheck issue #83, branch publication state, and `origin/main` before starting the next slice.
 
 ## Proven v1 behavior
 
@@ -75,6 +76,26 @@ route match. The existing endpoint routing, query supplier, dependency
 injection, lifecycle, and static SSR renderer remain in charge. The supported
 path neither copies nor extends the legacy hand-written conversion switch.
 
+Protected behavior for issue #83:
+
+> When a stock `@page` component requires an authorization policy, Htmxor
+> enforces the same policy and supplies the same authenticated user on normal
+> and direct GETs without treating HTMX request headers as authorization
+> evidence.
+
+The hosted proof uses one deterministic authentication scheme and one claim
+policy through the real ASP.NET Core 10 authentication and authorization
+middleware. Anonymous requests receive `401` on both paths. An authenticated
+user without the required claim receives `403` on both paths. The `HX-Request`
+header alone does not authorize a request.
+
+An authorized user's name and required claim reach the component unchanged on
+both paths. The normal response retains the stock application shell, while the
+direct response returns the protected component without that shell. The
+application still owns one component route and does not add a controller,
+Minimal API handler, or duplicate endpoint. No production change was required;
+the existing metadata-preserving direct path already satisfied this slice.
+
 ## Executable evidence
 
 - Meaningful red at `66139317b9edae1fff2ff73fa5175381ee3487b1`: the new .NET 10 hosted test discovered and executed one test, then failed during real application startup with the expected `NullReferenceException` in the obsolete private-reflection component discovery path.
@@ -85,30 +106,25 @@ path neither copies nor extends the legacy hand-written conversion switch.
 - Focused proof at clean implementation commit `0c3fec1b8c3425ef37c2d93a5fa131f3b0c2a649`: the same command discovered and executed 21 tests; 21 passed, 0 failed, 0 skipped.
 - Broader proof at the same clean implementation commit: `dotnet run --project eng/Htmxor.Quality/Htmxor.Quality.csproj -- check --profile fast` passed 102 quality tests, 21 .NET 10 hosted tests, and 150 existing non-browser tests. Total: 273 discovered, 273 executed, 273 passed, 0 failed, 0 skipped, 0 errors, and 0 timeouts. The Release build produced 0 warnings and 0 errors.
 - Mutation testing was not run. Issue #81 makes it optional diagnostic evidence for this proof of concept.
+- Meaningful red for issue #83 used the test tree at commit `46f5b5324c64bff111a8e9bbb38ea812c22067ef` plus a temporary negative-control mutation that removed authorization metadata from component endpoints: `dotnet test test/Htmxor.AspNetCore10.Tests/Htmxor.AspNetCore10.Tests.csproj --configuration Release --no-restore --filter "FullyQualifiedName~Issue83AuthorizationTests" --blame-hang --blame-hang-timeout 5min` discovered and executed 4 tests; 2 passed and 2 failed. The anonymous and claim-deficient cases reached their first status assertion with `200` instead of `401` and `403`. The mutation was removed and left no production diff.
+- Focused proof at the same clean commit with the same filtered command: 4 discovered, 4 executed, 4 passed, 0 failed, 0 skipped.
+- Hosted-project proof at the same clean commit without the filter: 25 discovered, 25 executed, 25 passed, 0 failed, 0 skipped.
+- Broader proof at the same clean commit: `dotnet run --project eng/Htmxor.Quality/Htmxor.Quality.csproj --no-restore -- check --profile fast` passed 102 quality tests, 25 .NET 10 hosted tests, and 150 existing non-browser tests. Total: 277 discovered, 277 executed, 277 passed, 0 failed, 0 skipped, 0 errors, and 0 timeouts. The Release build produced 0 warnings and 0 errors.
+- Mutation testing was not run. Issue #83 makes it optional diagnostic evidence for this proof of concept.
 
 ## Remaining limits
 
 - This is a project-reference proof, not packed-package or release-candidate evidence.
 - The matrix uses one representative valid and rejected value per documented constraint. It does not exhaust textual representations, undocumented custom conversion constraints, catch-all routes, or unconstrained routes.
 - The direct path is proved on ASP.NET Core 10 only. The supported framework matrix and packed-package consumption remain unproved.
-- The test does not exercise layouts, forms, unsafe methods, authorization, antiforgery enforcement, caching, concurrency, enhanced navigation, interactive render modes, browser behavior, application-selected HTMX runtimes, or performance.
+- The authorization proof uses one deterministic scheme and one claim policy. It does not cover scheme selection, custom challenge or forbid handlers, identity-provider integration, or authorization on other HTTP methods.
+- The tests do not exercise layouts, forms, unsafe methods, antiforgery enforcement, caching, concurrency, enhanced navigation, interactive render modes, browser behavior, application-selected HTMX runtimes, or performance.
 - The legacy test application still uses internal private-reflection discovery and global service replacements. Later slices must replace the behavior they cover instead of extending that prototype.
 - HTMX-only component routes and component-owned actions have not moved to the new public path.
 
 ## Recommended next slice
 
-Protected behavior for the recommended next slice:
-
-> When a stock `@page` component requires an authorization policy, Htmxor
-> enforces the same policy and supplies the same authenticated user on normal
-> and direct GETs without treating HTMX request headers as authorization
-> evidence.
-
-This comes next because the request-local endpoint copy retains authorization
-metadata structurally, but no test proves policy enforcement or authentication
-state on the direct path. A .NET 10 hosted integration test should use real
-authentication and authorization middleware, one component policy, and normal
-and direct HTTP requests. Forms, unsafe methods, antiforgery, fragments, browser
-conformance, packaging, and performance remain later slices.
-
-No new implementation issue has been published for this candidate.
+No next implementation slice was selected as part of issue #83. Recheck the
+live v1 tracker and `origin/main` before choosing one. Forms, unsafe methods,
+antiforgery, fragments, browser conformance, packaging, and performance remain
+outside this proof.

--- a/test/Htmxor.AspNetCore10.Tests/Issue83AuthorizationTests.cs
+++ b/test/Htmxor.AspNetCore10.Tests/Issue83AuthorizationTests.cs
@@ -1,0 +1,157 @@
+using System.Net;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Components.Endpoints;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Htmxor.AspNetCore10;
+
+public sealed class Issue83AuthorizationTests : IAsyncLifetime
+{
+	private const string PolicyName = "issue-83-policy";
+	private const string RequiredClaimType = "issue-83-access";
+	private const string RequiredClaimValue = "granted";
+	private WebApplication app = default!;
+	private HttpClient client = default!;
+
+	public async Task InitializeAsync()
+	{
+		var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+		{
+			ApplicationName = typeof(Issue83AuthorizationTests).Assembly.GetName().Name,
+			EnvironmentName = Environments.Development,
+		});
+		builder.WebHost.UseTestServer();
+		builder.Services.AddAuthentication(Issue83AuthenticationHandler.SchemeName)
+			.AddScheme<AuthenticationSchemeOptions, Issue83AuthenticationHandler>(
+				Issue83AuthenticationHandler.SchemeName,
+				_ => { });
+		builder.Services.AddAuthorization(options => options.AddPolicy(
+			PolicyName,
+			policy => policy.RequireClaim(RequiredClaimType, RequiredClaimValue)));
+		builder.Services.AddRazorComponents().AddHtmx();
+
+		app = builder.Build();
+		app.UseAuthentication();
+		app.UseAuthorization();
+		app.UseAntiforgery();
+		app.MapRazorComponents<Issue78App>()
+			.AddHtmxorComponentEndpoints(app);
+
+		await app.StartAsync();
+		client = app.GetTestClient();
+	}
+
+	[Theory]
+	[InlineData(null, HttpStatusCode.Unauthorized)]
+	[InlineData(Issue83AuthenticationHandler.ForbiddenUser, HttpStatusCode.Forbidden)]
+	public async Task Protected_page_rejects_normal_and_direct_gets_equally(
+		string? user,
+		HttpStatusCode expectedStatusCode)
+	{
+		using var normalResponse = await SendAsync(user, direct: false);
+		using var directResponse = await SendAsync(user, direct: true);
+
+		Assert.Equal(expectedStatusCode, normalResponse.StatusCode);
+		Assert.Equal(normalResponse.StatusCode, directResponse.StatusCode);
+	}
+
+	[Fact]
+	public async Task Authorized_user_reaches_normal_and_direct_gets_with_the_same_principal()
+	{
+		using var normalResponse = await SendAsync(Issue83AuthenticationHandler.AuthorizedUser, direct: false);
+		var normalBody = await normalResponse.Content.ReadAsStringAsync();
+		using var directResponse = await SendAsync(Issue83AuthenticationHandler.AuthorizedUser, direct: true);
+		var directBody = await directResponse.Content.ReadAsStringAsync();
+
+		Assert.Equal(HttpStatusCode.OK, normalResponse.StatusCode);
+		Assert.Equal(normalResponse.StatusCode, directResponse.StatusCode);
+		Assert.Contains("data-stock-shell", normalBody, StringComparison.Ordinal);
+		Assert.Contains("data-issue-83-page", normalBody, StringComparison.Ordinal);
+		Assert.Contains("data-authenticated-user>authorized-user|granted</p>", normalBody, StringComparison.Ordinal);
+		Assert.DoesNotContain("data-stock-shell", directBody, StringComparison.Ordinal);
+		Assert.Contains("data-issue-83-page", directBody, StringComparison.Ordinal);
+		Assert.Contains("data-authenticated-user>authorized-user|granted</p>", directBody, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void Protected_page_owns_one_component_route()
+	{
+		var pageEndpoints = ((IEndpointRouteBuilder)app).DataSources
+			.SelectMany(dataSource => dataSource.Endpoints)
+			.OfType<RouteEndpoint>()
+			.Where(endpoint => endpoint.Metadata.GetMetadata<ComponentTypeMetadata>()?.Type == typeof(Issue83ProtectedPage));
+
+		Assert.Single(pageEndpoints);
+	}
+
+	private async Task<HttpResponseMessage> SendAsync(string? user, bool direct)
+	{
+		using var request = new HttpRequestMessage(HttpMethod.Get, "/issue-83");
+		if (user is not null)
+		{
+			request.Headers.Add(Issue83AuthenticationHandler.UserHeaderName, user);
+		}
+
+		if (direct)
+		{
+			request.Headers.Add("HX-Request", "true");
+		}
+
+		return await client.SendAsync(request);
+	}
+
+	public async Task DisposeAsync()
+	{
+		client?.Dispose();
+		if (app is not null)
+		{
+			await app.DisposeAsync();
+		}
+	}
+}
+
+internal sealed class Issue83AuthenticationHandler(
+	IOptionsMonitor<AuthenticationSchemeOptions> options,
+	ILoggerFactory logger,
+	UrlEncoder encoder)
+	: AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+{
+	public const string SchemeName = "issue-83-test";
+	public const string UserHeaderName = "X-Issue-83-User";
+	public const string AuthorizedUser = "authorized-user";
+	public const string ForbiddenUser = "forbidden-user";
+
+	protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+	{
+		if (!Request.Headers.TryGetValue(UserHeaderName, out var userHeader))
+		{
+			return Task.FromResult(AuthenticateResult.NoResult());
+		}
+
+		var user = userHeader.ToString();
+		var claims = new List<Claim>
+		{
+			new(ClaimTypes.NameIdentifier, user),
+			new(ClaimTypes.Name, user),
+		};
+		if (string.Equals(user, AuthorizedUser, StringComparison.Ordinal))
+		{
+			claims.Add(new Claim("issue-83-access", "granted"));
+		}
+
+		var principal = new ClaimsPrincipal(new ClaimsIdentity(claims, SchemeName));
+		var ticket = new AuthenticationTicket(principal, SchemeName);
+		return Task.FromResult(AuthenticateResult.Success(ticket));
+	}
+}

--- a/test/Htmxor.AspNetCore10.Tests/Issue83ProtectedPage.razor
+++ b/test/Htmxor.AspNetCore10.Tests/Issue83ProtectedPage.razor
@@ -1,0 +1,11 @@
+@page "/issue-83"
+@attribute [Authorize(Policy = "issue-83-policy")]
+@using Microsoft.AspNetCore.Authorization
+
+<h1 data-issue-83-page>Protected route page</h1>
+<p data-authenticated-user>@HttpContext.User.Identity?.Name|@HttpContext.User.FindFirst("issue-83-access")?.Value</p>
+
+@code {
+    [CascadingParameter]
+    private HttpContext HttpContext { get; set; } = default!;
+}


### PR DESCRIPTION
## What changed

- Add one policy-protected stock Razor component route to the ASP.NET Core 10 hosted test application.
- Exercise anonymous, authenticated-but-claim-deficient, and authorized users through normal and direct HTMX GETs with one deterministic authentication scheme and one claim policy.
- Prove status parity, component-visible identity and claim parity, HX-Request non-authority, the stock-shell/direct-component response distinction, and single component-route ownership.
- Record the executed issue #83 evidence and residual limits in the v1 progress record.

The existing production path already preserves the endpoint authorization metadata and request user correctly, so this proof requires no production change.

## Why

The direct GET path replaces only the request-local root-component metadata after endpoint selection. Issue #83 needed executable proof that the real ASP.NET Core 10 authentication and authorization middleware still controls access and that the stock component renderer receives the authenticated principal. This closes that security evidence gap before later work considers unsafe methods or forms.

## Evidence

Reviewed HEAD: da523a69c95c4a16416d05d38df68deaed0e0740
Base: c00622dea7f9ee77d1274dc446806497fe340e5f

Meaningful red used the test tree from commit 46f5b5324c64bff111a8e9bbb38ea812c22067ef with a temporary negative-control mutation that removed authorization metadata from component endpoints. The focused command discovered 4 tests: 2 passed and 2 failed because the anonymous and claim-deficient cases observed 200 instead of 401 and 403. The mutation was removed and no production diff remains.

Focused hosted command:
    dotnet test test/Htmxor.AspNetCore10.Tests/Htmxor.AspNetCore10.Tests.csproj --configuration Release --no-restore --filter "FullyQualifiedName~Issue83AuthorizationTests" --blame-hang --blame-hang-timeout 5min
Result: 4 discovered, 4 executed, 4 passed, 0 failed, 0 skipped.

Repository fast command:
    dotnet run --project eng/Htmxor.Quality/Htmxor.Quality.csproj --no-restore -- check --profile fast
Result: 102 quality tests, 25 ASP.NET Core 10 hosted tests, and 150 non-browser tests. Total 277 discovered, 277 executed, 277 passed, 0 failed, 0 skipped, 0 errors, 0 timeouts. Release build: 0 warnings, 0 errors.

The first restricted-sandbox restore attempts failed with NU1301 network access errors. Network-enabled reruns passed; those setup failures were not treated as behavioral evidence.

Independent Standards review: pass, 0 findings.
Independent Spec review: pass, 0 findings.

## Not exercised

Kestrel or network transport, browsers, external identity providers, scheme selection, custom challenge or forbid handlers, other target frameworks, packed-package consumption, unsafe methods, forms, antiforgery behavior, or mutation testing.

Closes #83