### PR TITLE
feat: support stock EditForm POST through direct HTMX

### DIFF
--- a/docs/roadmap/v1/progress.md
+++ b/docs/roadmap/v1/progress.md
@@ -8,9 +8,10 @@ Last updated: 2026-08-27
 - Verified implementation commit for issue #78: `8dcca3c0749cf53e310b1dff9dc22612b0d5e8f5`.
 - Verified implementation commit for issue #81: `0c3fec1b8c3425ef37c2d93a5fa131f3b0c2a649`.
 - Verified evidence commit for issue #83: `46f5b5324c64bff111a8e9bbb38ea812c22067ef`.
-- Framework boundary under test: a real ASP.NET Core 10 and Blazor static SSR test host consuming the project-referenced `net8.0` Htmxor library.
-- V1 slices proved on this tree: issue #78, stock `@page` routing with a direct HTMX GET; issue #81, every documented .NET 10 Blazor component-route constraint plus typed optional presence and absence; issue #83, authorization-policy and authenticated-user parity for normal and direct GETs.
-- Current implementation slice after #83: none. Recheck issue #83, branch publication state, and `origin/main` before starting the next slice.
+- Verified implementation commit for issue #85: `0a87dcd8b50cb5fd1be6a4ddae57601986aaea4a`.
+- Framework boundary under test: a real ASP.NET Core 10.0.11 and Blazor static SSR test host consuming the project-referenced `net8.0` Htmxor library.
+- V1 slices proved on this tree: issue #78, stock `@page` routing with a direct HTMX GET; issue #81, every documented .NET 10 Blazor component-route constraint plus typed optional presence and absence; issue #83, authorization-policy and authenticated-user parity for normal and direct GETs; issue #85, one stock named `EditForm` POST with form binding, antiforgery ordering, request-component callback dispatch, and direct component output.
+- Current implementation slice after #85: none. Recheck issue #85, branch publication state, and `origin/main` before starting the next slice.
 
 ## Proven v1 behavior
 
@@ -96,6 +97,33 @@ application still owns one component route and does not add a controller,
 Minimal API handler, or duplicate endpoint. No production change was required;
 the existing metadata-preserving direct path already satisfied this slice.
 
+Protected behavior for issue #85:
+
+> When a component-owned stock form is submitted through HTMX, Htmxor lets
+> Blazor bind the form, validates antiforgery before application code, invokes
+> the request component callback, and returns the component response without a
+> parallel endpoint.
+
+The hosted proof uses one component-owned `@page` route, one named stock
+`EditForm`, and one `[SupplyParameterFromForm]` input. A normal GET renders the
+stock application shell and supplies the form handler, antiforgery token, and
+cookie. A valid direct HTMX POST binds `accepted-value`, initializes one request
+component with a new request-scoped dependency, invokes its callback once with
+that value, and returns the updated component without the stock shell.
+
+A direct POST without the antiforgery token and cookie returns `400` before the
+form property setter, component initialization, or callback records any
+activity. The application still owns one component route. It adds no controller,
+Minimal API handler, duplicate route, static endpoint-style action, custom form
+binder, or antiforgery runtime.
+
+The public endpoint convention now applies its request-local root-component
+substitution to direct GET and POST requests. It preserves the stock component
+endpoint's ordered metadata and invokes its captured request delegate, leaving
+ASP.NET Core 10.0.11 responsible for antiforgery validation, form mapping,
+component lifecycle, named callback dispatch, and rendering. Other HTTP methods
+continue through the stock delegate unchanged.
+
 ## Executable evidence
 
 - Meaningful red at `66139317b9edae1fff2ff73fa5175381ee3487b1`: the new .NET 10 hosted test discovered and executed one test, then failed during real application startup with the expected `NullReferenceException` in the obsolete private-reflection component discovery path.
@@ -111,6 +139,11 @@ the existing metadata-preserving direct path already satisfied this slice.
 - Hosted-project proof at the same clean commit without the filter: 25 discovered, 25 executed, 25 passed, 0 failed, 0 skipped.
 - Broader proof at the same clean commit: `dotnet run --project eng/Htmxor.Quality/Htmxor.Quality.csproj --no-restore -- check --profile fast` passed 102 quality tests, 25 .NET 10 hosted tests, and 150 existing non-browser tests. Total: 277 discovered, 277 executed, 277 passed, 0 failed, 0 skipped, 0 errors, and 0 timeouts. The Release build produced 0 warnings and 0 errors.
 - Mutation testing was not run. Issue #83 makes it optional diagnostic evidence for this proof of concept.
