### PR TITLE
feat: map HTMX-only component GET through Blazor

### DIFF
--- a/docs/roadmap/v1/progress.md
+++ b/docs/roadmap/v1/progress.md
@@ -14,9 +14,11 @@ Last updated: 2026-08-27
 - Issue #87 progress commits are documentation-only. Executable claims are tied to the tested heads above, not to the later documentation heads.
 - Verified executable proof commit for issue #89: `d5153938a2142b49a6b9c5168c14fda4944e315e`.
 - This issue #89 progress change is documentation-only. Executable claims are tied to the tested commit above, not to the later documentation head.
+- Verified implementation commit for issue #91: `47da4a36eb4909f8d120ab032bb12435196a23b9`.
+- This issue #91 progress change is documentation-only. Executable claims are tied to the tested implementation commit above, not to the later documentation head.
 - Framework boundary under test: a real ASP.NET Core 10.0.11 and Blazor static SSR test host consuming the project-referenced `net8.0` Htmxor library.
-- V1 slices proved on this tree: issue #78, stock `@page` routing with a direct HTMX GET; issue #81, every documented .NET 10 Blazor component-route constraint plus typed optional presence and absence; issue #83, authorization-policy and authenticated-user parity for normal and direct GETs; issue #85, one stock named `EditForm` POST with form binding, antiforgery ordering, request-component callback dispatch, and direct component output; issue #87, one shared runtime path for component-owned PUT, PATCH, and DELETE actions represented by fixed future-generator output; issue #89, composition of that assumed generated action output with an application-authored asynchronous parameter lifecycle override.
-- Current implementation slice after #89: none. Recheck issue #89, branch publication state, and `origin/main` before starting the next slice.
+- V1 slices proved on this tree: issue #78, stock `@page` routing with a direct HTMX GET; issue #81, every documented .NET 10 Blazor component-route constraint plus typed optional presence and absence; issue #83, authorization-policy and authenticated-user parity for normal and direct GETs; issue #85, one stock named `EditForm` POST with form binding, antiforgery ordering, request-component callback dispatch, and direct component output; issue #87, one shared runtime path for component-owned PUT, PATCH, and DELETE actions represented by fixed future-generator output; issue #89, composition of that assumed generated action output with an application-authored asynchronous parameter lifecycle override; issue #91, one assumed-generated constrained HTMX-only GET route for a component without `@page`, using stock Blazor invocation and static SSR.
+- Current implementation slice after #91: none. Recheck issue #91, branch publication state, and `origin/main` before starting the next slice.
 
 ## Proven v1 behavior
 
@@ -223,6 +225,45 @@ the request-scoped descriptor's atomic `TryConsume`, not from an assumption that
 Blazor supplies parameters only once. The stand-in proves neither source-generator
 behavior nor a final emitted API.
 
