### PR TITLE
test(browser): prove htmx 4 main-before-OOB order

### DIFF
--- a/docs/roadmap/v1/progress.md
+++ b/docs/roadmap/v1/progress.md
@@ -113,14 +113,18 @@ Last updated: 2026-08-31
 - Preserved meaningful package/browser red for issue #131: `58c111e0a6190191ab6d3178575536ab5da76e8e`, based on exact freshly fetched `origin/main` commit `5707b09cf8b7459ca1a753d2f7fe183017e2e8ca`.
 - Verified executable proof commit for issue #131: `a0f60d90faa004038c9320bd04afdd7a392cdb96`.
 - This issue #131 progress change is documentation-only. Executable claims are tied to the tested commits above, not to the later documentation head.
-- Framework boundary under test: ASP.NET Core 10.0.11 and Blazor static SSR. Issues #95, #97, #100, #103, #106, and #125 use a separate external .NET 10 Razor consumer on TestServer that restores a locally packed `net8.0` Htmxor package instead of referencing an Htmxor project. Issues #108, #56, #111, #50, #18, #72, #75, #116, #118, #120, #122, #64, #127, #129, and #131 use a separate package-only .NET 10 application on real Kestrel; its browser cases use Chromium, while issues #18, #50, and #127 also use `HttpClient` for server-response assertions. Issues #72, #75, #116, #118, #120, #122, #64, #127, #129, and #131 publish that external application before running its tests from the publish output in Production.
+- Preserved meaningful package/browser red for issue #133: `388c95baa70964bacf743037bb45c3b5a99f2df3`, based on exact freshly fetched `origin/main` commit `1ec62d203842d96ebb03be6972a8a5be96de49fb`.
+- Verified executable proof commit for issue #133: `cab80352e00af4e67592770e302c172743ce6aa9`.
+- Verified post-review response-shape and request-instance proof commit for issue #133: `f501f3f3f837523902e9c0e401fbbfb4f9b13f1e`.
+- This issue #133 progress change is documentation-only. Executable claims are tied to the tested commits above, not to the later documentation head.
+- Framework boundary under test: ASP.NET Core 10.0.11 and Blazor static SSR. Issues #95, #97, #100, #103, #106, and #125 use a separate external .NET 10 Razor consumer on TestServer that restores a locally packed `net8.0` Htmxor package instead of referencing an Htmxor project. Issues #108, #56, #111, #50, #18, #72, #75, #116, #118, #120, #122, #64, #127, #129, #131, and #133 use a separate package-only .NET 10 application on real Kestrel; its browser cases use Chromium, while issues #18, #50, and #127 also use `HttpClient` for server-response assertions. Issues #72, #75, #116, #118, #120, #122, #64, #127, #129, #131, and #133 publish that external application before running its tests from the publish output in Production.
 - Product target correction authorized on 2026-08-28: v1 documentation,
   examples, browser conformance, and release evidence target an
   application-supplied htmx 4.0.0 script running with htmx 4 defaults. Htmxor
   does not embed or silently select that runtime. Issue #108 is the first narrow
   executed htmx 4 browser slice; the remaining conformance matrix is unproved.