+- Meaningful red for issue #85 used the test tree preserved in `6d0fcf4dafe6e840423eb6e32eec41b1c8e3c7e3` with the unchanged production behavior from `4f2c0d81d25141643894d19972e1b701a9982615`: `dotnet test test/Htmxor.AspNetCore10.Tests/Htmxor.AspNetCore10.Tests.csproj --configuration Release --no-restore --filter "FullyQualifiedName~Issue85FormTests" --blame-hang --blame-hang-timeout 5min` discovered and executed 2 tests; 1 passed and 1 failed. Before the shell assertion failed, the valid POST had bound `accepted-value`, initialized one request component with a new request scope, and invoked its callback once with that value. Its response still contained the stock `<html>` shell. The missing-token request passed with `400` and zero form-binding, initialization, or callback activity.
+- Focused proof at clean implementation commit `0a87dcd8b50cb5fd1be6a4ddae57601986aaea4a`: the same filtered command discovered and executed 2 tests; 2 passed, 0 failed, 0 skipped.
+- Hosted-project proof at the same clean implementation commit without the filter: 27 discovered, 27 executed, 27 passed, 0 failed, 0 skipped.
+- Broader proof at the same clean implementation commit: `dotnet run --project eng/Htmxor.Quality/Htmxor.Quality.csproj --no-restore -- check --profile fast` passed 102 quality tests, 27 .NET 10 hosted tests, and 150 existing non-browser tests. Total: 279 discovered, 279 executed, 279 passed, 0 failed, 0 skipped, 0 errors, and 0 timeouts. The Release build produced 0 warnings and 0 errors.
+- Mutation testing was not run. Issue #85 makes it optional diagnostic evidence for this proof of concept.
 
 ## Remaining limits
 
@@ -118,13 +151,15 @@ the existing metadata-preserving direct path already satisfied this slice.
 - The matrix uses one representative valid and rejected value per documented constraint. It does not exhaust textual representations, undocumented custom conversion constraints, catch-all routes, or unconstrained routes.
 - The direct path is proved on ASP.NET Core 10 only. The supported framework matrix and packed-package consumption remain unproved.
 - The authorization proof uses one deterministic scheme and one claim policy. It does not cover scheme selection, custom challenge or forbid handlers, identity-provider integration, or authorization on other HTTP methods.
-- The tests do not exercise layouts, forms, unsafe methods, antiforgery enforcement, caching, concurrency, enhanced navigation, interactive render modes, browser behavior, application-selected HTMX runtimes, or performance.
+- The issue #85 proof covers one stock named `EditForm`, one valid value, and one missing-token POST. It does not cover multiple forms, validation failures, invalid-token variants, file uploads, normal POST parity, PUT, PATCH, DELETE, or custom method discovery.
+- The issue #85 host uses TestServer and the stock ephemeral Data Protection provider. It does not exercise Kestrel, TLS, persistent key storage, server-farm key sharing, a browser, or an application-selected HTMX runtime.
+- The tests do not exercise layouts, caching, concurrency, enhanced navigation, interactive render modes, fragments, browser behavior, or performance.
 - The legacy test application still uses internal private-reflection discovery and global service replacements. Later slices must replace the behavior they cover instead of extending that prototype.
-- HTMX-only component routes and component-owned actions have not moved to the new public path.
+- HTMX-only component routes and component-owned PUT, PATCH, and DELETE actions have not moved to the new public path. Per-component POST discovery beyond the one stock named form remains unproved.
 
 ## Recommended next slice
 
-No next implementation slice was selected as part of issue #83. Recheck the
-live v1 tracker and `origin/main` before choosing one. Forms, unsafe methods,
-antiforgery, fragments, browser conformance, packaging, and performance remain
+No next implementation slice was selected as part of issue #85. Recheck the
+live v1 tracker and `origin/main` before choosing one. Broader method discovery,
+fragments, browser conformance, packaging, caching, and performance remain
 outside this proof.

