### PR TITLE
docs(v1): target application-owned htmx 4

### DIFF
--- a/docs/roadmap/v1/goal.md
+++ b/docs/roadmap/v1/goal.md
@@ -52,6 +52,13 @@ without a wrapper. If the developer supplies element, identifier, or HTML
 attributes, the fragment wraps its child content and emits those values. There
 is no separate `HtmxFragmentElement` concept in v1.
 
+htmx 4's `<hx-partial>` is a client-side delivery envelope for multi-target
+responses. It does not replace the server-side `HtmxFragment` selection
+boundary. Application-authored `<hx-partial>` markup can compose inside a
+fragment and must reach the response unchanged. Any future typed convenience
+helper remains an explicit, optional markup adapter rather than a second
+fragment-selection concept.
+
 Fragment selection must have clear execution semantics. The component and any
 required ancestors may run their normal lifecycle, but Htmxor should not render
 excluded child branches below a known selection boundary. Tests and benchmarks
@@ -83,15 +90,41 @@ supported .NET version.
 
 ## The application owns HTMX
 
-Htmxor v1 does not require or distribute one specific HTMX runtime. The
-application chooses the script, version, extensions, content security policy,
-and upgrade schedule.
+Htmxor v1 targets application-supplied htmx 4.0.0 for its documentation,
+examples, browser conformance, and release evidence. Conformance uses htmx 4
+defaults rather than a compatibility extension or configuration that restores
+htmx 2 behavior.
+
+Htmxor does not distribute or silently select that runtime. The application
+chooses the script source, extensions, content security policy, and upgrade
+schedule. The server integration should remain compatible with other htmx
+versions where they share the required HTTP protocol, but Htmxor claims another
+version only after executing its compatibility evidence.
 
 The server integration must understand the stable HTTP protocol it needs and
 provide bounded hooks for new request headers, response headers, and extension
 behavior. An analyzer may validate values against a developer-selected HTMX
 profile. It must not reject unknown attributes, extension syntax, or newer
 values merely because Htmxor does not know them yet.
+
+Relevant htmx 4 changes include retained `HX-Request`, the new `HX-Request-Type`
+distinction, `HX-Source` in place of the old trigger identity headers, explicit
+attribute inheritance, changed error-response swapping, changed DELETE form-data
+behavior, main-content-before-out-of-band swap ordering, standardized event
+names and request context, extension API changes, and response-header changes.
+This is a risk inventory rather than an exhaustive feature requirement. Htmxor
+must test any behavior it builds on instead of carrying forward htmx 1 or 2
+assumptions. Client-side declarations such as `hx-action`, `hx-method`, and
+`hx-query` still do not grant server methods.
+
+The established v1 server-method model remains implicit GET plus POST, PUT,
+PATCH, and DELETE inferred from component intent. htmx 4's `QUERY` method has no
+matching component directive in that model and is not inferred. Supporting it
+requires a separate public-model decision and evidence.
+
+Targeting htmx 4 does not make every optional htmx 4 client feature a v1
+requirement beyond an explicitly agreed composition such as the raw
+`<hx-partial>` pass-through above.
 
 ## Security and HTTP behavior
 
@@ -118,9 +151,10 @@ allocations, response bytes, and work skipped by fragment selection. V1 needs an
 explicit request-cost budget based on those results.
 
 The exact release-candidate package must pass the supported .NET compatibility
-matrix, security tests, browser conformance tests using application-supplied
-HTMX scripts, package validation, and a clean Production publish and consumer
-test. Project-reference tests alone are not release evidence.
+matrix, security tests, browser conformance tests using an application-supplied
+htmx 4.0.0 script with htmx 4 defaults, package validation, and a clean
+Production publish and consumer test. Project-reference tests alone are not
+release evidence.
 
 ## Outside v1
 
@@ -135,5 +169,6 @@ V1 is complete when a developer can add Htmxor to a stock Blazor static SSR
 application, leave existing pages and forms unchanged, and progressively add
 component-owned HTMX routes, actions, and fragments without writing endpoint
 boilerplate or giving up Blazor behavior. The result must be secure by default,
-independent of the application's HTMX version, supported on the declared .NET
-versions, and within the published request-cost budget.
+proved against application-supplied htmx 4.0.0 without embedding that runtime,
+supported on the declared .NET versions, and within the published request-cost
+budget.

--- a/docs/roadmap/v1/orchestrator-brief.md
+++ b/docs/roadmap/v1/orchestrator-brief.md
@@ -82,6 +82,8 @@ Prefer the next slice that does the most to reduce one of these risks:
   case without endpoint boilerplate.
 - Fragment handling performs or transfers work it claims to avoid.
 - The application cannot choose and upgrade its own HTMX runtime.
+- Behavior differs from application-supplied htmx 4.0.0 running with htmx 4
+  defaults.
 - Package, browser, cache, or performance behavior differs from project-reference
   tests.
 