-- V1 slices proved on this tree: issue #78, stock `@page` routing with a direct HTMX GET; issue #81, every documented .NET 10 Blazor component-route constraint plus typed optional presence and absence; issue #83, authorization-policy and authenticated-user parity for normal and direct GETs; issue #85, one stock named `EditForm` POST with form binding, antiforgery ordering, request-component callback dispatch, and direct component output; issue #87, one shared runtime path for component-owned PUT, PATCH, and DELETE actions represented by fixed future-generator output; issue #89, composition of that assumed generated action output with an application-authored asynchronous parameter lifecycle override; issue #91, one assumed-generated constrained HTMX-only GET route for a component without `@page`, using stock Blazor invocation and static SSR; issue #93, build-time discovery and emission for that one constrained HTMX-only GET route without checked-in generated output; issue #95, analyzer packaging and one application-level registration that connects the generated route to runtime in an external package-only consumer; issue #97, deterministic aggregation of two supported package-consumer declarations through that single registration call; issue #100, one package-generated stock-page PUT callback bound to the compiled component endpoint while two explicit HTMX-only controls remain GET-only; issue #103, shared POST, PUT, PATCH, and DELETE inference for stock `@page` and omitted-`Methods` HTMX-only routes with explicit-method conflicts rejected before mapping; issue #106, explicit authoritative C# method discovery for matching `.razor.cs` partials and all-C# components, deterministic rejection and registration suppression when a C# declaration omits `Methods`, and no method widening from manual render-tree code; issue #108, removal of Htmxor-owned htmx distribution and one package-only application-owned htmx 4.0.0 stock-page and component-GET browser path; issue #56, stock antiforgery and generated POST, PUT, PATCH, and DELETE callback dispatch through the htmx 4 request context in a package-only browser consumer; issue #111, generated safe QUERY callback dispatch for stock and HTMX-only route owners through the real htmx 4 package/browser boundary; issue #50, standard OutputCache variation for one stock full/direct GET pair in a package-only Kestrel consumer; issue #18, dynamic application response headers through the stock request-owned `HttpContext` on normal and direct GET paths; issues #72 and #75, published Production startup plus stock fingerprinted application-asset and packaged-adapter compatibility; issue #116, one htmx 4 `HX-Trigger` response-event surface with post-swap Chromium dispatch and configured JSON details; issue #118, typed htmx 4 full/partial request context, complete source/target identities, stock/direct representation selection, and forged-header fail-closed controls; issue #120, distinct native POST and htmx 4 PUT form destinations with stock full-page fallback, direct partial swapping, and server-owned route, method, authorization, and antiforgery decisions; issue #122, one pure multi-target htmx 4 partial response composed from server-selected `HtmxFragment` instances; issue #64, stock local `NavigationManager.NavigateTo` redirect parity for ordinary GETs and successful `HX-Redirect` full-page navigation for direct htmx GETs; issue #125, static ID-selector `hx-target` order independence for all five generated action methods under stock and omitted-`Methods` route owners; issue #127, `Int32` route-value delivery for one omitted-Methods generated HTMX-only route on direct GET and its declared PUT action; issue #129, application-selected component error status/body plus native htmx 4 default and source-owned no-swap policies through the published package/browser boundary; issue #131, native htmx 4 DELETE form-value placement without stock antiforgery-token transport through the published package/browser boundary.
-- Current implementation slice: issue #131, antiforgery-safe native htmx 4 DELETE form inclusion for one generated stock-page action through the locally packed Production Kestrel/Chromium boundary.
+- V1 slices proved on this tree: issue #78, stock `@page` routing with a direct HTMX GET; issue #81, every documented .NET 10 Blazor component-route constraint plus typed optional presence and absence; issue #83, authorization-policy and authenticated-user parity for normal and direct GETs; issue #85, one stock named `EditForm` POST with form binding, antiforgery ordering, request-component callback dispatch, and direct component output; issue #87, one shared runtime path for component-owned PUT, PATCH, and DELETE actions represented by fixed future-generator output; issue #89, composition of that assumed generated action output with an application-authored asynchronous parameter lifecycle override; issue #91, one assumed-generated constrained HTMX-only GET route for a component without `@page`, using stock Blazor invocation and static SSR; issue #93, build-time discovery and emission for that one constrained HTMX-only GET route without checked-in generated output; issue #95, analyzer packaging and one application-level registration that connects the generated route to runtime in an external package-only consumer; issue #97, deterministic aggregation of two supported package-consumer declarations through that single registration call; issue #100, one package-generated stock-page PUT callback bound to the compiled component endpoint while two explicit HTMX-only controls remain GET-only; issue #103, shared POST, PUT, PATCH, and DELETE inference for stock `@page` and omitted-`Methods` HTMX-only routes with explicit-method conflicts rejected before mapping; issue #106, explicit authoritative C# method discovery for matching `.razor.cs` partials and all-C# components, deterministic rejection and registration suppression when a C# declaration omits `Methods`, and no method widening from manual render-tree code; issue #108, removal of Htmxor-owned htmx distribution and one package-only application-owned htmx 4.0.0 stock-page and component-GET browser path; issue #56, stock antiforgery and generated POST, PUT, PATCH, and DELETE callback dispatch through the htmx 4 request context in a package-only browser consumer; issue #111, generated safe QUERY callback dispatch for stock and HTMX-only route owners through the real htmx 4 package/browser boundary; issue #50, standard OutputCache variation for one stock full/direct GET pair in a package-only Kestrel consumer; issue #18, dynamic application response headers through the stock request-owned `HttpContext` on normal and direct GET paths; issues #72 and #75, published Production startup plus stock fingerprinted application-asset and packaged-adapter compatibility; issue #116, one htmx 4 `HX-Trigger` response-event surface with post-swap Chromium dispatch and configured JSON details; issue #118, typed htmx 4 full/partial request context, complete source/target identities, stock/direct representation selection, and forged-header fail-closed controls; issue #120, distinct native POST and htmx 4 PUT form destinations with stock full-page fallback, direct partial swapping, and server-owned route, method, authorization, and antiforgery decisions; issue #122, one pure multi-target htmx 4 partial response composed from server-selected `HtmxFragment` instances; issue #64, stock local `NavigationManager.NavigateTo` redirect parity for ordinary GETs and successful `HX-Redirect` full-page navigation for direct htmx GETs; issue #125, static ID-selector `hx-target` order independence for all five generated action methods under stock and omitted-`Methods` route owners; issue #127, `Int32` route-value delivery for one omitted-Methods generated HTMX-only route on direct GET and its declared PUT action; issue #129, application-selected component error status/body plus native htmx 4 default and source-owned no-swap policies through the published package/browser boundary; issue #131, native htmx 4 DELETE form-value placement without stock antiforgery-token transport through the published package/browser boundary; issue #133, raw application-authored OOB response composition with native htmx 4 main-before-OOB DOM and event order through the published package/browser boundary.
+- Current implementation slice: issue #133, mixed ordinary main-target plus one application-authored OOB response through the locally packed Production Kestrel/Chromium boundary.
 
 ## Proven v1 behavior
 
@@ -951,6 +955,41 @@ only `__RequestVerificationToken`. It does not rewrite routes, parse or scrub
 general query values, accept query antiforgery evidence, change another method,
 or alter server authorization, antiforgery metadata, middleware, or validation.
 
+Protected behavior for issue #133:
+
+> When a package-consuming .NET 10 Blazor static-SSR application invokes one
+> generated unsafe component action, one response may contain ordinary
+> main-target HTML plus one application-authored `hx-swap-oob` sibling. Exact
+> application-owned htmx 4.0.0 extracts the OOB element, swaps the remaining
+> main content first, then swaps the OOB target afterward. Response markup does
+> not add or widen route, method, authorization, or antiforgery authority.
+
+The separate package-only application publishes in Production, starts Kestrel,
+and runs exact application-owned htmx 4.0.0 in Chromium. One authorized stock
+`@page` owns one generated `@onput` action. A stock full-page GET renders the
+shell, one ordinary main target, one distinct OOB target, and no response-only
+`hx-swap-oob` declaration. Anonymous PUT receives `401`, and an authenticated
+PUT with an invalid stock token receives `400`; neither reaches the callback.
+
+The authorized antiforgery-valid PUT initializes one request component and
+invokes its sole declared callback once. Its shell-free static-SSR response
+contains deterministic ordinary main content followed by one raw
+application-authored sibling with `hx-swap-oob="true"` and the existing OOB
+target ID. Browser response inspection retains both pieces. Native htmx 4
+removes the OOB response element from the main payload, mutates the main target
+first, and replaces the OOB target second. Independent `htmx:before:settle`
+events and body-subtree mutation records observe the same main-then-OOB order;
+the final targets contain their exact new content and the OOB target is absent
+from inside the main target.
+
+No Htmxor production-library change was required. The slice adds no typed OOB
+component, service, public API, renderer path, source-generator feature, or
+fragment-selection concept. It adds no Htmxor production route, method, or
+endpoint convention, and the response markup adds or widens no route, method,
+authorization, or antiforgery authority. `HtmxFragment` remains the single
+server-side fragment-selection concept; raw `hx-swap-oob` markup remains
+application-owned client delivery policy.
+
 ## Executable evidence
 
 - Meaningful red at `66139317b9edae1fff2ff73fa5175381ee3487b1`: the new .NET 10 hosted test discovered and executed one test, then failed during real application startup with the expected `NullReferenceException` in the obsolete private-reflection component discovery path.