--- a/src/Htmxor/Builder/HtmxorComponentEndpointRouteBuilderExtensions.cs
+++ b/src/Htmxor/Builder/HtmxorComponentEndpointRouteBuilderExtensions.cs
@@ -54,7 +54,8 @@ public static class HtmxorComponentEndpointRouteBuilderExtensions
 
 	private static async Task InvokeEndpoint(HttpContext context, RequestDelegate stockRequestDelegate)
 	{
-		if (!HttpMethods.IsGet(context.Request.Method) ||
+		if ((!HttpMethods.IsGet(context.Request.Method) &&
+			!HttpMethods.IsPost(context.Request.Method)) ||
 			context.GetHtmxContext().Request.RoutingMode is not RoutingMode.Direct)
 		{
 			await stockRequestDelegate(context);

--- a/test/Htmxor.AspNetCore10.Tests/Issue85FormTests.cs
+++ b/test/Htmxor.AspNetCore10.Tests/Issue85FormTests.cs
@@ -1,0 +1,201 @@
+using System.Net;
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Components.Endpoints;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Htmxor.AspNetCore10;
+
+public sealed class Issue85FormTests : IAsyncLifetime
+{
+	private WebApplication app = default!;
+	private HttpClient client = default!;
+
+	public async Task InitializeAsync()
+	{
+		var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+		{
+			ApplicationName = typeof(Issue85FormTests).Assembly.GetName().Name,
+			EnvironmentName = Environments.Development,
+		});
+		builder.WebHost.UseTestServer();
+		builder.Logging.ClearProviders();
+		builder.Services.AddDataProtection().UseEphemeralDataProtectionProvider();
+		builder.Services.AddRazorComponents().AddHtmx();
+		builder.Services.AddSingleton<Issue85ApplicationProbe>();
+		builder.Services.AddScoped<Issue85RequestProbe>();
+
+		app = builder.Build();
+		app.UseAntiforgery();
+		app.MapRazorComponents<Issue78App>()
+			.AddHtmxorComponentEndpoints(app);
+
+		await app.StartAsync();
+		client = app.GetTestClient();
+	}
+
+	[Fact]
+	public async Task Valid_htmx_form_submission_uses_one_request_component()
+	{
+		var pageEndpoints = ((IEndpointRouteBuilder)app).DataSources
+			.SelectMany(dataSource => dataSource.Endpoints)
+			.OfType<RouteEndpoint>()
+			.Where(endpoint => endpoint.Metadata.GetMetadata<ComponentTypeMetadata>()?.Type == typeof(Issue85Page));
+		Assert.Single(pageEndpoints);
+
+		using var normalResponse = await client.GetAsync("/issue-85");
+		var normalBody = await normalResponse.Content.ReadAsStringAsync();
+		Assert.True(normalResponse.StatusCode == HttpStatusCode.OK, normalBody);
+		Assert.Contains("data-stock-shell", normalBody, StringComparison.Ordinal);
+		Assert.Contains("hx-post=\"/issue-85\"", normalBody, StringComparison.Ordinal);
+		Assert.Contains("data-binding-count=\"0\"", normalBody, StringComparison.Ordinal);
+		Assert.Contains("data-initialization-count=\"1\"", normalBody, StringComparison.Ordinal);
+		Assert.Contains("data-callback-count=\"0\"", normalBody, StringComparison.Ordinal);
+		Assert.Equal("issue-85-form", ExtractAttribute(normalBody, "name=\"_handler\"", "value"));
+		Assert.Equal("Input.Value", ExtractAttribute(normalBody, "data-issue-85-input", "name"));
+		var token = ExtractAttribute(normalBody, "name=\"__RequestVerificationToken\"", "value");
+		var cookie = ExtractAntiforgeryCookie(normalResponse);
+		var normalRequestId = ExtractAttribute(normalBody, "data-issue-85-result", "data-request-id");
+
+		using var request = CreatePostRequest(cookie, token);
+		using var response = await client.SendAsync(request);
+		var body = await response.Content.ReadAsStringAsync();
+
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		Assert.Contains("data-bound-value=\"accepted-value\"", body, StringComparison.Ordinal);
+		Assert.Contains("data-submitted-value=\"accepted-value\"", body, StringComparison.Ordinal);
+		Assert.Contains("data-binding-count=\"1\"", body, StringComparison.Ordinal);
+		Assert.Contains("data-initialization-count=\"1\"", body, StringComparison.Ordinal);
+		Assert.Contains("data-callback-count=\"1\"", body, StringComparison.Ordinal);
+		Assert.NotEqual(normalRequestId, ExtractAttribute(body, "data-issue-85-result", "data-request-id"));
+		Assert.DoesNotContain("<html", body, StringComparison.OrdinalIgnoreCase);
+		Assert.DoesNotContain("data-stock-shell", body, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public async Task Missing_antiforgery_token_rejects_before_form_binding_or_callback()
+	{
+		using var request = CreatePostRequest(cookie: null, token: null);
+		using var response = await client.SendAsync(request);
+		var body = await response.Content.ReadAsStringAsync();
+		var probe = app.Services.GetRequiredService<Issue85ApplicationProbe>();
+
+		Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+		Assert.DoesNotContain("data-issue-85-result", body, StringComparison.Ordinal);
+		Assert.Equal(0, probe.BindingCount);
+		Assert.Equal(0, probe.InitializationCount);
+		Assert.Equal(0, probe.CallbackCount);
+	}
+
+	private static HttpRequestMessage CreatePostRequest(string? cookie, string? token)
+	{
+		var fields = new Dictionary<string, string>
+		{
+			["_handler"] = "issue-85-form",
+			["Input.Value"] = "accepted-value",
+		};
+		if (token is not null)
+		{
+			fields["__RequestVerificationToken"] = token;
+		}
+
+		var request = new HttpRequestMessage(HttpMethod.Post, "/issue-85")
+		{
+			Content = new FormUrlEncodedContent(fields),
+		};
+		request.Headers.Add("HX-Request", "true");
+		if (cookie is not null)
+		{
+			request.Headers.Add("Cookie", cookie);
+		}
+
+		return request;
+	}
+
+	private static string ExtractAttribute(string html, string elementMarker, string attributeName)
+	{
+		var markerIndex = html.IndexOf(elementMarker, StringComparison.Ordinal);
+		Assert.True(markerIndex >= 0, $"Expected an element containing '{elementMarker}'.");
+		var elementStart = html.LastIndexOf('<', markerIndex);
+		var elementEnd = html.IndexOf('>', markerIndex);
+		Assert.True(elementStart >= 0 && elementEnd > elementStart, $"Expected complete markup around '{elementMarker}'.");
+		var element = html[elementStart..(elementEnd + 1)];
+		var match = Regex.Match(
+			element,
+			$"(?:^|\\s){Regex.Escape(attributeName)}=\"(?<value>[^\"]*)\"",
+			RegexOptions.CultureInvariant);
+		Assert.True(match.Success, $"Expected attribute '{attributeName}' in '{element}'.");
+		return WebUtility.HtmlDecode(match.Groups["value"].Value);
+	}
+
+	private static string ExtractAntiforgeryCookie(HttpResponseMessage response)
+	{
+		var cookie = Assert.Single(
+			response.Headers.GetValues("Set-Cookie"),
+			value => value.StartsWith(".AspNetCore.Antiforgery.", StringComparison.Ordinal));
+		return cookie.Split(';', 2)[0];
+	}
+
+	public async Task DisposeAsync()
+	{
+		client?.Dispose();
+		if (app is not null)
+		{
+			await app.DisposeAsync();
+		}
+	}
+}
+
+internal sealed class Issue85ApplicationProbe
+{
+	private int bindingCount;
+	private int initializationCount;
+	private int callbackCount;
+
+	public int BindingCount => Volatile.Read(ref bindingCount);
+
+	public int InitializationCount => Volatile.Read(ref initializationCount);
+
+	public int CallbackCount => Volatile.Read(ref callbackCount);
+
+	public void RecordBinding() => Interlocked.Increment(ref bindingCount);
+
+	public void RecordInitialization() => Interlocked.Increment(ref initializationCount);
+
+	public void RecordCallback() => Interlocked.Increment(ref callbackCount);
+}
+
+internal sealed class Issue85RequestProbe(Issue85ApplicationProbe applicationProbe)
+{
+	public string Id { get; } = Guid.NewGuid().ToString("D");
+
+	public int BindingCount { get; private set; }
+
+	public int InitializationCount { get; private set; }
+
+	public int CallbackCount { get; private set; }
+
+	public void RecordBinding()
+	{
+		BindingCount++;
+		applicationProbe.RecordBinding();
+	}
+
+	public void RecordInitialization()
+	{
+		InitializationCount++;
+		applicationProbe.RecordInitialization();
+	}
+
+	public void RecordCallback()
+	{
+		CallbackCount++;
+		applicationProbe.RecordCallback();
+	}
+}

--- a/test/Htmxor.AspNetCore10.Tests/Issue85Page.razor
+++ b/test/Htmxor.AspNetCore10.Tests/Issue85Page.razor
@@ -1,0 +1,50 @@
+@page "/issue-85"
+@using Microsoft.AspNetCore.Components.Forms
+@inject Issue85RequestProbe RequestProbe
+
+<EditForm Model="Input" FormName="issue-85-form" OnValidSubmit="HandleValidSubmit" hx-post="/issue-85">
+    <InputText @bind-Value="Input.Value" data-issue-85-input />
+    <button type="submit">Submit</button>
+</EditForm>
+
+<p data-issue-85-result
+   data-bound-value="@Input.Value"
+   data-submitted-value="@submittedValue"
+   data-request-id="@RequestProbe.Id"
+   data-binding-count="@RequestProbe.BindingCount"
+   data-initialization-count="@RequestProbe.InitializationCount"
+   data-callback-count="@RequestProbe.CallbackCount">
+    @Input.Value
+</p>
+
+@code {
+    private Issue85FormInput input = new();
+    private string? submittedValue;
+
+    [SupplyParameterFromForm(FormName = "issue-85-form")]
+    private Issue85FormInput Input
+    {
+        get => input;
+        set
+        {
+            input = value;
+            RequestProbe.RecordBinding();
+        }
+    }
+
+    protected override void OnInitialized()
+    {
+        RequestProbe.RecordInitialization();
+    }
+
+    private void HandleValidSubmit()
+    {
+        submittedValue = Input.Value;
+        RequestProbe.RecordCallback();
+    }
+
+    public sealed class Issue85FormInput
+    {
+        public string Value { get; set; } = string.Empty;
+    }
+}


### PR DESCRIPTION
Closes #85

## Why

Direct HTMX GETs already reuse the stock ASP.NET Core Razor Components request delegate with a request-local root-component substitution. A direct POST still fell through to the stock application root, so Blazor bound the form and invoked the callback but returned the full application shell.

ASP.NET Core 10.0.11 component endpoints already own GET and POST metadata, antiforgery policy, form mapping, request-component lifecycle, named submit dispatch, and rendering. Htmxor only needs to select the direct component representation for POST.

## What changed

- Extend the existing direct-request gate from GET to an explicit GET-or-POST allow-list.
- Add one hosted .NET 10 proof using a component-owned page, one named stock EditForm, one SupplyParameterFromForm input, and request-scoped lifecycle probes.
- Prove a valid token round trip returns bound callback output without the shell, while a missing token returns 400 before form binding, initialization, or callback activity.
- Record the executed behavior and remaining limits in the v1 progress document.

The change does not add a controller, Minimal API handler, duplicate route, static component action, private reflection, copied renderer code, custom form binder, or replacement antiforgery runtime. It does not read Request.Form in Htmxor or infer server method exposure from hx-* attributes.

## Evidence

Meaningful red used the test tree preserved in 6d0fcf4dafe6e840423eb6e32eec41b1c8e3c7e3 against the unchanged production behavior from 4f2c0d81d25141643894d19972e1b701a9982615:

dotnet test test/Htmxor.AspNetCore10.Tests/Htmxor.AspNetCore10.Tests.csproj --configuration Release --no-restore --filter "FullyQualifiedName~Issue85FormTests" --blame-hang --blame-hang-timeout 5min

Two tests ran. The missing-token case passed. The valid POST bound accepted-value, initialized one request component in a new scope, and invoked its callback once with that value, then failed only because the response still contained the stock HTML shell.

At clean implementation commit 0a87dcd8b50cb5fd1be6a4ddae57601986aaea4a:

- Focused issue tests: 2 discovered, 2 executed, 2 passed.
- Hosted ASP.NET Core 10 project: 27 discovered, 27 executed, 27 passed.
- Repository fast profile: 102 quality tests, 27 hosted tests, and 150 existing non-browser tests. Total 279/279 passed, with 0 failures, skips, errors, or timeouts.
- Release build: 0 warnings and 0 errors.
- Standards review: pass, 0 findings.
- Spec review: pass after the progress-record finding was resolved, 0 remaining findings.

Commit 1ad2f62ca51713760d96c2acaa30ca9bb0013729 only updates docs/roadmap/v1/progress.md; code verification remains attributed to the implementation commit above. Mutation was not run because issue #85 makes it optional diagnostic evidence.

## Deliberate boundaries

This proof uses TestServer and ASP.NET Core's stock ephemeral Data Protection provider on Windows. It does not exercise a browser or application-selected HTMX runtime, Kestrel/TLS, persistent or server-farm key storage, multiple forms, validation failures, invalid-token variants, file uploads, normal POST parity, PUT/PATCH/DELETE, HTMX-only routes, fragments, caching, external identity providers, packed-package consumption, release work, or performance.