@@ -96,6 +98,9 @@ that leaves reusable verification behind.
 - Do not copy private Blazor renderer code or use new private reflection.
 - Do not treat HTMX headers as authorization evidence.
 - Do not bind Htmxor to one embedded HTMX version.
+- Use application-supplied htmx 4.0.0 with htmx 4 defaults for v1 browser,
+  example, and release evidence. Do not claim compatibility with another htmx
+  version unless that version was executed.
 - Do not claim support for a .NET version, browser path, package, or performance
   budget that was not executed.
 - Do not publish issues, pull requests, packages, or releases without the user's

--- a/docs/roadmap/v1/progress.md
+++ b/docs/roadmap/v1/progress.md
@@ -29,8 +29,15 @@ Last updated: 2026-08-28
 - Verified post-review compiled-route fix for issue #100: `42082a1bacb71364f5ccf513c8b5e791528d83cf`.
 - This issue #100 progress change is documentation-only. Executable claims are tied to the tested commits above, not to the later documentation head.
 - Framework boundary under test: ASP.NET Core 10.0.11 and Blazor static SSR on TestServer. Issues #95, #97, and #100 use a separate external .NET 10 Razor consumer that restores a locally packed `net8.0` Htmxor package instead of referencing an Htmxor project.
+- Product target correction authorized on 2026-08-28: v1 documentation,
+  examples, browser conformance, and release evidence target an
+  application-supplied htmx 4.0.0 script running with htmx 4 defaults. Htmxor
+  does not embed or silently select that runtime. This records a product
+  decision, not executed htmx 4 compatibility evidence.
 - V1 slices proved on this tree: issue #78, stock `@page` routing with a direct HTMX GET; issue #81, every documented .NET 10 Blazor component-route constraint plus typed optional presence and absence; issue #83, authorization-policy and authenticated-user parity for normal and direct GETs; issue #85, one stock named `EditForm` POST with form binding, antiforgery ordering, request-component callback dispatch, and direct component output; issue #87, one shared runtime path for component-owned PUT, PATCH, and DELETE actions represented by fixed future-generator output; issue #89, composition of that assumed generated action output with an application-authored asynchronous parameter lifecycle override; issue #91, one assumed-generated constrained HTMX-only GET route for a component without `@page`, using stock Blazor invocation and static SSR; issue #93, build-time discovery and emission for that one constrained HTMX-only GET route without checked-in generated output; issue #95, analyzer packaging and one application-level registration that connects the generated route to runtime in an external package-only consumer; issue #97, deterministic aggregation of two supported package-consumer declarations through that single registration call; issue #100, one package-generated stock-page PUT callback bound to the compiled component endpoint while two explicit HTMX-only controls remain GET-only.
-- Current implementation slice: issue #100. The live v1 milestone contains issue #100 and parent issue #77; no later implementation child is filed.
+- Current implementation slice: issue #103, shared unsafe-method inference for stock
+  `@page` and omitted-`Methods` HTMX-only routes. The live v1 milestone contains
+  issue #103 and parent issue #77.
 
 ## Proven v1 behavior
 
@@ -542,6 +549,26 @@ remain separate and green.
 - The issue #85, #87, and #89 hosts run on Windows TestServer with the stock ephemeral Data Protection provider. They do not exercise Kestrel, TLS, persistent key storage, server-farm key sharing, Linux, a browser, or an application-selected HTMX runtime.
 - Issues #91, #93, #95, #97, and #100 ran their hosted contract only on Windows TestServer. They did not exercise Kestrel, TLS, Linux runtime, a browser, or an application-selected HTMX runtime. Earlier broader full profiles exercised the existing Chromium tests on Windows, but did not prove fresh browser provisioning or the package-only routes and action in a browser.
 - The tests do not exercise layouts, caching, concurrency, enhanced navigation, interactive render modes, fragments, browser behavior, or performance.
+- The existing browser fixture still loads Htmxor's embedded htmx 1.9.12 asset.
+  `HtmxConfig` and `HtmxHeadOutlet` still describe and emit the legacy
+  `htmx-config` schema. The shipped `htmxor.js` adapter listens for
+  `htmx:configRequest` and reads the old event-detail shape, while htmx 4 uses
+  `htmx:config:request` and `detail.ctx`. The legacy event-header extension uses
+  the old callback API, and `HtmxResponseHeaderNames` still exposes
+  `HX-Trigger-After-Swap` and `HX-Trigger-After-Settle`, which htmx 4 consolidates
+  into `HX-Trigger`. This is legacy coverage and does not prove the htmx 4.0.0
+  target.
+- No executed evidence yet covers htmx 4 explicit inheritance,
+  `HX-Request-Type`, `HX-Source`, the changed `HX-Target` format,
+  error-response swapping, DELETE form-data behavior,
+  main-content-before-out-of-band ordering, standardized events and request
+  context, extension registration, or `hx-action` and `hx-method`. New optional
+  client features are not automatically v1 requirements. For the agreed raw
+  `<hx-partial>` composition, target and `id` behavior, partial-only responses,
+  main-before-partial ordering, mixed main/OOB/partial content, swap selection,
+  and browser execution remain unproved. htmx 4's `QUERY` method is not part of
+  the established v1 component-directive method model and requires a separate
+  product decision.
 - The legacy test application still uses internal private-reflection discovery and global service replacements. Later slices must replace the behavior they cover instead of extending that prototype.
 - Issue #91 proves one assumed-generated HTMX-only GET route with an `int`
   constraint, one authorization policy, and one application route-group metadata