@@ -1265,19 +1304,27 @@ or alter server authorization, antiforgery metadata, middleware, or validation.
 - Full-profile proof at the same exact clean executable commit passed 118 quality tests, 45 ASP.NET Core 10 hosted tests, and all 284 library, generator, analyzer, runtime, and browser tests. Total: 447 discovered, 447 executed, 447 passed, 0 failed, 0 skipped, 0 errors, and 0 timeouts. The authoritative Release build produced 0 warnings and 0 errors and retained fresh canonical coverage at `artifacts/results/full/htmxor/ed5d5880-49b5-41e7-ac68-2622be2bb1b6/coverage.cobertura.xml`.
 - Issue #131's exact-head proof used .NET SDK 10.0.400, ASP.NET Core 10.0.11, Microsoft.Playwright 1.62.0, cached Chromium revision 1234 / 151.0.7922.34, Ubuntu 26.04.1 under WSL2, exact application-owned htmx 4.0.0, a locally packed unsigned Htmxor package, a published framework-dependent `net10.0` application, Production, and Kestrel loopback HTTP. It did not exercise TLS, Windows, macOS, Firefox, WebKit, a NuGet-published or signed package, self-contained or trimmed publish, another target framework or htmx version, inherited inclusion, another selector shape, files, multipart or JSON data, large or streaming payloads, custom antiforgery, proxies, containers, external services, or performance. Full-scope mutation was optional for this POC and was not run.
 - Separate Standards and Spec reviews inspected base `5707b09cf8b7459ca1a753d2f7fe183017e2e8ca` through executable `a0f60d90faa004038c9320bd04afdd7a392cdb96` plus docs head `9bccb0e78f1dc220b3e70517d0569fa756ffccff`. Both found the P2 exclusivity wording fixed by `c33ddd40527bcea3e79d4f202f62d46ac094203d`; Standards also found the P2 shell-free wording now removed. Independent Standards and Spec rereviews both inspected corrected head `1f9fc413c2d9f2a1d3cc6a08b64331f7b36d1580` and returned 0 findings; both prior exclusivity wording findings are resolved; Standards' shell-free wording finding is resolved. Neither reviewer reran heavy profiles.
+- Issue #133 started from clean exact freshly fetched `origin/main` `1ec62d203842d96ebb03be6972a8a5be96de49fb` on branch `egil/issue-133-oob-order`. Live issue #133 and parent #77 were open with no assignee or comments, no open pull request owned the slice, and no competing local or remote issue #133 branch existed.
+- Meaningful package/browser red is preserved at clean test-only commit `388c95baa70964bacf743037bb45c3b5a99f2df3`: `dotnet test test/Htmxor.Quality.Tests/Htmxor.Quality.Tests.csproj --configuration Release --no-restore --filter "FullyQualifiedName~Htmx4PackageBrowserTests.Package_only_net10_production_publish_preserves_assets_and_component_actions" --blame-hang --blame-hang-timeout 5min --logger "trx;LogFileName=issue-133-red.trx" --results-directory artifacts/results/issue-133-red --verbosity minimal` packed unchanged Htmxor production code, restored and published the separate Production `net10.0` application, started Kestrel, and executed 18 of 18 inner tests. Seventeen passed and the issue #133 Chromium case failed because its response contained the expected ordinary main content but no `hx-swap-oob` sibling. The case had already exercised the `401` and `400` controls with no callback effects. Initial missing-assets, sandboxed-socket, compilation-ambiguity, and authentication-fixture attempts were setup failures and are not red evidence.
+- Initial focused package/browser proof at exact clean executable commit `cab80352e00af4e67592770e302c172743ce6aa9` used the same command with `issue-133-green.trx` and passed 1 of 1 outer tests while asserting 18 of 18 published consumer tests. It proved stock shell GET, exact application-owned htmx 4.0.0, anonymous `401`, authenticated invalid-token `400`, authorized antiforgery-valid generated PUT, one callback with a matching initialization, expected main/OOB response markers, OOB extraction from the main target, exact final target content, and identical main-before-OOB order in `htmx:before:settle` events and mutation records without timing sleeps.
+- Post-review focused proof at exact clean executable commit `f501f3f3f837523902e9c0e401fbbfb4f9b13f1e` used the same command with `issue-133-post-review-green.trx` and again passed 1 of 1 outer tests while asserting 18 of 18 published consumer tests. It additionally parses the response into exactly three top-level elements, proves the ordinary result precedes and is a sibling of the single OOB element, and proves the valid PUT adds exactly one initialization followed by exactly one callback on the same request component.
+- Fast-profile proof at the same exact clean post-review executable commit passed 117 quality tests, 45 ASP.NET Core 10 hosted tests, and 282 non-browser library, generator, analyzer, and runtime tests. Total: 444 discovered, 444 executed, 444 passed, 0 failed, 0 skipped, 0 errors, and 0 timeouts. The authoritative Release build produced 0 warnings and 0 errors.
+- Full-profile proof at the same exact clean post-review executable commit passed 118 quality tests, 45 ASP.NET Core 10 hosted tests, and all 284 library, generator, analyzer, runtime, and browser tests. Total: 447 discovered, 447 executed, 447 passed, 0 failed, 0 skipped, 0 errors, and 0 timeouts. The authoritative Release build produced 0 warnings and 0 errors and retained fresh canonical coverage at `artifacts/results/full/htmxor/79a2b98e-eadf-4c30-827d-dcf8c596931f/coverage.cobertura.xml`.
+- Issue #133's exact-head proof used .NET SDK 10.0.400, ASP.NET Core 10.0.11, Microsoft.Playwright 1.62.0, cached Chromium revision 1234 / 151.0.7922.34, Ubuntu 26.04.1 under WSL2, exact application-owned htmx 4.0.0, a locally packed unsigned Htmxor package, a published framework-dependent `net10.0` application, Production, and Kestrel loopback HTTP. It did not exercise TLS, Windows, macOS, Firefox, WebKit, a NuGet-published or signed package, self-contained or trimmed publish, another target framework or htmx version, pure OOB, empty main-swap configuration, nested or multiple OOB elements, missing or repeated targets, alternate OOB selectors or swap styles, `hx-select-oob`, OOB plus `<hx-partial>`, streaming, caching, history, extensions, interactive rendering, concurrency, proxies, containers, external services, or performance. Full-scope mutation was optional for this POC and was not run.
+- Separate independent Standards and Spec reviews inspected base `1ec62d203842d96ebb03be6972a8a5be96de49fb` through executable head `f501f3f3f837523902e9c0e401fbbfb4f9b13f1e` plus this progress draft. Standards found two P2 assertion gaps in response sibling/order and exact valid-request initialization evidence; Spec found two P2 documentation overclaims and later joined Standards in blocking publication until the strengthened assertions had clean exact-head provenance. The response parser, exact probe delta, narrowed wording, and clean focused, fast, and full reruns resolved every finding. Final Standards and Spec rereviews each passed with 0 findings and worst priority none. Both ran or inspected `git diff --check` and the retained exact-head artifacts; neither independently reran the focused browser command, fast, full, or mutation.
 
 ## Remaining limits
 