+Protected behavior for issue #91:
+
+> When a component without `@page` declares an HTMX-only GET route, assumed
+> generated registration maps that route through the stock Blazor invoker so an
+> authorized direct HTMX request receives the request-owned component, while a
+> normal GET cannot reach it.
+
+The ASP.NET Core 10.0.11 hosted proof uses one component without `@page`, one
+`/reports/{ReportId:int}` GET route under an application route group, one query
+value, one claim policy, and one request-scoped dependency. A hand-authored
+`.g.cs` stand-in supplies only the component type, normalized constrained route,
+GET and authorization metadata, and registration on the exact route group. It
+does not prove source-generator behavior or a final generated API.
+
+The shared internal registration maps the normalized route with the public
+[`MapGet`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.builder.endpointroutebuilderextensions.mapget?view=aspnetcore-10.0)
+overload that accepts an explicit `RequestDelegate`. That delegate resolves the
+public `IRazorComponentEndpointInvoker` and calls `Render`, matching the stock
+[Razor component endpoint factory's invocation path](https://github.com/dotnet/aspnetcore/blob/v10.0.11/src/Components/Endpoints/src/Builder/RazorComponentEndpointFactory.cs#L18-L68).
+The endpoint carries component, direct-root, link-suppression, route, and
+authorization metadata. Mapping it on the exact route group preserves the
+group's prefix and application metadata marker.
+
+A direct-only matcher removes this endpoint from normal requests; it grants no
+authority. ASP.NET Core authorization still enforces the endpoint policy. The
+stock invoker initializes route state, and the stock static SSR renderer creates
+the request-owned component. A narrow direct root renders that route data without
+a `Router` route-table lookup, which the component cannot satisfy because it has
+no `@page`. This path neither copies renderer code nor replaces Blazor services.
+
+An authorized direct GET returns `200` without the stock shell and renders one
+initialized component containing route value `42`, query value `from-query`,
+identity `issue-91-user`, the scoped dependency, and the group marker. A normal
+GET returns `404`, an anonymous direct GET returns `401`, rejected constrained
+input returns `404`, and POST, PUT, PATCH, and DELETE return `405`. Exactly one
+component endpoint owns the prefixed route. The host application authors no
+matching handler; the checked-in `.g.cs` stand-in supplies the assumed-generated
+registration.
+
 ## Executable evidence
 
 - Meaningful red at `66139317b9edae1fff2ff73fa5175381ee3487b1`: the new .NET 10 hosted test discovered and executed one test, then failed during real application startup with the expected `NullReferenceException` in the obsolete private-reflection component discovery path.
@@ -255,6 +296,11 @@ behavior nor a final emitted API.
 - Issue #87 regression proof at the same clean commit used `dotnet test test/Htmxor.AspNetCore10.Tests/Htmxor.AspNetCore10.Tests.csproj --configuration Release --no-restore --filter "FullyQualifiedName~Issue89LifecycleCompositionTests|FullyQualifiedName~Issue87UnsafeActionTests" --blame-hang --blame-hang-timeout 5min`; 12 cases were discovered, executed, and passed with 0 failures or skips. This retained issue #87 method identity, authorization metadata, and antiforgery coverage alongside the composition proof.
 - Broader proof at the same clean commit: `dotnet run --project eng/Htmxor.Quality/Htmxor.Quality.csproj -- check --profile fast` passed 102 quality tests, 39 .NET 10 hosted tests, and 150 existing non-browser tests. Total: 291 discovered, 291 executed, 291 passed, 0 failed, 0 skipped, 0 errors, and 0 timeouts. The Release build produced 0 warnings and 0 errors.
 - Mutation testing was not run. Issue #89 makes it optional diagnostic evidence for this proof of concept.
+- Meaningful red for issue #91 is preserved at `319a23680d2b89b7eed39504c9e974e0e3772cae`: `dotnet test test/Htmxor.AspNetCore10.Tests/Htmxor.AspNetCore10.Tests.csproj --configuration Release --no-restore --filter "FullyQualifiedName~Issue91HtmxOnlyRouteTests" --blame-hang --blame-hang-timeout 5min` discovered and executed 1 hosted test; 0 passed, 1 failed, 0 skipped. The authorized direct HTMX GET expected `200` but received `404` because the component had neither a stock `@page` endpoint nor an assumed-generated HTMX-only endpoint.
+- Focused proof at clean implementation commit `47da4a36eb4909f8d120ab032bb12435196a23b9`: the same command discovered and executed 1 hosted test; 1 passed, 0 failed, 0 skipped.
+- Broader proof at the same clean implementation commit: `dotnet run --project eng/Htmxor.Quality/Htmxor.Quality.csproj --no-restore -- check --profile fast` passed 102 quality tests, 40 .NET 10 hosted tests, and 150 existing non-browser tests. Total: 292 discovered, 292 executed, 292 passed, 0 failed, 0 skipped, 0 errors, and 0 timeouts. The Release build produced 0 warnings and 0 errors.
+- The first Standards review found one P3 root-component naming ambiguity. The implementation commit was amended, affected evidence was rerun, and separate Standards and Spec rereviews of `9c89b7f5629b53a1dfed8fd1186dd44d374524c6...47da4a36eb4909f8d120ab032bb12435196a23b9` passed with zero actionable findings.
+- Mutation testing was not run. Issue #91 makes it optional diagnostic evidence for this proof of concept.
 
 ## Remaining limits
 
@@ -263,22 +309,29 @@ behavior nor a final emitted API.
 - The direct path is proved on ASP.NET Core 10 only. The supported framework matrix and packed-package consumption remain unproved.
 - The authorization proof uses one deterministic scheme and one claim policy. It does not cover scheme selection, custom challenge or forbid handlers, identity-provider integration, or authorization on other HTTP methods.
 - The issue #85 proof covers one stock named `EditForm`, one valid value, and one missing-token POST. It does not cover multiple forms, validation failures, invalid-token variants, file uploads, normal POST parity, or custom method discovery. Issue #87 proves unsafe route/query instance dispatch separately, without request-body or form binding.
-- The issue #87 and #89 stand-ins assume future generator output. Generator discovery, Razor expression analysis, diagnostics, final public API, and packaged-consumer registration remain unproved.
+- The issue #87, #89, and #91 stand-ins assume future generator output. Generator discovery, Razor expression and route-metadata analysis, route normalization, generated registration, diagnostics, final public API, and packaged-consumer registration remain unproved.
 - Issue #89 covers an application-authored public `SetParametersAsync` override. An application that explicitly implements `IComponent.SetParametersAsync` would conflict with the generated explicit member and needs a future diagnostic or developer-model decision. Repeated parameter delivery, an override that intentionally omits its base call, async actions, request-body and form binding, multiple actions on one verb, multiple routes or components, navigation, exception and cancellation behavior, `ShouldRender` overrides, and streaming SSR remain unexercised.
 - The issue #85, #87, and #89 hosts run on Windows TestServer with the stock ephemeral Data Protection provider. They do not exercise Kestrel, TLS, persistent key storage, server-farm key sharing, Linux, a browser, or an application-selected HTMX runtime.
+- Issue #91 also ran only on Windows TestServer. It did not exercise Kestrel, TLS, Linux, a browser, an application-selected HTMX runtime, or packed-package consumption.
 - The tests do not exercise layouts, caching, concurrency, enhanced navigation, interactive render modes, fragments, browser behavior, or performance.
 - The legacy test application still uses internal private-reflection discovery and global service replacements. Later slices must replace the behavior they cover instead of extending that prototype.
-- HTMX-only component routes remain unproved. PUT, PATCH, and DELETE now have an internal runtime proof driven by test-only fixed descriptors, but no public generated consumer path. Per-component POST discovery beyond the one stock named form also remains unproved.
+- Issue #91 proves one assumed-generated HTMX-only GET route with an `int`
+  constraint, one authorization policy, and one application route-group metadata
+  marker. It does not prove typed route-value conversion through this new seam,
+  other constraints, multiple generated routes or components, collisions,
+  normal-only or dual generated reachability, HEAD or OPTIONS behavior, or the
+  full range of application group and security conventions. PUT, PATCH, and
+  DELETE still have only test-stand-in generated descriptors, and per-component
+  POST discovery beyond the stock named-form proof remains unproved.
 
 ## Recommended next slice
 
-A narrow source-generator tracer should replace the hand-authored stand-in for
-one page-local unsafe method group. Its protected behavior should be: when a
-Razor page declares one statically discoverable unsafe method-group action,
-Htmxor emits the proved descriptor and lifecycle composition so the hosted HTTP
-behavior passes without checked-in generated code. The slice should diagnose an
-application-owned explicit `IComponent.SetParametersAsync` implementation and
-ambiguous handler shapes rather than changing the developer model. It should not
-promote issue #87's internal registration shape into a final public API or widen
-into the complete action generator. Recheck the live v1 tracker and
-`origin/main` before selecting or creating that issue.
+A narrow source-generator tracer should replace `Issue91GeneratedRoute.g.cs` for
+one component without `@page` and one statically discoverable HTMX-only GET
+route. Its protected behavior should be: when that component declares the route,
+Htmxor emits the proved descriptor and exact-group registration so the hosted
+HTTP behavior passes without checked-in generated output. The slice should add
+compilation evidence and useful diagnostics for its one supported shape, without
+widening into normal-only or dual reachability, unsafe actions, packaging, or a
+final public generated API. Recheck the live v1 tracker and `origin/main` before
+selecting or creating the issue.

--- a/src/Htmxor/Builder/HtmxorComponentEndpointRouteBuilderExtensions.cs
+++ b/src/Htmxor/Builder/HtmxorComponentEndpointRouteBuilderExtensions.cs
@@ -15,7 +15,8 @@ namespace Microsoft.AspNetCore.Builder;
 
 public static class HtmxorComponentEndpointRouteBuilderExtensions
 {
-	private static readonly RootComponentMetadata DirectRootComponent = new(typeof(HtmxorDirectRenderHost));
+	private static readonly RootComponentMetadata PageRouteDirectRoot = new(typeof(HtmxorDirectRenderHost));
+	private static readonly RootComponentMetadata HtmxOnlyGetDirectRoot = new(typeof(HtmxorDirectComponentHost));
 
 	public static RazorComponentsEndpointConventionBuilder AddHtmxorComponentEndpoints(
 		this RazorComponentsEndpointConventionBuilder builder,
@@ -31,6 +32,23 @@ public static class HtmxorComponentEndpointRouteBuilderExtensions
 		ArgumentNullException.ThrowIfNull(endpoints);
 		ArgumentNullException.ThrowIfNull(generatedActions);
 		builder.Finally(endpointBuilder => ConfigureEndpoint(endpointBuilder, generatedActions));
+
+		return builder;
+	}
+
+	internal static IEndpointConventionBuilder MapHtmxorComponentEndpoint(
+		this IEndpointRouteBuilder endpoints,
+		HtmxorComponentGetRouteDescriptor generatedRoute)
+	{
+		ArgumentNullException.ThrowIfNull(endpoints);
+		ArgumentNullException.ThrowIfNull(generatedRoute);
+		ArgumentException.ThrowIfNullOrWhiteSpace(generatedRoute.NormalizedRoute);
+		ArgumentNullException.ThrowIfNull(generatedRoute.Metadata);
+		RequestDelegate requestDelegate = static context => context.RequestServices
+			.GetRequiredService<IRazorComponentEndpointInvoker>()
+			.Render(context);
+		var builder = endpoints.MapGet(generatedRoute.NormalizedRoute, requestDelegate);
+		builder.Add(endpointBuilder => ConfigureGeneratedGetEndpoint(endpointBuilder, generatedRoute));
 
 		return builder;
 	}
@@ -63,6 +81,22 @@ public static class HtmxorComponentEndpointRouteBuilderExtensions
 		var endpointActions = GetEndpointActions(routeEndpointBuilder, generatedActions);
 		AddActionMetadata(endpointBuilder, endpointActions);
 		endpointBuilder.RequestDelegate = context => InvokeEndpoint(context, stockRequestDelegate, endpointActions);
+	}
+
+	private static void ConfigureGeneratedGetEndpoint(
+		EndpointBuilder endpointBuilder,
+		HtmxorComponentGetRouteDescriptor generatedRoute)
+	{
+		foreach (var metadata in generatedRoute.Metadata)
+		{
+			endpointBuilder.Metadata.Add(metadata);
+		}
+
+		endpointBuilder.Metadata.Add(new SuppressLinkGenerationMetadata());
+		endpointBuilder.Metadata.Add(new ComponentTypeMetadata(generatedRoute.ComponentType));
+		endpointBuilder.Metadata.Add(HtmxOnlyGetDirectRoot);
+		endpointBuilder.Metadata.Add(HtmxorDirectEndpointMetadata.Instance);
+		endpointBuilder.DisplayName = $"{generatedRoute.NormalizedRoute} ({generatedRoute.ComponentType.Name}) (HTMX-only GET)";
 	}
 
 	private static HtmxorComponentActionDescriptor[] GetEndpointActions(
@@ -180,7 +214,7 @@ public static class HtmxorComponentEndpointRouteBuilderExtensions
 		var requestDelegate = selectedEndpoint.RequestDelegate
 			?? throw new InvalidOperationException("A routed Razor component endpoint must have a request delegate.");
 		var metadata = selectedEndpoint.Metadata
-			.Select(item => item is RootComponentMetadata ? DirectRootComponent : item)
+			.Select(item => item is RootComponentMetadata ? PageRouteDirectRoot : item)
 			.ToArray();
 		return new RouteEndpoint(
 			requestDelegate,

--- a/src/Htmxor/Builder/HtmxorComponentGetRouteDescriptor.cs
+++ b/src/Htmxor/Builder/HtmxorComponentGetRouteDescriptor.cs
@@ -1,0 +1,6 @@
+namespace Htmxor.Builder;
+
+internal sealed record HtmxorComponentGetRouteDescriptor(
+	Type ComponentType,
+	string NormalizedRoute,
+	IReadOnlyList<object> Metadata);

--- a/src/Htmxor/Builder/HtmxorDirectEndpointMatcherPolicy.cs
+++ b/src/Htmxor/Builder/HtmxorDirectEndpointMatcherPolicy.cs
@@ -1,0 +1,39 @@
+using Htmxor.Http;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Matching;
+
+namespace Htmxor.Builder;
+
+internal sealed class HtmxorDirectEndpointMatcherPolicy : MatcherPolicy, IEndpointSelectorPolicy
+{
+	public override int Order => int.MinValue + 150;
+
+	public bool AppliesToEndpoints(IReadOnlyList<Endpoint> endpoints)
+	{
+		ArgumentNullException.ThrowIfNull(endpoints);
+		return endpoints.Any(endpoint =>
+			endpoint.Metadata.GetMetadata<HtmxorDirectEndpointMetadata>() is not null);
+	}
+
+	public Task ApplyAsync(HttpContext httpContext, CandidateSet candidates)
+	{
+		ArgumentNullException.ThrowIfNull(httpContext);
+		ArgumentNullException.ThrowIfNull(candidates);
+		if (httpContext.GetHtmxContext().Request.RoutingMode is RoutingMode.Direct)
+		{
+			return Task.CompletedTask;
+		}
+
+		for (var index = 0; index < candidates.Count; index++)
+		{
+			if (candidates.IsValidCandidate(index) &&
+				candidates[index].Endpoint.Metadata.GetMetadata<HtmxorDirectEndpointMetadata>() is not null)
+			{
+				candidates.SetValidity(index, false);
+			}
+		}
+
+		return Task.CompletedTask;
+	}
+}

--- a/src/Htmxor/Builder/HtmxorDirectEndpointMetadata.cs
+++ b/src/Htmxor/Builder/HtmxorDirectEndpointMetadata.cs
@@ -1,0 +1,10 @@
+namespace Htmxor.Builder;
+
+internal sealed class HtmxorDirectEndpointMetadata
+{
+	public static HtmxorDirectEndpointMetadata Instance { get; } = new();
+
+	private HtmxorDirectEndpointMetadata()
+	{
+	}
+}

--- a/src/Htmxor/DependencyInjection/HtmxorApplicationBuilderExtensions.cs
+++ b/src/Htmxor/DependencyInjection/HtmxorApplicationBuilderExtensions.cs
@@ -53,6 +53,7 @@ public static class HtmxorApplicationBuilderExtensions
 		});
 		services.AddCascadingValue(serviceProvider => serviceProvider.GetRequiredService<HtmxContext>());
 		services.AddScoped<HtmxorComponentActionRequest>();
+		services.TryAddEnumerable(ServiceDescriptor.Singleton<MatcherPolicy, HtmxorDirectEndpointMatcherPolicy>());
 
 		return razorComponentsBuilder;
 	}