@@ -615,23 +642,19 @@ remain separate and green.
   case comes from a second `[Route]` on the `.razor.cs` partial; Htmxor does not
   choose between those routes or discover an action in code-behind.
 
-## Recommended next slice
+## Current implementation slice
 
-Under parent issue #77, select one package-only tracer for method inference on
-a genuinely HTMX-only route before adding another verb or binding source:
+Issue #103 owns the shared method-inference path:
 
 > When a package-only .NET 10 Blazor static SSR application declares an
-> `HtmxRoute` without a `Methods` argument and one supported `@onput` callback,
-> Htmxor derives the server method allow-list from the component declaration.
-> An explicit `Methods` argument remains authoritative, and a conflicting
-> component directive fails with a deterministic diagnostic. Client `hx-*`
-> attributes never add a server method.
+> `@page` route or an HTMX-only `HtmxRoute` without `Methods`, Htmxor keeps GET
+> implicit and derives POST, PUT, PATCH, and DELETE server intent from supported
+> `@onpost`, `@onput`, `@onpatch`, and `@ondelete` declarations. Explicit
+> `Methods` remains authoritative, conflicts fail with a deterministic
+> diagnostic, and client `hx-*` declarations never add a server method.
 
-This comes next because issue #100 corrects the ordinary `@page` convention but
-deliberately leaves the current explicit GET-only `HtmxRoute` contract intact.
-The next evidence should retain the packaged stock-page matrix and both explicit
-GET controls, add one omitted-`Methods` HTMX-only PUT tracer, and prove an
-explicit mismatch fails without widening the endpoint. Recheck the live
-tracker, competing ownership, branch publication state, and `origin/main`
-before refining or filing that slice; stop for the user if the result requires
-changing the v1 goal, supported framework, or security posture.
+This server-side slice does not prove htmx 4 browser compatibility. Before its
+final evidence or progress update, recheck the live tracker, competing
+ownership, branch publication state, and `origin/main`. Stop for the user if
+the result requires changing the v1 goal, supported framework, or security
+posture.


### PR DESCRIPTION
## Summary

- Make application-supplied htmx 4.0.0, running with htmx 4 defaults, the primary v1 target for documentation, examples, browser conformance, and release evidence.
- Preserve application ownership of the browser runtime: Htmxor does not bundle or silently select htmx, and it claims other-version compatibility only after execution.
- Keep client `hx-*` declarations separate from server authority. The established server model remains implicit GET plus component-declared POST, PUT, PATCH, and DELETE; htmx 4 `QUERY` needs a later product decision.
- Clarify that `HtmxFragment` selects server-rendered work while application-authored `<hx-partial>` is an optional htmx 4 delivery envelope. A future typed helper would be an explicit markup adapter, not a second fragment-selection concept.
- Record the active #103 server/compiler slice and the exact legacy runtime, configuration, event, header, and browser gaps that still prevent an htmx 4 compatibility claim.

## Why

[htmx 4.0.0 is now released](https://four.htmx.org/announcements/2026-08-28-htmx-4.0.0-is-released). The previous v1 wording was intentionally runtime-independent but did not identify a concrete browser conformance target. A stable release needs one executable default contract while still allowing applications to own and upgrade their htmx runtime.

This change records the product target only. It does not port the embedded 1.9.12 fixture, the legacy `HtmxConfig`/`HtmxHeadOutlet` surface, adapters, headers, samples, or browser tests. Those remain later verified slices.

## Verification

Exact clean head: `39a50c6a71ebacca924838cebc8ff82f87b734c6`

```powershell
dotnet run --project eng/Htmxor.Quality/Htmxor.Quality.csproj -- check --profile fast
```

- Release build: 0 warnings, 0 errors.
- Quality tests: 105/105.
- ASP.NET Core 10 tests: 40/40.
- Non-browser Htmxor tests: 196/196.
- Total: 341/341, with no failures, skips, errors, or timeouts.
- Independent Standards review: pass, 0 findings.
- Independent Spec review: pass, 0 findings.

The full/browser profile was not run because its current fixture embeds htmx 1.9.12 and cannot prove this target. Application-supplied htmx 4 browser behavior, Linux, Kestrel/TLS, package publication, performance, and mutation testing were not exercised. Mutation is not applicable to this documentation-only contract correction.

## Tracker

Parent #77 and active slice #103 were updated to match this contract. This PR does not close either issue and does not broaden #103 into browser migration.