-- Issues #95, #97, #100, #103, #106, #108, #56, #111, #50, #18, #72, #75, #116, #118, #120, #122, #64, #127, #129, and #131 prove one locally packed package with the current SDK and dependency set. Issues #72, #75, #116, #118, #120, #122, #64, #127, #129, and #131 additionally prove a framework-dependent application publish, but none proves a NuGet-published or signed package, a release candidate, package compatibility across SDK or compiler versions, or a broader target-framework matrix.
+- Issues #95, #97, #100, #103, #106, #108, #56, #111, #50, #18, #72, #75, #116, #118, #120, #122, #64, #127, #129, #131, and #133 prove one locally packed package with the current SDK and dependency set. Issues #72, #75, #116, #118, #120, #122, #64, #127, #129, #131, and #133 additionally prove a framework-dependent application publish, but none proves a NuGet-published or signed package, a release candidate, package compatibility across SDK or compiler versions, or a broader target-framework matrix.
 - The matrix uses one representative valid and rejected value per documented constraint. It does not exhaust textual representations, undocumented custom conversion constraints, catch-all routes, or unconstrained routes.
 - The direct path is proved on ASP.NET Core 10 only. The supported framework matrix remains unproved.
-- The authorization proof uses one deterministic scheme and one claim policy. It covers the earlier GET path, issue #120's PUT path, and issue #131's DELETE path, but not scheme selection, custom challenge or forbid handlers, identity-provider integration, or other HTTP methods.
+- The authorization proof uses one deterministic scheme and one claim policy. It covers the earlier GET path, issue #120 and issue #133 PUT paths, and issue #131's DELETE path, but not scheme selection, custom challenge or forbid handlers, identity-provider integration, or other HTTP methods.
 - The issue #85 proof covers one stock named `EditForm`, one valid value, and one missing-token POST. It does not cover multiple forms, validation failures, invalid-token variants, file uploads, normal POST parity, or custom method discovery. Issue #87 proves unsafe route/query instance dispatch separately, without request-body or form binding.
 - Issue #103 replaces the verb-specific package proof with generated stock DELETE and HTMX-only PATCH paths. The issue #87 and #89 fixed stand-ins remain as earlier hosted regression fixtures, not as the only unsafe-method evidence.
 - Issue #89 covers an application-authored public `SetParametersAsync` override. An application that explicitly implements `IComponent.SetParametersAsync` would conflict with the generated explicit member and needs a future diagnostic or developer-model decision. Repeated parameter delivery, an override that intentionally omits its base call, async actions, request-body and form binding, multiple actions on one verb, multiple-route action mapping, multiple action-owning components, navigation, exception and cancellation behavior, `ShouldRender` overrides, and streaming SSR remain unexercised.
 - The issue #85, #87, and #89 hosts run on Windows TestServer with the stock ephemeral Data Protection provider. They do not exercise Kestrel, TLS, persistent key storage, server-farm key sharing, Linux, a browser, or an application-selected HTMX runtime.
 - Issues #91, #93, #95, #97, #100, and #103 ran their hosted contract only on Windows TestServer. They did not exercise Kestrel, TLS, Linux runtime, a browser, or an application-selected HTMX runtime. Issue #108 adds one package-only Kestrel and Chromium GET path on Windows and Linux, but it does not prove those earlier package-only routes and actions in a browser.
-- Beyond issue #108's GET, issue #56's unsafe-action matrix, issue #111's QUERY slice, issue #50's server OutputCache slice, issue #122's pure multi-target fragment response, issue #64's full-page redirect navigation, issue #129's application-owned error response, and issue #131's native DELETE placement, the htmx 4 browser tests do not exercise layouts, browser caching, concurrency, enhanced navigation, interactive render modes, broader fragment shapes, out-of-band content, history, extensions, or performance.
+- Beyond issue #108's GET, issue #56's unsafe-action matrix, issue #111's QUERY slice, issue #50's server OutputCache slice, issue #122's pure multi-target fragment response, issue #64's full-page redirect navigation, issue #129's application-owned error response, issue #131's native DELETE placement, and issue #133's single mixed main/OOB response, the htmx 4 browser tests do not exercise layouts, browser caching, concurrency, enhanced navigation, interactive render modes, broader fragment shapes, other OOB shapes, history, extensions, or performance.
 - Htmxor no longer packages or emits htmx 1.9.12, htmx type declarations, the
   event-header extension, or an Htmxor-owned `htmx-config` payload. No maintained
   sample or browser fixture retains the old 1.9.12 asset or configuration;
@@ -1285,13 +1332,13 @@ or alter server authorization, antiforgery metadata, middleware, or validation.
   The maintained samples and browser fixtures now own exact htmx 4.0.0 assets,
   and unsafe UI uses stock Blazor antiforgery inputs. Htmxor still owns only the
   narrow `htmxor.js` adapter.
-- Issues #108, #56, #111, #50, #116, #118, #120, #64, #129, and #131 cover application-owned htmx
+- Issues #108, #56, #111, #50, #116, #118, #120, #64, #129, #131, and #133 cover application-owned htmx
   4.0.0 GET, unsafe methods, QUERY, one server-cache variation, `HX-Trigger`
   response events, full/partial request type, and complete source/target element
   identities plus distinct `hx-action`/`hx-method` progressive form destinations
   using htmx 4 defaults. Other response headers, explicit inheritance, broader DELETE body behavior,
   broader status codes and error policies, standardized events and request context, broader fragment shapes,