--- a/src/Htmxor/Endpoints/HtmxorDirectComponentHost.cs
+++ b/src/Htmxor/Endpoints/HtmxorDirectComponentHost.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.AspNetCore.Components.Routing;
+
+namespace Htmxor.Endpoints;
+
+internal sealed class HtmxorDirectComponentHost : ComponentBase
+{
+	[Inject]
+	private IRoutingStateProvider RoutingStateProvider { get; set; } = default!;
+
+	protected override void BuildRenderTree(RenderTreeBuilder builder)
+	{
+		var routeData = RoutingStateProvider.RouteData
+			?? throw new InvalidOperationException("The stock Razor component invoker did not initialize route data.");
+		builder.AddContent(0, HtmxorDirectRenderHost.RenderRoute(routeData));
+	}
+}

--- a/src/Htmxor/Endpoints/HtmxorDirectRenderHost.cs
+++ b/src/Htmxor/Endpoints/HtmxorDirectRenderHost.cs
@@ -20,7 +20,7 @@ internal sealed class HtmxorDirectRenderHost : ComponentBase
 		builder.CloseComponent();
 	}
 
-	private static RenderFragment RenderRoute(RouteData routeData) => builder =>
+	internal static RenderFragment RenderRoute(RouteData routeData) => builder =>
 	{
 		builder.OpenComponent<DynamicComponent>(0);
 		builder.AddComponentParameter(1, nameof(DynamicComponent.Type), routeData.PageType);

--- a/test/Htmxor.AspNetCore10.Tests/Issue91GeneratedRoute.g.cs
+++ b/test/Htmxor.AspNetCore10.Tests/Issue91GeneratedRoute.g.cs
@@ -1,0 +1,25 @@
+using Htmxor.Builder;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace Htmxor.AspNetCore10;
+
+// Hand-authored stand-in for future generated output. Issue #91 exercises only route registration.
+internal static class Issue91GeneratedRoute
+{
+	public const string NormalizedRoute = "/reports/{ReportId:int}";
+	public const string PolicyName = "issue-91-policy";
+
+	public static HtmxorComponentGetRouteDescriptor Descriptor { get; } = new(
+		typeof(Issue91HtmxOnlyComponent),
+		NormalizedRoute,
+		[
+			new HtmxRouteAttribute(NormalizedRoute) { Methods = [HttpMethods.Get] },
+			new AuthorizeAttribute(PolicyName),
+		]);
+
+	public static IEndpointConventionBuilder Register(IEndpointRouteBuilder endpoints)
+		=> endpoints.MapHtmxorComponentEndpoint(Descriptor);
+}

--- a/test/Htmxor.AspNetCore10.Tests/Issue91HtmxOnlyComponent.razor
+++ b/test/Htmxor.AspNetCore10.Tests/Issue91HtmxOnlyComponent.razor
@@ -1,0 +1,30 @@
+@attribute [Htmxor.HtmxRoute("/reports/{ReportId:int}", Methods = new[] { "GET" })]
+@attribute [Authorize(Policy = "issue-91-policy")]
+@inject Issue91RequestProbe RequestProbe
+@using Microsoft.AspNetCore.Authorization
+
+<section data-issue-91-component>
+    <p data-request-values>@ReportId|@QueryValue|@HttpContext.User.Identity?.Name|@RequestProbe.Value|@InitializationCount|@GroupMarker</p>
+</section>
+
+@code {
+    [Parameter]
+    public int ReportId { get; set; }
+
+    [Parameter]
+    [SupplyParameterFromQuery(Name = "query")]
+    public string? QueryValue { get; set; }
+
+    [CascadingParameter]
+    private HttpContext HttpContext { get; set; } = default!;
+
+    private int InitializationCount { get; set; }
+
+    private string? GroupMarker
+        => HttpContext.GetEndpoint()?.Metadata.GetMetadata<Issue91GroupMetadata>()?.Value;
+
+    protected override void OnInitialized()
+    {
+        InitializationCount = RequestProbe.RecordInitialization();
+    }
+}

--- a/test/Htmxor.AspNetCore10.Tests/Issue91HtmxOnlyComponent.razor
+++ b/test/Htmxor.AspNetCore10.Tests/Issue91HtmxOnlyComponent.razor
@@ -9,7 +9,7 @@
 
 @code {
     [Parameter]
-    public int ReportId { get; set; }
+    public string? ReportId { get; set; }
 
     [Parameter]
     [SupplyParameterFromQuery(Name = "query")]

--- a/test/Htmxor.AspNetCore10.Tests/Issue91HtmxOnlyRouteTests.cs
+++ b/test/Htmxor.AspNetCore10.Tests/Issue91HtmxOnlyRouteTests.cs
@@ -1,0 +1,172 @@
+using System.Net;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Components.Endpoints;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Htmxor.AspNetCore10;
+
+public sealed class Issue91HtmxOnlyRouteTests : IAsyncLifetime
+{
+	private const string PolicyName = "issue-91-policy";
+	private const string RoutePrefix = "/issue-91-group";
+	private const string DeclaredRoute = "/reports/{ReportId:int}";
+	private const string RequestPath = "/issue-91-group/reports/42?query=from-query";
+	private WebApplication app = default!;
+	private HttpClient client = default!;
+
+	public async Task InitializeAsync()
+	{
+		var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+		{
+			ApplicationName = typeof(Issue91HtmxOnlyRouteTests).Assembly.GetName().Name,
+			EnvironmentName = Environments.Development,
+		});
+		builder.WebHost.UseTestServer();
+		builder.Services.AddAuthentication(Issue91AuthenticationHandler.SchemeName)
+			.AddScheme<AuthenticationSchemeOptions, Issue91AuthenticationHandler>(
+				Issue91AuthenticationHandler.SchemeName,
+				_ => { });
+		builder.Services.AddAuthorization(options => options.AddPolicy(
+			PolicyName,
+			policy => policy.RequireClaim(Issue91AuthenticationHandler.AccessClaim, "granted")));
+		builder.Services.AddRazorComponents().AddHtmx();
+		builder.Services.AddScoped(_ => new Issue91RequestProbe("from-scoped-di"));
+
+		app = builder.Build();
+		app.UseAuthentication();
+		app.UseAuthorization();
+		app.UseAntiforgery();
+		var routes = app.MapGroup(RoutePrefix)
+			.WithMetadata(Issue91GroupMetadata.Instance);
+		routes.MapRazorComponents<Issue78App>()
+			.AddHtmxorComponentEndpoints(app);
+
+		await app.StartAsync();
+		client = app.GetTestClient();
+	}
+
+	[Fact]
+	public async Task Htmx_only_get_uses_one_generated_component_endpoint()
+	{
+		using var directResponse = await SendAsync(HttpMethod.Get, direct: true, authenticated: true);
+		var directBody = await directResponse.Content.ReadAsStringAsync();
+
+		Assert.Equal(HttpStatusCode.OK, directResponse.StatusCode);
+		Assert.Contains("data-issue-91-component", directBody, StringComparison.Ordinal);
+		Assert.Contains(
+			"data-request-values>42|from-query|issue-91-user|from-scoped-di|1|group-convention-preserved</p>",
+			directBody,
+			StringComparison.Ordinal);
+		Assert.Equal(2, directBody.Split("data-issue-91-component", StringSplitOptions.None).Length);
+		Assert.DoesNotContain("<html", directBody, StringComparison.OrdinalIgnoreCase);
+		Assert.DoesNotContain("data-stock-shell", directBody, StringComparison.Ordinal);
+
+		var componentEndpoints = ((IEndpointRouteBuilder)app).DataSources
+			.SelectMany(dataSource => dataSource.Endpoints)
+			.OfType<RouteEndpoint>()
+			.Where(endpoint => endpoint.Metadata.GetMetadata<ComponentTypeMetadata>()?.Type == typeof(Issue91HtmxOnlyComponent));
+		var componentEndpoint = Assert.Single(componentEndpoints);
+		Assert.Equal(RoutePrefix + DeclaredRoute, componentEndpoint.RoutePattern.RawText);
+		Assert.Equal(
+			[HttpMethods.Get],
+			componentEndpoint.Metadata.GetRequiredMetadata<HttpMethodMetadata>().HttpMethods);
+		Assert.Same(
+			Issue91GroupMetadata.Instance,
+			componentEndpoint.Metadata.GetRequiredMetadata<Issue91GroupMetadata>());
+		Assert.Contains(
+			componentEndpoint.Metadata.GetOrderedMetadata<IAuthorizeData>(),
+			metadata => string.Equals(metadata.Policy, PolicyName, StringComparison.Ordinal));
+
+		using var normalResponse = await SendAsync(HttpMethod.Get, direct: false, authenticated: true);
+		Assert.Equal(HttpStatusCode.NotFound, normalResponse.StatusCode);
+
+		using var anonymousResponse = await SendAsync(HttpMethod.Get, direct: true, authenticated: false);
+		Assert.Equal(HttpStatusCode.Unauthorized, anonymousResponse.StatusCode);
+
+		foreach (var method in new[] { HttpMethod.Post, HttpMethod.Put, HttpMethod.Patch, HttpMethod.Delete })
+		{
+			using var response = await SendAsync(method, direct: true, authenticated: true);
+			Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
+		}
+	}
+
+	private async Task<HttpResponseMessage> SendAsync(HttpMethod method, bool direct, bool authenticated)
+	{
+		using var request = new HttpRequestMessage(method, RequestPath);
+		if (direct)
+		{
+			request.Headers.Add("HX-Request", "true");
+		}
+
+		if (authenticated)
+		{
+			request.Headers.Add(Issue91AuthenticationHandler.UserHeaderName, "issue-91-user");
+		}
+
+		return await client.SendAsync(request);
+	}
+
+	public async Task DisposeAsync()
+	{
+		client?.Dispose();
+		if (app is not null)
+		{
+			await app.DisposeAsync();
+		}
+	}
+}
+
+internal sealed record Issue91GroupMetadata(string Value)
+{
+	public static Issue91GroupMetadata Instance { get; } = new("group-convention-preserved");
+}
+
+internal sealed class Issue91RequestProbe(string value)
+{
+	private int initializationCount;
+
+	public string Value { get; } = value;
+
+	public int RecordInitialization() => ++initializationCount;
+}
+
+internal sealed class Issue91AuthenticationHandler(
+	IOptionsMonitor<AuthenticationSchemeOptions> options,
+	ILoggerFactory logger,
+	UrlEncoder encoder)
+	: AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+{
+	public const string SchemeName = "issue-91-test";
+	public const string UserHeaderName = "X-Issue-91-User";
+	public const string AccessClaim = "issue-91-access";
+
+	protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+	{
+		if (!Request.Headers.TryGetValue(UserHeaderName, out var userHeader))
+		{
+			return Task.FromResult(AuthenticateResult.NoResult());
+		}
+
+		var user = userHeader.ToString();
+		var claims = new[]
+		{
+			new Claim(ClaimTypes.NameIdentifier, user),
+			new Claim(ClaimTypes.Name, user),
+			new Claim(AccessClaim, "granted"),
+		};
+		var principal = new ClaimsPrincipal(new ClaimsIdentity(claims, SchemeName));
+		var ticket = new AuthenticationTicket(principal, SchemeName);
+		return Task.FromResult(AuthenticateResult.Success(ticket));
+	}
+}

--- a/test/Htmxor.AspNetCore10.Tests/Issue91HtmxOnlyRouteTests.cs
+++ b/test/Htmxor.AspNetCore10.Tests/Issue91HtmxOnlyRouteTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
+using Htmxor.Endpoints;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
@@ -51,6 +52,7 @@ public sealed class Issue91HtmxOnlyRouteTests : IAsyncLifetime
 			.WithMetadata(Issue91GroupMetadata.Instance);
 		routes.MapRazorComponents<Issue78App>()
 			.AddHtmxorComponentEndpoints(app);
+		Issue91GeneratedRoute.Register(routes);
 
 		await app.StartAsync();
 		client = app.GetTestClient();
@@ -84,26 +86,49 @@ public sealed class Issue91HtmxOnlyRouteTests : IAsyncLifetime
 		Assert.Same(
 			Issue91GroupMetadata.Instance,
 			componentEndpoint.Metadata.GetRequiredMetadata<Issue91GroupMetadata>());
+		Assert.Equal(
+			typeof(HtmxorDirectComponentHost),
+			componentEndpoint.Metadata.GetRequiredMetadata<RootComponentMetadata>().Type);
+		var declaredRoute = componentEndpoint.Metadata.GetRequiredMetadata<HtmxRouteAttribute>();
+		Assert.Equal(DeclaredRoute, declaredRoute.Template);
+		Assert.Equal(HttpMethods.Get, Assert.Single(declaredRoute.Methods));
 		Assert.Contains(
 			componentEndpoint.Metadata.GetOrderedMetadata<IAuthorizeData>(),
 			metadata => string.Equals(metadata.Policy, PolicyName, StringComparison.Ordinal));
 
 		using var normalResponse = await SendAsync(HttpMethod.Get, direct: false, authenticated: true);
+		var normalBody = await normalResponse.Content.ReadAsStringAsync();
 		Assert.Equal(HttpStatusCode.NotFound, normalResponse.StatusCode);
+		Assert.DoesNotContain("data-issue-91-component", normalBody, StringComparison.Ordinal);
 
 		using var anonymousResponse = await SendAsync(HttpMethod.Get, direct: true, authenticated: false);
+		var anonymousBody = await anonymousResponse.Content.ReadAsStringAsync();
 		Assert.Equal(HttpStatusCode.Unauthorized, anonymousResponse.StatusCode);
+		Assert.DoesNotContain("data-issue-91-component", anonymousBody, StringComparison.Ordinal);
+
+		using var rejectedConstraintResponse = await SendAsync(
+			HttpMethod.Get,
+			direct: true,
+			authenticated: true,
+			"/issue-91-group/reports/not-an-int?query=from-query");
+		Assert.Equal(HttpStatusCode.NotFound, rejectedConstraintResponse.StatusCode);
 
 		foreach (var method in new[] { HttpMethod.Post, HttpMethod.Put, HttpMethod.Patch, HttpMethod.Delete })
 		{
 			using var response = await SendAsync(method, direct: true, authenticated: true);
+			var body = await response.Content.ReadAsStringAsync();
 			Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
+			Assert.DoesNotContain("data-issue-91-component", body, StringComparison.Ordinal);
 		}
 	}
 
-	private async Task<HttpResponseMessage> SendAsync(HttpMethod method, bool direct, bool authenticated)
+	private async Task<HttpResponseMessage> SendAsync(
+		HttpMethod method,
+		bool direct,
+		bool authenticated,
+		string path = RequestPath)
 	{
-		using var request = new HttpRequestMessage(method, RequestPath);
+		using var request = new HttpRequestMessage(method, path);
 		if (direct)
 		{
 			request.Headers.Add("HX-Request", "true");


### PR DESCRIPTION
Closes #91.

## Why

V1 promises components that have no normal `@page` route and are reachable only through HTMX. The legacy prototype discovers those components privately and renders them through replaced framework services. This POC proves the replacement runtime seam on public ASP.NET Core 10 contracts without building the generator.

## What changed

- Added an internal future-generator route descriptor and registration path for one constrained GET.
- Mapped the descriptor on the application's exact route group with the `MapGet(..., RequestDelegate)` overload. The delegate resolves the stock `IRazorComponentEndpointInvoker` and calls `Render`.
- Added component, root, link-suppression, route, authorization, and direct-only metadata while preserving the route-group prefix and application marker.
- Added a matcher policy that removes the endpoint from non-direct requests. Authorization remains endpoint-policy and middleware owned; the HTMX header grants no authority.
- Added a narrow direct root that renders the invoker-supplied `RouteData` through the stock static SSR renderer, without replacing Blazor services or copying renderer code.
- Added one no-`@page` component, a hand-authored `.g.cs` stand-in, and a hosted ASP.NET Core 10 proof. No generator discovery, Razor analysis, diagnostics, packaging, or final generated API was added.
- Recorded the executed contract, limits, and next tracer slice in `docs/roadmap/v1/progress.md` as a documentation-only commit.

The host application maps no matching controller, Minimal API handler, or per-component endpoint. The checked-in `.g.cs` stand-in supplies only the assumed generated registration.

## Framework seam and rejected path

The stock [Razor component endpoint factory](https://github.com/dotnet/aspnetcore/blob/v10.0.11/src/Components/Endpoints/src/Builder/RazorComponentEndpointFactory.cs#L18-L68) uses a request delegate that resolves `IRazorComponentEndpointInvoker`, plus `ComponentTypeMetadata` and `RootComponentMetadata`. The POC mirrors that public invocation contract and uses the public [`MapGet`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.builder.endpointroutebuilderextensions.mapget?view=aspnetcore-10.0) request-delegate overload on the exact route group.

The first green-path experiment reused the existing Router-based direct root. The real host rejected it with `InvalidOperationException: Unable to find the provided template '/issue-91-group/reports/{ReportId:int}'` because the component deliberately has no `@page`/`RouteAttribute`. The final narrow root consumes the route state already initialized by the stock invoker instead of forcing a second route-table lookup. No private or copied framework seam was introduced.

## Evidence

Meaningful red is preserved at `319a23680d2b89b7eed39504c9e974e0e3772cae`:

```powershell
dotnet test test/Htmxor.AspNetCore10.Tests/Htmxor.AspNetCore10.Tests.csproj --configuration Release --no-restore --filter "FullyQualifiedName~Issue91HtmxOnlyRouteTests" --blame-hang --blame-hang-timeout 5min
```

One hosted test was discovered and executed; `0` passed and `1` failed. The authorized direct HTMX GET expected `200` but received the required `404` because neither a stock `@page` endpoint nor assumed-generated endpoint existed.

Clean tested implementation head: `47da4a36eb4909f8d120ab032bb12435196a23b9`.

- The same focused command passed `1/1`.
- `dotnet run --project eng/Htmxor.Quality/Htmxor.Quality.csproj --no-restore -- check --profile fast` passed `102` quality, `40` ASP.NET Core 10 hosted, and `150` library tests: `292/292`, with `0` failures, skips, errors, or timeouts. Release build: `0` warnings and `0` errors.
- The hosted proof observes authorized direct `200`, normal `404`, anonymous direct `401`, rejected route constraint `404`, and POST/PUT/PATCH/DELETE `405`; it also observes the route and query values, identity, scoped dependency, one initialization, one prefixed endpoint, preserved group metadata, and no stock shell.
- The first Standards review found one P3 root-name ambiguity. After the feature commit was amended and affected evidence rerun, separate Standards and Spec rereviews both passed with zero findings.
- Final branch head `249c568522e7880039c497dbeec021be2aa5cde5` adds only this executed-evidence documentation. `git diff --exit-code 47da4a36eb4909f8d120ab032bb12435196a23b9 HEAD -- src test eng samples Htmxor.sln Directory.Build.props Directory.Build.targets` passed, and final full-branch Standards and Spec reviews both passed with zero findings.
- Mutation testing was not run; issue #91 makes it optional diagnostic evidence.

## Not exercised

Source-generator behavior, typed route conversion through this new no-`@page` seam, additional constraints/routes/components and collisions, HEAD/OPTIONS, broader group/security conventions, interactive render modes, forms and unsafe actions, browser/HTMX runtime behavior, Linux, Kestrel/TLS, packed-package consumption, caching, concurrency, performance, and mutation remain unproved.