-  out-of-band ordering, history, extensions, broader cache policy, repeatable CI browser
+  broader out-of-band behavior, history, extensions, broader cache policy, repeatable CI browser
   provisioning, package publication, and the supported framework matrix remain
   separate evidence. Issue #64 adds the narrow successful `HX-Redirect` full-page
   navigation shape. Issue #103 proves only at the compiler boundary that client
@@ -1324,6 +1371,15 @@ or alter server authorization, antiforgery metadata, middleware, or validation.
   antiforgery system, another method or htmx version, or general secret/query
   scrubbing. The adapter intentionally removes only the stock field name from
   htmx's pending DELETE values and does not accept antiforgery from the query.
+- Issue #133 proves one generated stock-page PUT action returning one ordinary
+  main result followed by one sibling `hx-swap-oob="true"` element for an
+  existing distinct ID target. It proves exact final content, response
+  extraction, and main-before-OOB event and mutation order. It does not prove a
+  pure-OOB response, empty-main configuration, nested or multiple OOB elements,
+  missing or repeated targets, alternate selectors or swap styles,
+  `hx-select-oob`, composition with `<hx-partial>`, another method or htmx
+  version, streaming, caching, history, extensions, interactive rendering,
+  concurrency, or performance.
 - Issue #111 proves one QUERY callback per route owner with one form-encoded
   value read through the public request API. It does not prove JSON or other
   content types, large or streaming bodies, cancellation, concurrent QUERY
@@ -1432,33 +1488,31 @@ or alter server authorization, antiforgery metadata, middleware, or validation.
 
 ## Current implementation slice
 
-Issue #131 establishes the current native DELETE request-content contract:
+Issue #133 establishes the current native mixed main/OOB response contract:
 
 > When a package-consuming .NET 10 Blazor static-SSR application invokes one
-> generated component DELETE action, Htmxor preserves native htmx 4.0.0
-> request-value behavior without exposing the stock antiforgery token. Default
-> `hx-delete` excludes enclosing form values. Explicit
-> `hx-include="closest form"` carries the application value through native
-> DELETE query placement, while the stock token remains only in Htmxor's valid
-> antiforgery header. Authorization and antiforgery reject before callback.
+> generated unsafe component action, Htmxor preserves an application-authored
+> response containing ordinary main-target content followed by one sibling
+> `hx-swap-oob="true"` element. Exact application-owned htmx 4.0.0 extracts the
+> OOB element, swaps the remaining main content first, then swaps the OOB target
+> afterward without changing server route, method, authorization, antiforgery,
+> or fragment-selection authority.
 
-The published Production package consumer proves the two application-authored
-source shapes, exact browser URL/body/header behavior, relative route and
-existing query preservation, authorization and antiforgery ordering, distinct
-request-component lifecycle and callback identity, and deterministic swaps
-through Kestrel and Chromium. The narrow adapter correction removes only the
-stock antiforgery field from htmx's pending DELETE values after retaining its
-header; all other values and methods keep their established behavior.
+The published Production package consumer proves the intact stock page GET,
+anonymous and invalid-token rejection before callback, one valid generated PUT,
+one request component, one callback, a shell-free response containing the
+expected main and OOB content, OOB extraction from the main payload, exact final
+targets, and matching
+main-before-OOB event and mutation order through Kestrel and Chromium. The
+response uses raw application markup; no Htmxor production or public API change
+was required.
 
-The recommended next slice is native htmx 4 mixed main-target plus
-application-authored out-of-band response composition for one component-owned
-response. It should use the same package, Production Kestrel, and Chromium
-boundary with one generated action, one main target, one application-authored
-out-of-band target, and deterministic final DOM/event observations that prove
-htmx extracts and removes the out-of-band content from the response, applies the
-remaining main-target DOM swap first, then applies the application-authored
-out-of-band DOM swap afterward in response document order, without changing
-server fragment selection or route, method, authorization, and antiforgery
-ownership. Streaming, caching expansion, broader fragment shapes, lifecycle and
+The recommended next slice is native htmx 4 mixed ordinary main-target plus one
+application-authored `<hx-partial>` response through the same package,
+Production Kestrel, and Chromium boundary. It should prove deterministic
+main-before-partial DOM and event order, exact final targets, and removal of the
+partial delivery envelope from ordinary main content without mixing OOB and
+partial delivery or adding a second server-side fragment-selection concept.
+Streaming, caching expansion, broader fragment shapes, lifecycle and
 excluded-work performance, broader typed constraints, and positive
 omitted-`Methods` inference remain separate slices.

--- a/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue111AuthenticationHandler.cs.template
+++ b/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue111AuthenticationHandler.cs.template
@@ -18,7 +18,8 @@ public sealed class Issue111AuthenticationHandler(
 	{
 		if ((!Request.Path.StartsWithSegments("/issue-111") &&
 			!Request.Path.StartsWithSegments("/issue-120") &&
-			!Request.Path.StartsWithSegments("/issue-131")) ||
+			!Request.Path.StartsWithSegments("/issue-131") &&
+			!Request.Path.StartsWithSegments("/issue-133")) ||
 			!Request.Headers.ContainsKey(UserHeaderName))
 		{
 			return Task.FromResult(AuthenticateResult.NoResult());

--- a/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue133OobOrderPage.razor.template
+++ b/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue133OobOrderPage.razor.template
@@ -24,6 +24,7 @@
 else
 {
 	<section data-issue-133-main="main-updated">Main updated</section>
+	<aside id="issue-133-oob-target" hx-swap-oob="true" data-state="oob-updated">OOB updated</aside>
 }
 
 @code {

--- a/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue133OobOrderPage.razor.template
+++ b/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue133OobOrderPage.razor.template
@@ -1,0 +1,40 @@
+@page "/issue-133/oob-order"
+@using Htmxor
+@using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.Components.Forms
+@attribute [Authorize("issue-133")]
+@inject Issue133RequestProbe Probe
+
+<section @onput="Put"></section>
+
+@if (!updated)
+{
+	<form @formname="issue-133-oob-order">
+		<AntiforgeryToken />
+		<button id="issue-133-update"
+			type="button"
+			hx-put="/issue-133/oob-order"
+			hx-target="#issue-133-main-target">Update main and OOB targets</button>
+	</form>
+	<main data-issue-133-page>
+		<div id="issue-133-main-target" data-state="main-original">Main original</div>
+		<aside id="issue-133-oob-target" data-state="oob-original">OOB original</aside>
+	</main>
+}
+else
+{
+	<section data-issue-133-main="main-updated">Main updated</section>
+}
+
+@code {
+	private readonly string requestId = Guid.NewGuid().ToString("N");
+	private bool updated;
+
+	protected override void OnInitialized() => Probe.RecordInitialization(requestId);
+
+	private void Put()
+	{
+		updated = true;
+		Probe.RecordCallback(requestId);
+	}
+}

--- a/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue133RequestProbe.cs.template
+++ b/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue133RequestProbe.cs.template
@@ -1,0 +1,18 @@
+using System.Collections.Concurrent;
+
+namespace Htmxor.Htmx4Browser;
+
+public sealed class Issue133RequestProbe
+{
+	private readonly ConcurrentQueue<Issue133Observation> observations = new();
+
+	public void RecordInitialization(string requestId) =>
+		observations.Enqueue(new("initialized", requestId));
+
+	public void RecordCallback(string requestId) =>
+		observations.Enqueue(new("callback", requestId));
+
+	public IReadOnlyList<Issue133Observation> Snapshot() => observations.ToArray();
+}
+
+public sealed record Issue133Observation(string Phase, string RequestId);

--- a/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue56BrowserTests.cs.template
+++ b/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue56BrowserTests.cs.template
@@ -694,6 +694,7 @@ public sealed class Issue56BrowserTests
 			}
 			""");
 
+		var beforeSuccessfulRequest = probe.Snapshot();
 		var responseTask = WaitForIssue133PutAsync(page);
 		await page.Locator("#issue-133-update").ClickAsync();
 		var response = await responseTask;
@@ -711,6 +712,28 @@ public sealed class Issue56BrowserTests
 			"id=\"issue-133-oob-target\" hx-swap-oob=\"true\" data-state=\"oob-updated\"",
 			responseBody,
 			StringComparison.Ordinal);
+		var responseChildren = await page.EvaluateAsync<JsonElement>(
+			"""
+			body => {
+				const template = document.createElement('template');
+				template.innerHTML = body;
+				return Array.from(template.content.children).map(element => ({
+					tagName: element.localName,
+					mainState: element.getAttribute('data-issue-133-main'),
+					id: element.id,
+					oob: element.getAttribute('hx-swap-oob'),
+					oobState: element.getAttribute('data-state')
+				}));
+			}
+			""",
+			responseBody);
+		var responseElements = responseChildren.EnumerateArray().ToArray();
+		Assert.Equal(3, responseElements.Length);
+		Assert.Equal("section", responseElements[0].GetProperty("tagName").GetString());
+		Assert.Equal("main-updated", responseElements[1].GetProperty("mainState").GetString());
+		Assert.Equal("issue-133-oob-target", responseElements[2].GetProperty("id").GetString());
+		Assert.Equal("true", responseElements[2].GetProperty("oob").GetString());
+		Assert.Equal("oob-updated", responseElements[2].GetProperty("oobState").GetString());
 
 		await page.WaitForFunctionAsync(
 			"() => window.issue133SwapEvents.length === 2 && window.issue133Mutations.length === 2");
@@ -731,12 +754,15 @@ public sealed class Issue56BrowserTests
 			0,
 			await page.Locator("#issue-133-main-target #issue-133-oob-target").CountAsync());
 
-		var observations = probe.Snapshot();
-		var callback = Assert.Single(observations, observation => observation.Phase == "callback");
-		Assert.Contains(
-			observations,
-			observation => observation.Phase == "initialized" &&
-				observation.RequestId == callback.RequestId);
+		var successfulRequest = probe.Snapshot().Skip(beforeSuccessfulRequest.Count).ToArray();
+		Assert.Collection(
+			successfulRequest,
+			initialization => Assert.Equal("initialized", initialization.Phase),
+			callback =>
+			{
+				Assert.Equal("callback", callback.Phase);
+				Assert.Equal(successfulRequest[0].RequestId, callback.RequestId);
+			});
 	}
 
 	[Fact]

--- a/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue56BrowserTests.cs.template
+++ b/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue56BrowserTests.cs.template
@@ -30,6 +30,7 @@ public sealed class Issue56BrowserTests
 	private const string Issue122Path = "/issue-122/fragments";
 	private const string Issue129Path = "/issue-129/error";
 	private const string Issue131Path = "/issue-131/delete";
+	private const string Issue133Path = "/issue-133/oob-order";
 	private const string Issue64Path = "/issue-64";
 	private const string Issue64RedirectPath = "/issue-64/redirect";
 	private const string Issue64DestinationPath = "/issue-64/destination";
@@ -627,6 +628,118 @@ public sealed class Issue56BrowserTests
 	}
 
 	[Fact]
+	public async Task Mixed_main_and_oob_response_swaps_main_before_oob()
+	{
+		var probe = new Issue133RequestProbe();
+		await using var app = CreateApplication(new Issue56RequestProbe(), issue133Probe: probe);
+		await app.StartAsync();
+		var baseAddress = new Uri(Assert.Single(app.Urls));
+
+		using var playwright = await Playwright.CreateAsync();
+		await using var browser = await playwright.Chromium.LaunchAsync(new() { Headless = true });
+		await using var context = await browser.NewContextAsync(new() { BaseURL = baseAddress.AbsoluteUri });
+		var page = await context.NewPageAsync();
+		await page.SetExtraHTTPHeadersAsync(AuthenticatedIssue133Headers());
+		var navigation = await page.GotoAsync(Issue133Path);
+		Assert.NotNull(navigation);
+		Assert.Equal((int)HttpStatusCode.OK, navigation.Status);
+		var normalBody = await navigation.TextAsync();
+		Assert.Contains("<html", normalBody, StringComparison.OrdinalIgnoreCase);
+		Assert.Contains("data-stock-shell", normalBody, StringComparison.Ordinal);
+		Assert.Contains("data-issue-133-page", normalBody, StringComparison.Ordinal);
+		Assert.DoesNotContain("hx-swap-oob", normalBody, StringComparison.OrdinalIgnoreCase);
+		await page.WaitForFunctionAsync("() => window.htmx?.version === '4.0.0'");
+
+		var beforeUnauthorized = probe.Snapshot();
+		await page.SetExtraHTTPHeadersAsync(new Dictionary<string, string>());
+		var unauthorizedResponseTask = WaitForIssue133PutAsync(page);
+		await page.Locator("#issue-133-update").ClickAsync();
+		Assert.Equal((int)HttpStatusCode.Unauthorized, (await unauthorizedResponseTask).Status);
+		Assert.Equal(beforeUnauthorized, probe.Snapshot());
+
+		await page.SetExtraHTTPHeadersAsync(AuthenticatedIssue133Headers());
+		await page.ReloadAsync();
+		await page.WaitForFunctionAsync("() => window.htmx?.version === '4.0.0'");
+		var beforeInvalidToken = probe.Snapshot();
+		await page.Locator("input[name='__RequestVerificationToken']").EvaluateAsync(
+			"element => element.value = 'invalid-request-token'");
+		var invalidTokenResponseTask = WaitForIssue133PutAsync(page);
+		await page.Locator("#issue-133-update").ClickAsync();
+		Assert.Equal((int)HttpStatusCode.BadRequest, (await invalidTokenResponseTask).Status);
+		Assert.Equal(beforeInvalidToken, probe.Snapshot());
+
+		await page.ReloadAsync();
+		await page.WaitForFunctionAsync("() => window.htmx?.version === '4.0.0'");
+		await page.EvaluateAsync(
+			"""
+			() => {
+				window.issue133SwapEvents = [];
+				window.issue133Mutations = [];
+				document.body.addEventListener('htmx:before:settle', event => {
+					if (event.target.id === 'issue-133-main-target' ||
+						event.target.id === 'issue-133-oob-target') {
+						window.issue133SwapEvents.push(event.target.id);
+					}
+				});
+				new MutationObserver(records => {
+					for (const record of records) {
+						if (record.target.id === 'issue-133-main-target') {
+							window.issue133Mutations.push('issue-133-main-target');
+						} else if (Array.from(record.addedNodes).some(
+							node => node.id === 'issue-133-oob-target' && node.dataset.state === 'oob-updated')) {
+							window.issue133Mutations.push('issue-133-oob-target');
+						}
+					}
+				}).observe(document.body, { childList: true, subtree: true });
+			}
+			""");
+
+		var responseTask = WaitForIssue133PutAsync(page);
+		await page.Locator("#issue-133-update").ClickAsync();
+		var response = await responseTask;
+		Assert.Equal((int)HttpStatusCode.OK, response.Status);
+		var requestHeaders = await response.Request.AllHeadersAsync();
+		Assert.Equal("true", requestHeaders["hx-request"], StringComparer.OrdinalIgnoreCase);
+		Assert.Equal("partial", requestHeaders["hx-request-type"], StringComparer.OrdinalIgnoreCase);
+		Assert.Equal("button#issue-133-update", requestHeaders["hx-source"]);
+		Assert.True(requestHeaders.ContainsKey("requestverificationtoken"));
+		var responseBody = await response.TextAsync();
+		Assert.DoesNotContain("<html", responseBody, StringComparison.OrdinalIgnoreCase);
+		Assert.DoesNotContain("data-stock-shell", responseBody, StringComparison.Ordinal);
+		Assert.Contains("data-issue-133-main=\"main-updated\"", responseBody, StringComparison.Ordinal);
+		Assert.Contains(
+			"id=\"issue-133-oob-target\" hx-swap-oob=\"true\" data-state=\"oob-updated\"",
+			responseBody,
+			StringComparison.Ordinal);
+
+		await page.WaitForFunctionAsync(
+			"() => window.issue133SwapEvents.length === 2 && window.issue133Mutations.length === 2");
+		Assert.Equal(
+			new[] { "issue-133-main-target", "issue-133-oob-target" },
+			await page.EvaluateAsync<string[]>("() => window.issue133SwapEvents"));
+		Assert.Equal(
+			new[] { "issue-133-main-target", "issue-133-oob-target" },
+			await page.EvaluateAsync<string[]>("() => window.issue133Mutations"));
+		Assert.Equal(
+			"Main updated",
+			await page.Locator("#issue-133-main-target [data-issue-133-main='main-updated']")
+				.TextContentAsync());
+		Assert.Equal(
+			"OOB updated",
+			await page.Locator("#issue-133-oob-target[data-state='oob-updated']").TextContentAsync());
+		Assert.Equal(
+			0,
+			await page.Locator("#issue-133-main-target #issue-133-oob-target").CountAsync());
+
+		var observations = probe.Snapshot();
+		var callback = Assert.Single(observations, observation => observation.Phase == "callback");
+		Assert.Contains(
+			observations,
+			observation => observation.Phase == "initialized" &&
+				observation.RequestId == callback.RequestId);
+	}
+
+	[Fact]
 	public async Task Progressive_enhancement_preserves_native_post_and_htmx_put_paths()
 	{
 		var probe = new Issue120RequestProbe();
@@ -1048,6 +1161,7 @@ public sealed class Issue56BrowserTests
 		Issue120RequestProbe? issue120Probe = null,
 		Issue129RequestProbe? issue129Probe = null,
 		Issue131RequestProbe? issue131Probe = null,
+		Issue133RequestProbe? issue133Probe = null,
 		bool useHtmxor = true)
 	{
 		var builder = WebApplication.CreateBuilder(new WebApplicationOptions
@@ -1070,7 +1184,8 @@ public sealed class Issue56BrowserTests
 		builder.Services.AddAuthorizationBuilder()
 			.AddPolicy("issue-111", policy => policy.RequireAuthenticatedUser())
 			.AddPolicy("issue-120", policy => policy.RequireAuthenticatedUser())
-			.AddPolicy("issue-131", policy => policy.RequireAuthenticatedUser());
+			.AddPolicy("issue-131", policy => policy.RequireAuthenticatedUser())
+			.AddPolicy("issue-133", policy => policy.RequireAuthenticatedUser());
 		builder.Services.AddOutputCache();
 		builder.Services.AddSingleton(probe);
 		builder.Services.AddSingleton(issue111Probe ?? new Issue111RequestProbe());
@@ -1079,6 +1194,7 @@ public sealed class Issue56BrowserTests
 		builder.Services.AddSingleton(issue120Probe ?? new Issue120RequestProbe());
 		builder.Services.AddSingleton(issue129Probe ?? new Issue129RequestProbe());
 		builder.Services.AddSingleton(issue131Probe ?? new Issue131RequestProbe());
+		builder.Services.AddSingleton(issue133Probe ?? new Issue133RequestProbe());
 		builder.Services.AddScoped<Issue120RequestScope>();
 
 		var app = builder.Build();
@@ -1134,10 +1250,21 @@ public sealed class Issue56BrowserTests
 			new Uri(response.Url).AbsolutePath == Issue131Path &&
 			string.Equals(response.Request.Method, "DELETE", StringComparison.Ordinal));
 
+	private static Task<IResponse> WaitForIssue133PutAsync(IPage page) =>
+		page.WaitForResponseAsync(response =>
+			new Uri(response.Url).AbsolutePath == Issue133Path &&
+			string.Equals(response.Request.Method, "PUT", StringComparison.Ordinal));
+
 	private static Dictionary<string, string> AuthenticatedIssue131Headers() =>
 		new()
 		{
 			[Issue111AuthenticationHandler.UserHeaderName] = "issue-131-user",
+		};
+
+	private static Dictionary<string, string> AuthenticatedIssue133Headers() =>
+		new()
+		{
+			[Issue111AuthenticationHandler.UserHeaderName] = "issue-133-user",
 		};
 
 	private static Task WaitForIssue129RequestAsync(IPage page, int expectedCount) =>

--- a/test/Htmxor.Quality.Tests/Htmx4PackageBrowserTests.cs
+++ b/test/Htmxor.Quality.Tests/Htmx4PackageBrowserTests.cs
@@ -20,7 +20,7 @@ public sealed class Htmx4PackageBrowserTests
 			result.ExitCode == 0,
 			result.StandardOutput + Environment.NewLine + result.StandardError +
 			Environment.NewLine + $"TRX: {testRun}");
-		Assert.Equal(new TrxTestRun(17, 17, 17, 0, 0, 0, 0), testRun);
+		Assert.Equal(new TrxTestRun(18, 18, 18, 0, 0, 0, 0), testRun);
 		PackageConsumerEvidence.AssertPackage(workspace.PackagePath);
 		Htmx4PackageBrowserEvidence.AssertConsumer(workspace);
 	}


### PR DESCRIPTION
Closes #133.

## Why

Htmxor v1 targets application-owned htmx 4.0.0, whose OOB contract applies ordinary main content before out-of-band response elements. This PR leaves executable package-consumer evidence for that browser behavior without inventing an Htmxor OOB API or changing server authority.

## What changed

- Added one package-consuming .NET 10 Blazor static-SSR page with one generated PUT action, stock authorization, and stock antiforgery.
- Added one raw application-authored hx-swap-oob="true" sibling after deterministic ordinary main content.
- Proved in Production Kestrel and Chromium that htmx extracts the OOB element, applies main first and OOB second in both before-settle events and mutation records, leaves exact final content, and does not retain the OOB element inside the main target.
- Proved anonymous 401 and invalid-token 400 rejection before effects, exactly one valid-request initialization and callback, exact top-level response sibling order, application-owned htmx 4.0.0, and intact stock shell GET.
- Updated the v1 progress record with executed evidence, explicit exclusions, independent review outcomes, and the bounded next main-plus-partial slice.

No Htmxor production-library code, public API, route or method convention, endpoint shape, renderer path, generator feature, or second fragment-selection concept changed. HtmxFragment remains the single server-side fragment-selection concept.

## Provenance

- Base: 1ec62d203842d96ebb03be6972a8a5be96de49fb
- Meaningful red: 388c95baa70964bacf743037bb45c3b5a99f2df3
- Initial green: cab80352e00af4e67592770e302c172743ce6aa9
- Post-review executable green: f501f3f3f837523902e9c0e401fbbfb4f9b13f1e
- Final documentation head: 04bf6b709e4632b1684511e848026eda87e428b6

The red packed unchanged production code, published the external Production net10.0 consumer, started Kestrel, and executed 18 inner tests: 17 passed and the new Chromium case failed at the deliberately missing OOB response sibling.

## Verification

At clean post-review executable head f501f3f3f837523902e9c0e401fbbfb4f9b13f1e:

- Focused package/browser: 1 of 1 outer passed, asserting 18 of 18 published consumer tests.
- Fast profile: 444 discovered and executed; 444 passed; 0 failed, skipped, errors, or timeouts. Release build: 0 warnings, 0 errors.
- Full profile: 447 discovered and executed; 447 passed; 0 failed, skipped, errors, or timeouts. Release build: 0 warnings, 0 errors.
- Fresh canonical coverage: artifacts/results/full/htmxor/79a2b98e-eadf-4c30-827d-dcf8c596931f/coverage.cobertura.xml.
- Full-scope mutation was optional for this POC and was not run.

Environment: .NET SDK 10.0.400, ASP.NET Core 10.0.11, Microsoft.Playwright 1.62.0, cached Chromium revision 1234 / 151.0.7922.34, Ubuntu 26.04.1 under WSL2, exact application-owned htmx 4.0.0, locally packed unsigned Htmxor, framework-dependent net10.0 publish, Production, and Kestrel loopback HTTP.

Not exercised: TLS, Windows, macOS, Firefox, WebKit, published or signed NuGet, self-contained or trimmed publish, other target frameworks or htmx versions, excluded broader OOB shapes, OOB plus hx-partial, streaming, caching, history, extensions, interactive rendering, concurrency, proxies, containers, external services, performance, or mutation.

## Reviews

Independent Standards and Spec reviews inspected the complete base-to-post-review executable diff plus progress draft. Standards findings on response sibling/order and exact request-instance evidence were resolved by strengthened assertions. Spec wording and exact-head provenance findings were resolved. Final Standards and Spec rereviews each passed with 0 findings; neither reviewer independently reran the heavy commands.

Official behavior references:
- https://four.htmx.org/docs/whats-new-in-htmx-4#oob-swap-order
- https://four.htmx.org/reference/attributes/hx-swap-oob