### PR TITLE
feat(routing): carry the complete HtmxRoute contract through generated routes

### DIFF
--- a/docs/htmxor-v1-feature-guide.md
+++ b/docs/htmxor-v1-feature-guide.md
@@ -159,6 +159,28 @@ public sealed partial class ProductCard : ComponentBase
 An explicit `Methods` value is the complete allow-list. It does not add to an
 inferred list.
 
+An HTMX-only route may also declare representation filters. `CurrentUrl` is a
+relative or absolute HTTP(S) browser-location hint, `Target` is one exact
+element identity, and `Targets` is an ordered set of acceptable identities:
+
+```csharp
+[HtmxRoute(
+    "/products/{id:int}",
+    Methods = [HttpMethods.Get],
+    CurrentUrl = "/orders",
+    Target = "section#product",
+    Targets = ["section#product", "div#fallback"])]
+public sealed class ProductCard : ComponentBase
+{
+}
+```
+
+When a direct htmx request is evaluated, every declared filter must match. A
+missing or invalid `HX-Current-URL`, or a nonmatching `HX-Target`, leaves the
+route unselected. These values choose among component representations only;
+they never widen the route or method allow-list and never grant action,
+authentication, authorization, antiforgery, or other security authority.
+
 ## Declare component actions
 
 The v1 method model is small:

--- a/src/Htmxor.Generators/Htmxor.Generators.csproj
+++ b/src/Htmxor.Generators/Htmxor.Generators.csproj
@@ -19,6 +19,9 @@
 		<Compile
 			Include="..\Htmxor\Builder\HtmxorRouteTemplateContract.cs"
 			Link="Shared\HtmxorRouteTemplateContract.cs" />
+		<Compile
+			Include="..\Htmxor\Builder\HtmxRouteRepresentationContract.cs"
+			Link="Shared\HtmxRouteRepresentationContract.cs" />
 	</ItemGroup>
 
 </Project>

--- a/src/Htmxor.Generators/HtmxorRoutedComponent.cs
+++ b/src/Htmxor.Generators/HtmxorRoutedComponent.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
+using Htmxor;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -199,12 +200,17 @@ internal sealed class HtmxorRoutedComponent
 			"Methods" => HasSupportedExplicitMethods(argument.Value)
 				? null
 				: "explicit HtmxRoute Methods must resolve to a non-empty unique subset of GET, POST, PUT, PATCH, DELETE, and QUERY",
-			"CurrentUrl" or "Target" => HasSupportedOptionalString(argument.Value)
+			"CurrentUrl" => HasSupportedOptionalString(argument.Value) &&
+				HtmxRouteRepresentationContract.IsValidCurrentUrl(argument.Value.Value as string)
 				? null
-				: "HtmxRoute named argument '" + argument.Key + "' must resolve to a constant string or null",
-			"Targets" => HasSupportedTargets(argument.Value)
+				: "HtmxRoute named argument 'CurrentUrl' must resolve to a valid relative or absolute HTTP(S) URI or null",
+			"Target" => HasSupportedOptionalString(argument.Value) &&
+				HtmxRouteRepresentationContract.IsValidOptionalTarget(argument.Value.Value as string)
 				? null
-				: "HtmxRoute named argument 'Targets' must resolve to a constant string array",
+				: "HtmxRoute named argument 'Target' must resolve to a valid element identity or null or whitespace",
+			"Targets" => HasSupportedTargets(argument.Value) && HasSupportedTargetValues(argument.Value)
+				? null
+				: "HtmxRoute named argument 'Targets' must resolve to a constant array of valid element identities",
 			_ => "HtmxRoute named argument '" + argument.Key + "' is not supported",
 		};
 
@@ -374,6 +380,11 @@ internal sealed class HtmxorRoutedComponent
 		=> targets.IsNull ||
 			(targets.Kind == TypedConstantKind.Array &&
 				targets.Values.All(static value => value.Value is string));
+
+	private static bool HasSupportedTargetValues(TypedConstant targets)
+		=> targets.IsNull ||
+			targets.Values.All(static value =>
+			value.Value is string target && HtmxRouteRepresentationContract.IsValidTarget(target));
 
 	private static bool IsSupportedMethod(string method)
 		=> string.Equals(method, "GET", StringComparison.OrdinalIgnoreCase) ||

--- a/src/Htmxor.Generators/HtmxorRoutedComponent.cs
+++ b/src/Htmxor.Generators/HtmxorRoutedComponent.cs
@@ -173,7 +173,7 @@ internal sealed class HtmxorRoutedComponent
 	{
 		var unsupportedArgument = route.NamedArguments
 			.Select(static argument => argument.Key)
-			.Where(static name => !string.Equals(name, "Methods", StringComparison.Ordinal))
+			.Where(static name => !IsSupportedRouteNamedArgument(name))
 			.OrderBy(static name => name, StringComparer.Ordinal)
 			.FirstOrDefault();
 		if (unsupportedArgument is not null)
@@ -181,19 +181,38 @@ internal sealed class HtmxorRoutedComponent
 			return "HtmxRoute named argument '" + unsupportedArgument + "' is not supported";
 		}
 
-		var methods = route.NamedArguments
-			.Where(static argument => string.Equals(argument.Key, "Methods", StringComparison.Ordinal))
-			.Select(static argument => argument.Value)
-			.ToImmutableArray();
-		if (methods.Length == 0)
+		foreach (var argument in route.NamedArguments)
 		{
-			return null;
+			var reason = ValidateRouteNamedArgument(argument);
+			if (reason is not null)
+			{
+				return reason;
+			}
 		}
 
-		return methods.Length == 1 && HasSupportedExplicitMethods(methods[0])
-			? null
-			: "explicit HtmxRoute Methods must resolve to a non-empty unique subset of GET, POST, PUT, PATCH, DELETE, and QUERY";
+		return null;
 	}
+
+	private static string? ValidateRouteNamedArgument(KeyValuePair<string, TypedConstant> argument)
+		=> argument.Key switch
+		{
+			"Methods" => HasSupportedExplicitMethods(argument.Value)
+				? null
+				: "explicit HtmxRoute Methods must resolve to a non-empty unique subset of GET, POST, PUT, PATCH, DELETE, and QUERY",
+			"CurrentUrl" or "Target" => HasSupportedOptionalString(argument.Value)
+				? null
+				: "HtmxRoute named argument '" + argument.Key + "' must resolve to a constant string or null",
+			"Targets" => HasSupportedTargets(argument.Value)
+				? null
+				: "HtmxRoute named argument 'Targets' must resolve to a constant string array",
+			_ => "HtmxRoute named argument '" + argument.Key + "' is not supported",
+		};
+
+	private static bool IsSupportedRouteNamedArgument(string name)
+		=> string.Equals(name, "Methods", StringComparison.Ordinal) ||
+			string.Equals(name, "CurrentUrl", StringComparison.Ordinal) ||
+			string.Equals(name, "Target", StringComparison.Ordinal) ||
+			string.Equals(name, "Targets", StringComparison.Ordinal);
 
 	private string? ValidateRouteOrigin(CancellationToken cancellationToken)
 	{
@@ -347,6 +366,14 @@ internal sealed class HtmxorRoutedComponent
 			IsSupportedMethod(method) &&
 			uniqueMethods.Add(method));
 	}
+
+	private static bool HasSupportedOptionalString(TypedConstant value)
+		=> value.IsNull || value.Value is string;
+
+	private static bool HasSupportedTargets(TypedConstant targets)
+		=> targets.IsNull ||
+			(targets.Kind == TypedConstantKind.Array &&
+				targets.Values.All(static value => value.Value is string));
 
 	private static bool IsSupportedMethod(string method)
 		=> string.Equals(method, "GET", StringComparison.OrdinalIgnoreCase) ||

--- a/src/Htmxor/Builder/HtmxRouteRepresentationContract.cs
+++ b/src/Htmxor/Builder/HtmxRouteRepresentationContract.cs
@@ -1,0 +1,132 @@
+using System;
+
+namespace Htmxor;
+
+internal static class HtmxRouteRepresentationContract
+{
+	public static bool IsValidCurrentUrl(string? declaration)
+	{
+		if (declaration is null || string.IsNullOrWhiteSpace(declaration))
+		{
+			return true;
+		}
+
+		if (!IsWellFormedUtf16(declaration))
+		{
+			return false;
+		}
+
+		var declarationWithoutFragment = RemoveFragment(declaration);
+		if (!Uri.TryCreate(declarationWithoutFragment, UriKind.RelativeOrAbsolute, out var declaredUrl) ||
+			declaredUrl is null ||
+			!declaredUrl.IsWellFormedOriginalString())
+		{
+			return false;
+		}
+
+		return !declaredUrl.IsAbsoluteUri || IsHttpUrl(declaredUrl);
+	}
+
+	public static bool IsValidOptionalTarget(string? declaration)
+		=> string.IsNullOrWhiteSpace(declaration) || IsValidTarget(declaration);
+
+	public static bool IsValidTarget(string? declaration)
+	{
+		if (declaration is null)
+		{
+			return false;
+		}
+
+		if (string.IsNullOrWhiteSpace(declaration))
+		{
+			return false;
+		}
+
+		if (!IsWellFormedUtf16(declaration))
+		{
+			return false;
+		}
+
+		var separator = FindHash(declaration);
+		if (!IsValidSeparator(declaration, separator))
+		{
+			return false;
+		}
+
+		var tagLength = separator < 0 ? declaration.Length : separator;
+		return IsValidIdentityPart(declaration, 0, tagLength) &&
+			(separator < 0 || IsValidIdentityPart(
+				declaration,
+				separator + 1,
+				declaration.Length - separator - 1));
+	}
+
+	private static bool IsValidSeparator(string value, int separator)
+		=> separator != 0 &&
+			separator != value.Length - 1 &&
+			(separator < 0 || FindHash(value, separator + 1) < 0);
+
+	private static bool IsValidIdentityPart(string value, int start, int length)
+	{
+		if (length == 0)
+		{
+			return false;
+		}
+
+		for (var index = start; index < start + length; index++)
+		{
+			if (char.IsControl(value[index]) || char.IsWhiteSpace(value[index]))
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	private static bool IsWellFormedUtf16(string value)
+	{
+		for (var index = 0; index < value.Length; index++)
+		{
+			if (char.IsHighSurrogate(value[index]))
+			{
+				if (index + 1 >= value.Length || !char.IsLowSurrogate(value[index + 1]))
+				{
+					return false;
+				}
+
+				index++;
+			}
+			else if (char.IsLowSurrogate(value[index]))
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	private static string RemoveFragment(string value)
+	{
+		var fragmentStart = FindHash(value);
+		return fragmentStart < 0 ? value : value.Substring(0, fragmentStart);
+	}
+
+	private static int FindHash(string value, int start = 0)
+	{
+		for (var index = start; index < value.Length; index++)
+		{
+			if (value[index] == '#')
+			{
+				return index;
+			}
+		}
+
+		return -1;
+	}
+
+	private static bool IsHttpUrl(Uri uri)
+		=> (string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) ||
+			string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)) &&
+			!string.IsNullOrEmpty(uri.Host);
+}

--- a/src/Htmxor/Builder/HtmxorAttributedRouteCatalog.cs
+++ b/src/Htmxor/Builder/HtmxorAttributedRouteCatalog.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Htmxor;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Http;
@@ -212,6 +213,19 @@ internal static class HtmxorAttributedRouteCatalog
 
 		if (argument.TypedValue.Value is string value)
 		{
+			var isValid = argument.MemberName switch
+			{
+				nameof(HtmxRouteAttribute.CurrentUrl) => HtmxRouteRepresentationContract.IsValidCurrentUrl(value),
+				nameof(HtmxRouteAttribute.Target) => HtmxRouteRepresentationContract.IsValidOptionalTarget(value),
+				_ => false,
+			};
+			if (!isValid)
+			{
+				throw Unsupported(
+					componentType,
+					$"HtmxRoute named argument '{argument.MemberName}' must be a valid representation value");
+			}
+
 			return value;
 		}
 
@@ -239,7 +253,7 @@ internal static class HtmxorAttributedRouteCatalog
 		var values = targets
 			.Select(static argument => argument.Value as string)
 			.ToArray();
-		if (values.Any(static value => value is null))
+		if (values.Any(static value => !HtmxRouteRepresentationContract.IsValidTarget(value)))
 		{
 			throw Unsupported(
 				componentType,

--- a/src/Htmxor/Builder/HtmxorAttributedRouteCatalog.cs
+++ b/src/Htmxor/Builder/HtmxorAttributedRouteCatalog.cs
@@ -136,7 +136,14 @@ internal static class HtmxorAttributedRouteCatalog
 		}
 
 		var policy = ReadAuthorizationPolicy(componentType);
-		return new ValidatedDeclaration(componentType, route.Template, policy, route.ExplicitMethods);
+		return new ValidatedDeclaration(
+			componentType,
+			route.Template,
+			policy,
+			route.ExplicitMethods,
+			route.CurrentUrl,
+			route.Target,
+			route.Targets);
 	}
 
 	private static ValidatedRoute ReadRoute(Type componentType, CustomAttributeData attribute)
@@ -148,17 +155,32 @@ internal static class HtmxorAttributedRouteCatalog
 			throw Unsupported(componentType, "the HtmxRoute template must be a non-blank string");
 		}
 
-		if (attribute.NamedArguments.Count > 1 ||
-			attribute.NamedArguments.Count == 1 &&
-			!string.Equals(attribute.NamedArguments[0].MemberName, nameof(HtmxRouteAttribute.Methods), StringComparison.Ordinal))
+		string[]? explicitMethods = null;
+		string? currentUrl = null;
+		string? target = null;
+		string[]? targets = null;
+		foreach (var namedArgument in attribute.NamedArguments)
 		{
-			throw Unsupported(
-				componentType,
-				"HtmxRoute supports only the Methods named argument");
+			switch (namedArgument.MemberName)
+			{
+				case nameof(HtmxRouteAttribute.Methods):
+					explicitMethods = ReadExplicitMethods(componentType, namedArgument.TypedValue);
+					break;
+				case nameof(HtmxRouteAttribute.CurrentUrl):
+					currentUrl = ReadOptionalString(componentType, namedArgument);
+					break;
+				case nameof(HtmxRouteAttribute.Target):
+					target = ReadOptionalString(componentType, namedArgument);
+					break;
+				case nameof(HtmxRouteAttribute.Targets):
+					targets = ReadTargets(componentType, namedArgument.TypedValue);
+					break;
+				default:
+					throw Unsupported(
+						componentType,
+						$"HtmxRoute named argument '{namedArgument.MemberName}' is not supported");
+			}
 		}
-		var explicitMethods = attribute.NamedArguments.Count == 0
-			? null
-			: ReadExplicitMethods(componentType, attribute.NamedArguments[0].TypedValue);
 
 		if (!HtmxorRouteTemplateContract.IsSupported(template))
 		{
@@ -176,7 +198,55 @@ internal static class HtmxorAttributedRouteCatalog
 			throw Unsupported(componentType, "the HtmxRoute template is not a valid route pattern", exception);
 		}
 
-		return new ValidatedRoute(template, explicitMethods);
+		return new ValidatedRoute(template, explicitMethods, currentUrl, target, targets);
+	}
+
+	private static string? ReadOptionalString(
+		Type componentType,
+		CustomAttributeNamedArgument argument)
+	{
+		if (argument.TypedValue.Value is null)
+		{
+			return null;
+		}
+
+		if (argument.TypedValue.Value is string value)
+		{
+			return value;
+		}
+
+		throw Unsupported(
+			componentType,
+			$"HtmxRoute named argument '{argument.MemberName}' must be a string or null");
+	}
+
+	private static string[] ReadTargets(
+		Type componentType,
+		CustomAttributeTypedArgument targetsArgument)
+	{
+		if (targetsArgument.Value is null)
+		{
+			return [];
+		}
+
+		if (targetsArgument.Value is not IEnumerable<CustomAttributeTypedArgument> targets)
+		{
+			throw Unsupported(
+				componentType,
+				"HtmxRoute named argument 'Targets' must be a string array");
+		}
+
+		var values = targets
+			.Select(static argument => argument.Value as string)
+			.ToArray();
+		if (values.Any(static value => value is null))
+		{
+			throw Unsupported(
+				componentType,
+				"HtmxRoute named argument 'Targets' must be a string array");
+		}
+
+		return values!;
 	}
 
 	private static string[] ReadExplicitMethods(
@@ -298,9 +368,15 @@ internal static class HtmxorAttributedRouteCatalog
 
 		var route = metadata.OfType<HtmxRouteAttribute>().SingleOrDefault();
 		var expectedMethods = declaration.ExplicitMethods ?? [HtmxRouteAttribute.ImplicitHttpMethod];
+		var expectedTargets = declaration.Targets ?? [];
+		var actualTargets = route?.Targets ?? [];
 		if (route is null ||
 			!string.Equals(route.Template, declaration.Route, StringComparison.Ordinal) ||
-			!route.Methods.SequenceEqual(expectedMethods, StringComparer.OrdinalIgnoreCase))
+			route.Methods is null ||
+			!route.Methods.SequenceEqual(expectedMethods, StringComparer.OrdinalIgnoreCase) ||
+			!string.Equals(route.CurrentUrl, declaration.CurrentUrl, StringComparison.Ordinal) ||
+			!string.Equals(route.Target, declaration.Target, StringComparison.Ordinal) ||
+			!actualTargets.SequenceEqual(expectedTargets, StringComparer.Ordinal))
 		{
 			throw Unsupported(
 				declaration.ComponentType,
@@ -337,11 +413,19 @@ internal static class HtmxorAttributedRouteCatalog
 
 	private sealed record RoutedType(Type ComponentType, CustomAttributeData[] Routes);
 
-	private sealed record ValidatedRoute(string Template, string[]? ExplicitMethods);
+	private sealed record ValidatedRoute(
+		string Template,
+		string[]? ExplicitMethods,
+		string? CurrentUrl,
+		string? Target,
+		string[]? Targets);
 
 	private sealed record ValidatedDeclaration(
 		Type ComponentType,
 		string Route,
 		string Policy,
-		string[]? ExplicitMethods);
+		string[]? ExplicitMethods,
+		string? CurrentUrl,
+		string? Target,
+		string[]? Targets);
 }

--- a/src/Htmxor/Builder/HtmxorComponentEndpointRouteBuilderExtensions.cs
+++ b/src/Htmxor/Builder/HtmxorComponentEndpointRouteBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Reflection;
+using Htmxor;
 using Htmxor.Builder;
 using Htmxor.Endpoints;
 using Htmxor.Http;
@@ -161,6 +162,13 @@ public static class HtmxorComponentEndpointRouteBuilderExtensions
 		foreach (var metadata in generatedRoute.Metadata)
 		{
 			endpointBuilder.Metadata.Add(metadata);
+		}
+		var routeMetadata = generatedRoute.Metadata
+			.OfType<HtmxRouteAttribute>()
+			.SingleOrDefault();
+		if (routeMetadata is not null)
+		{
+			endpointBuilder.Metadata.Add(new EndpointMetadata(routeMetadata));
 		}
 
 		var routeEndpointBuilder = endpointBuilder as RouteEndpointBuilder

--- a/src/Htmxor/Builder/HtmxorDirectEndpointMatcherPolicy.cs
+++ b/src/Htmxor/Builder/HtmxorDirectEndpointMatcherPolicy.cs
@@ -20,8 +20,24 @@ internal sealed class HtmxorDirectEndpointMatcherPolicy : MatcherPolicy, IEndpoi
 	{
 		ArgumentNullException.ThrowIfNull(httpContext);
 		ArgumentNullException.ThrowIfNull(candidates);
-		if (httpContext.GetHtmxContext().Request.RoutingMode is RoutingMode.Direct)
+		var htmxRequest = httpContext.GetHtmxContext().Request;
+		if (htmxRequest.RoutingMode is RoutingMode.Direct)
 		{
+			for (var index = 0; index < candidates.Count; index++)
+			{
+				if (!candidates.IsValidCandidate(index) ||
+					candidates[index].Endpoint.Metadata.GetMetadata<HtmxorDirectEndpointMetadata>() is null)
+				{
+					continue;
+				}
+
+				var routeMetadata = candidates[index].Endpoint.Metadata.GetMetadata<EndpointMetadata>();
+				if (routeMetadata is not null && !routeMetadata.IsValidFor(htmxRequest))
+				{
+					candidates.SetValidity(index, false);
+				}
+			}
+
 			return Task.CompletedTask;
 		}
 

--- a/src/Htmxor/HtmxRouteAttribute.cs
+++ b/src/Htmxor/HtmxRouteAttribute.cs
@@ -48,12 +48,18 @@ public sealed class HtmxRouteAttribute : Attribute, IEquatable<HtmxRouteAttribut
 	/// </summary>
 	public string? Target { get; init; }
 
+	private string[] targets = [];
+
 	/// <summary>
 	/// Specify to only use this representation if the complete <see cref="HtmxRequestHeaderNames.Target"/>
 	/// element identity in `tag#id` or `tag` form matches one of the specified values.
 	/// If null or empty, this route is not limited to a specific set of targets.
 	/// </summary>
-	public string[] Targets { get; init; } = [];
+	public string[] Targets
+	{
+		get => targets;
+		init => targets = value ?? [];
+	}
 
 	/// <summary>
 	/// Constructs an instance of <see cref="HtmxRouteAttribute"/>.

--- a/test/Htmxor.Quality.Tests/PackageConsumer/Issue141AuditComponent.razor.template
+++ b/test/Htmxor.Quality.Tests/PackageConsumer/Issue141AuditComponent.razor.template
@@ -1,4 +1,8 @@
-@attribute [HtmxRoute("/audits/{AuditId:int}", Methods = ["GET", "POST"])]
+@attribute [HtmxRoute(
+    "/audits/{AuditId:int}",
+	Methods = ["GET", "POST"],
+	CurrentUrl = "/orders",
+	Targets = ["section", "div#fallback"])]
 @attribute [Authorize(Policy = "issue-141-audit-policy")]
 @attribute [Host("audits.internal.example")]
 @using Htmxor

--- a/test/Htmxor.Quality.Tests/PackageConsumer/Issue145RootRegistrationTests.cs.template
+++ b/test/Htmxor.Quality.Tests/PackageConsumer/Issue145RootRegistrationTests.cs.template
@@ -121,6 +121,8 @@ public sealed class Issue145RootRegistrationTests : IAsyncLifetime
 		{
 			request.Headers.Add("HX-Request", "true");
 			request.Headers.Add("HX-Request-Type", "partial");
+			request.Headers.Add("HX-Current-URL", "https://example.test/orders");
+			request.Headers.Add("HX-Target", "section#patch-result");
 		}
 
 		return await client.SendAsync(request);

--- a/test/Htmxor.Quality.Tests/PackageConsumer/Issue97ReportComponent.razor.cs.template
+++ b/test/Htmxor.Quality.Tests/PackageConsumer/Issue97ReportComponent.razor.cs.template
@@ -3,7 +3,12 @@ using Htmxor;
 
 namespace Htmxor.PackageConsumer;
 
-[HtmxRoute("/htmx-reports/{ReportId:int}", Methods = ["GET", "PATCH"])]
+[HtmxRoute(
+	"/htmx-reports/{ReportId:int}",
+	Methods = ["GET", "PATCH"],
+	CurrentUrl = "/orders",
+	Target = "section#patch-result",
+	Targets = ["section#patch-result", "div#fallback"])]
 [Host("reports.internal.example")]
 public partial class Issue97ReportComponent
 {

--- a/test/Htmxor.Quality.Tests/PackageConsumer/Issue97SummaryComponent.cs.template
+++ b/test/Htmxor.Quality.Tests/PackageConsumer/Issue97SummaryComponent.cs.template
@@ -7,7 +7,12 @@ using Microsoft.AspNetCore.Routing;
 
 namespace Htmxor.PackageConsumer;
 
-[HtmxRoute("/summaries/{SummaryId:int}", Methods = ["GET"])]
+[HtmxRoute(
+	"/summaries/{SummaryId:int}",
+	Methods = ["GET"],
+	CurrentUrl = "/orders",
+	Target = "section",
+	Targets = null!)]
 [Authorize(Policy = "issue-97-summary-policy")]
 [Host("summaries.internal.example")]
 public sealed class Issue97SummaryComponent : ComponentBase

--- a/test/Htmxor.Quality.Tests/PackageConsumer/PackageConsumerTests.cs.template
+++ b/test/Htmxor.Quality.Tests/PackageConsumer/PackageConsumerTests.cs.template
@@ -803,7 +803,10 @@ public sealed partial class PackageConsumerTests : IAsyncLifetime
 			.GetProperties(BindingFlags.Public | BindingFlags.Instance)
 			.Select(static property => property.Name)
 			.ToArray();
+		Assert.Contains(nameof(HtmxRouteAttribute.Methods), routePropertyNames);
 		Assert.Contains(nameof(HtmxRouteAttribute.CurrentUrl), routePropertyNames);
+		Assert.Contains(nameof(HtmxRouteAttribute.Target), routePropertyNames);
+		Assert.Contains(nameof(HtmxRouteAttribute.Targets), routePropertyNames);
 		Assert.DoesNotContain("CurrentURL", routePropertyNames);
 
 		var valid = ParseWireRequest(
@@ -1074,7 +1077,10 @@ public sealed partial class PackageConsumerTests : IAsyncLifetime
 			ReportDeclaredRoute,
 			ReportPolicyName,
 			[HttpMethods.Get, HttpMethods.Patch],
-			[HttpMethods.Get, HttpMethods.Patch]);
+			[HttpMethods.Get, HttpMethods.Patch],
+			"/orders",
+			"section#patch-result",
+			["section#patch-result", "div#fallback"]);
 		AssertHost(endpoint, ReportHost);
 		Assert.True(endpoint.Metadata.GetRequiredMetadata<IAntiforgeryMetadata>().RequiresValidation);
 
@@ -1129,12 +1135,18 @@ public sealed partial class PackageConsumerTests : IAsyncLifetime
 			SummaryPolicyName,
 #if ISSUE103_ACTIONLESS_UNSAFE
 			[HttpMethods.Get, HttpMethods.Delete],
-			[HttpMethods.Get, HttpMethods.Delete]);
+			[HttpMethods.Get, HttpMethods.Delete],
+			"/orders",
+			"section",
+			[]);
 		AssertHost(endpoint, SummaryHost);
 		Assert.True(endpoint.Metadata.GetRequiredMetadata<IAntiforgeryMetadata>().RequiresValidation);
 #else
 			[HttpMethods.Get],
-			[HttpMethods.Get]);
+			[HttpMethods.Get],
+			"/orders",
+			"section",
+			[]);
 		AssertHost(endpoint, SummaryHost);
 		Assert.Null(endpoint.Metadata.GetMetadata<IAntiforgeryMetadata>());
 #endif
@@ -1195,7 +1207,10 @@ public sealed partial class PackageConsumerTests : IAsyncLifetime
 			AuditDeclaredRoute,
 			AuditPolicyName,
 			[HttpMethods.Get, HttpMethods.Post],
-			[HttpMethods.Get, HttpMethods.Post]);
+			[HttpMethods.Get, HttpMethods.Post],
+			"/orders",
+			null,
+			["section", "div#fallback"]);
 		AssertHost(endpoint, AuditHost);
 		Assert.True(endpoint.Metadata.GetRequiredMetadata<IAntiforgeryMetadata>().RequiresValidation);
 
@@ -1229,6 +1244,29 @@ public sealed partial class PackageConsumerTests : IAsyncLifetime
 			PackageConsumerAuthenticationHandler.AuditUserName,
 			AuditHost,
 			HttpStatusCode.NotFound);
+	}
+
+	[Fact]
+	public async Task Route_representation_filters_select_only_matching_packed_routes()
+	{
+		await AssertRouteRepresentationAsync(
+			ReportRequestPath,
+			PackageConsumerAuthenticationHandler.ReportUserName,
+			ReportHost,
+			"data-issue-97-report-component",
+			"section#patch-result");
+		await AssertRouteRepresentationAsync(
+			SummaryRequestPath,
+			PackageConsumerAuthenticationHandler.SummaryUserName,
+			SummaryHost,
+			"data-issue-97-summary-component",
+			"section");
+		await AssertRouteRepresentationAsync(
+			AuditRequestPath,
+			PackageConsumerAuthenticationHandler.AuditUserName,
+			AuditHost,
+			"data-issue-141-audit-component",
+			"div#fallback");
 	}
 
 	[Fact]
@@ -1554,6 +1592,12 @@ public sealed partial class PackageConsumerTests : IAsyncLifetime
 		request.Headers.Host = host;
 		request.Headers.Add("HX-Request", "true");
 		request.Headers.Add("HX-Request-Type", "partial");
+		request.Headers.Add(HtmxRequestHeaderNames.CurrentUrl, "https://example.test/orders");
+		request.Headers.Add(
+			HtmxRequestHeaderNames.Target,
+			path.Contains("htmx-reports", StringComparison.Ordinal)
+				? "section#patch-result"
+				: "section");
 		if (userName is not null)
 		{
 			request.Headers.Add(PackageConsumerAuthenticationHandler.UserHeaderName, userName);
@@ -1836,6 +1880,71 @@ public sealed partial class PackageConsumerTests : IAsyncLifetime
 		Assert.DoesNotContain("data-issue-100-report-page", body, StringComparison.Ordinal);
 	}
 
+	private async Task AssertRouteRepresentationAsync(
+		string path,
+		string userName,
+		string host,
+		string expectedComponent,
+		string expectedTarget)
+	{
+		using var matchingResponse = await SendAsync(
+			path,
+			direct: true,
+			userName,
+			host,
+			target: expectedTarget);
+		var matchingBody = await matchingResponse.Content.ReadAsStringAsync();
+		Assert.True(
+			matchingResponse.StatusCode == HttpStatusCode.OK,
+			$"Expected a matching 200 OK, received {(int)matchingResponse.StatusCode} " +
+			$"{matchingResponse.StatusCode}. Body: {matchingBody}");
+		Assert.Contains(expectedComponent, matchingBody, StringComparison.Ordinal);
+
+		using var wrongUrlResponse = await SendAsync(
+			path,
+			direct: true,
+			userName,
+			host,
+			currentUrl: "https://example.test/other",
+			target: expectedTarget);
+		var wrongUrlBody = await wrongUrlResponse.Content.ReadAsStringAsync();
+		Assert.Equal(HttpStatusCode.NotFound, wrongUrlResponse.StatusCode);
+		Assert.DoesNotContain(expectedComponent, wrongUrlBody, StringComparison.Ordinal);
+
+		using var wrongTargetResponse = await SendAsync(
+			path,
+			direct: true,
+			userName,
+			host,
+			currentUrl: "https://example.test/orders",
+			target: "div#other");
+		var wrongTargetBody = await wrongTargetResponse.Content.ReadAsStringAsync();
+		Assert.Equal(HttpStatusCode.NotFound, wrongTargetResponse.StatusCode);
+		Assert.DoesNotContain(expectedComponent, wrongTargetBody, StringComparison.Ordinal);
+
+		using var malformedUrlResponse = await SendAsync(
+			path,
+			direct: true,
+			userName,
+			host,
+			currentUrl: "ftp://example.test/orders",
+			target: expectedTarget);
+		var malformedUrlBody = await malformedUrlResponse.Content.ReadAsStringAsync();
+		Assert.Equal(HttpStatusCode.NotFound, malformedUrlResponse.StatusCode);
+		Assert.DoesNotContain(expectedComponent, malformedUrlBody, StringComparison.Ordinal);
+
+		using var malformedTargetResponse = await SendAsync(
+			path,
+			direct: true,
+			userName,
+			host,
+			currentUrl: "https://example.test/orders",
+			target: " ");
+		var malformedTargetBody = await malformedTargetResponse.Content.ReadAsStringAsync();
+		Assert.Equal(HttpStatusCode.NotFound, malformedTargetResponse.StatusCode);
+		Assert.DoesNotContain(expectedComponent, malformedTargetBody, StringComparison.Ordinal);
+	}
+
 	private RouteEndpoint[] GetGeneratedComponentEndpoints() =>
 		((IEndpointRouteBuilder)app).DataSources
 			.SelectMany(dataSource => dataSource.Endpoints)
@@ -1881,7 +1990,10 @@ public sealed partial class PackageConsumerTests : IAsyncLifetime
 		string declaredRoute,
 		string policyName,
 		IReadOnlyList<string> expectedMethods,
-		IReadOnlyList<string>? declaredMethods = null)
+		IReadOnlyList<string>? declaredMethods = null,
+		string? expectedCurrentUrl = null,
+		string? expectedTarget = null,
+		IReadOnlyList<string>? expectedTargets = null)
 	{
 		var endpoint = Assert.Single(endpoints, endpoint =>
 			endpoint.Metadata.GetRequiredMetadata<ComponentTypeMetadata>().Type == typeof(TComponent));
@@ -1895,6 +2007,9 @@ public sealed partial class PackageConsumerTests : IAsyncLifetime
 		var route = Assert.Single(endpoint.Metadata.GetOrderedMetadata<HtmxRouteAttribute>());
 		Assert.Equal(declaredRoute, route.Template);
 		Assert.Equal(declaredMethods ?? [HttpMethods.Get], route.Methods);
+		Assert.Equal(expectedCurrentUrl, route.CurrentUrl);
+		Assert.Equal(expectedTarget, route.Target);
+		Assert.Equal(expectedTargets ?? [], route.Targets);
 		var authorization = endpoint.Metadata.GetOrderedMetadata<IAuthorizeData>();
 		Assert.Contains(authorization, data => data.Policy == policyName);
 		Assert.Contains(authorization, data => data.Policy == GroupPolicyName);
@@ -1912,7 +2027,9 @@ public sealed partial class PackageConsumerTests : IAsyncLifetime
 		string path,
 		bool direct,
 		string? userName,
-		string host)
+		string host,
+		string currentUrl = "https://example.test/orders",
+		string? target = null)
 	{
 		using var request = new HttpRequestMessage(HttpMethod.Get, path);
 		request.Headers.Host = host;
@@ -1920,6 +2037,12 @@ public sealed partial class PackageConsumerTests : IAsyncLifetime
 		{
 			request.Headers.Add("HX-Request", "true");
 			request.Headers.Add("HX-Request-Type", "partial");
+			request.Headers.Add(HtmxRequestHeaderNames.CurrentUrl, currentUrl);
+			request.Headers.Add(
+				HtmxRequestHeaderNames.Target,
+				target ?? (path.Contains("htmx-reports", StringComparison.Ordinal)
+					? "section#patch-result"
+					: "section"));
 		}
 
 		if (userName is not null)

--- a/test/Htmxor.Quality.Tests/PackedPackageConsumerTests.cs
+++ b/test/Htmxor.Quality.Tests/PackedPackageConsumerTests.cs
@@ -36,7 +36,7 @@ public sealed class PackedPackageConsumerTests
 			result.ExitCode == 0,
 			result.StandardOutput + Environment.NewLine + result.StandardError +
 			Environment.NewLine + $"TRX: {testRun}");
-		Assert.Equal(new TrxTestRun(93, 93, 93, 0, 0, 0, 0), testRun);
+		Assert.Equal(new TrxTestRun(94, 94, 94, 0, 0, 0, 0), testRun);
 		PackageConsumerEvidence.AssertPackage(workspace.PackagePath);
 		PackageConsumerEvidence.AssertConsumer(workspace.ConsumerDirectory, workspace.PackageVersion);
 	}
@@ -54,7 +54,7 @@ public sealed class PackedPackageConsumerTests
 			result.ExitCode == 0,
 			result.StandardOutput + Environment.NewLine + result.StandardError +
 			Environment.NewLine + $"TRX: {testRun}");
-		Assert.Equal(new TrxTestRun(96, 96, 96, 0, 0, 0, 0), testRun);
+		Assert.Equal(new TrxTestRun(97, 97, 97, 0, 0, 0, 0), testRun);
 		PackageConsumerEvidence.AssertPackage(workspace.PackagePath);
 	}
 
@@ -272,10 +272,8 @@ internal sealed class PackageConsumerWorkspace : IDisposable
 			consumerDirectory,
 			"Issue97ReportComponent.razor.cs");
 		var source = File.ReadAllText(componentPath);
-		const string supportedMethods =
-			"HtmxRoute(\"/htmx-reports/{ReportId:int}\", Methods = [\"GET\", \"PATCH\"])";
-		const string conflictingMethods =
-			"HtmxRoute(\"/htmx-reports/{ReportId:int}\", Methods = [\"GET\"])";
+		const string supportedMethods = "Methods = [\"GET\", \"PATCH\"]";
+		const string conflictingMethods = "Methods = [\"GET\"]";
 		var rewritten = source.Replace(
 			supportedMethods,
 			conflictingMethods,
@@ -295,10 +293,8 @@ internal sealed class PackageConsumerWorkspace : IDisposable
 			consumerDirectory,
 			"Issue97SummaryComponent.cs");
 		var source = File.ReadAllText(componentPath);
-		const string explicitMethods =
-			"HtmxRoute(\"/summaries/{SummaryId:int}\", Methods = [\"GET\"])";
-		const string omittedMethods =
-			"HtmxRoute(\"/summaries/{SummaryId:int}\")";
+		const string explicitMethods = "Methods = [\"GET\"],";
+		const string omittedMethods = "";
 		var rewritten = source.Replace(
 			explicitMethods,
 			omittedMethods,
@@ -339,10 +335,8 @@ internal sealed class PackageConsumerWorkspace : IDisposable
 			consumerDirectory,
 			"Issue97SummaryComponent.cs");
 		var componentSource = File.ReadAllText(componentPath);
-		const string getOnlyRoute =
-			"HtmxRoute(\"/summaries/{SummaryId:int}\", Methods = [\"GET\"])";
-		const string unsafeRoute =
-			"HtmxRoute(\"/summaries/{SummaryId:int}\", Methods = [\"GET\", \"DELETE\"])";
+		const string getOnlyRoute = "Methods = [\"GET\"],";
+		const string unsafeRoute = "Methods = [\"GET\", \"DELETE\"],";
 		var rewrittenComponent = componentSource.Replace(
 			getOnlyRoute,
 			unsafeRoute,
@@ -1023,12 +1017,6 @@ internal static class PackageConsumerEvidence
 		var pageSource = File.ReadAllText(Path.Combine(
 			consumerDirectory,
 			"Issue100ReportPage.razor"));
-		const string reportRoute =
-			"[HtmxRoute(\"/htmx-reports/{ReportId:int}\", Methods = [\"GET\", \"PATCH\"])]";
-		const string summaryRoute =
-			"[HtmxRoute(\"/summaries/{SummaryId:int}\", Methods = [\"GET\"])]";
-		const string auditRoute =
-			"@attribute [HtmxRoute(\"/audits/{AuditId:int}\", Methods = [\"GET\", \"POST\"])]";
 		const string pageRoute = "@page \"/reports/{ReportId:int}\"";
 
 		Assert.Equal(2, Count(applicationSource, "AddHtmxor()"));
@@ -1054,10 +1042,25 @@ internal static class PackageConsumerEvidence
 		Assert.Equal(1, Count(reportSource, "hx-put="));
 		Assert.Equal(1, Count(reportSource, "@onpatch=\"PatchReport\""));
 		Assert.DoesNotContain("@onput", reportSource, StringComparison.Ordinal);
-		Assert.Equal(1, Count(reportPartialSource, reportRoute));
+		Assert.Equal(1, Count(reportPartialSource, "[HtmxRoute("));
+		Assert.Contains("Methods = [\"GET\", \"PATCH\"]", reportPartialSource, StringComparison.Ordinal);
+		Assert.Contains("CurrentUrl = \"/orders\"", reportPartialSource, StringComparison.Ordinal);
+		Assert.Contains("Target = \"section#patch-result\"", reportPartialSource, StringComparison.Ordinal);
+		Assert.Contains(
+			"Targets = [\"section#patch-result\", \"div#fallback\"]",
+			reportPartialSource,
+			StringComparison.Ordinal);
 		Assert.Equal(1, Count(reportPartialSource, "private void PatchReport(HtmxEventArgs _)"));
-		Assert.Equal(1, Count(summarySource, summaryRoute));
-		Assert.Equal(1, Count(auditSource, auditRoute));
+		Assert.Equal(1, Count(summarySource, "[HtmxRoute("));
+		Assert.Contains("Methods = [\"GET\"]", summarySource, StringComparison.Ordinal);
+		Assert.Contains("CurrentUrl = \"/orders\"", summarySource, StringComparison.Ordinal);
+		Assert.Contains("Target = \"section\"", summarySource, StringComparison.Ordinal);
+		Assert.Contains("Targets = null!", summarySource, StringComparison.Ordinal);
+		Assert.Equal(1, Count(auditSource, "@attribute [HtmxRoute("));
+		Assert.Contains("Methods = [\"GET\", \"POST\"]", auditSource, StringComparison.Ordinal);
+		Assert.Contains("CurrentUrl = \"/orders\"", auditSource, StringComparison.Ordinal);
+		Assert.DoesNotContain("Target = ", auditSource, StringComparison.Ordinal);
+		Assert.Contains("Targets = [\"section\", \"div#fallback\"]", auditSource, StringComparison.Ordinal);
 		Assert.Equal(1, Count(summarySource, "[Authorize("));
 		Assert.Contains(
 			"protected override void BuildRenderTree(RenderTreeBuilder builder)",

--- a/test/Htmxor.Tests/Builder/HtmxorAttributedRouteCatalogTests.cs
+++ b/test/Htmxor.Tests/Builder/HtmxorAttributedRouteCatalogTests.cs
@@ -175,6 +175,45 @@ public sealed class HtmxorAttributedRouteCatalogTests
 	}
 
 	[Fact]
+	public async Task Bridge_rejects_an_invalid_current_url_before_mapping()
+	{
+		await AssertInvalidRouteDeclarationAsync(
+			new ComponentDefinition(
+				"PackageConsumer.ZInvalidCurrentUrlComponent",
+				"/invalid-current-url/{Id:int}",
+				"invalid.policy",
+				HasAdditionalRouteFilter: true,
+				CurrentUrl: "ftp://example.test/orders"),
+			"CurrentUrl");
+	}
+
+	[Fact]
+	public async Task Bridge_rejects_an_invalid_target_before_mapping()
+	{
+		await AssertInvalidRouteDeclarationAsync(
+			new ComponentDefinition(
+				"PackageConsumer.ZInvalidTargetComponent",
+				"/invalid-target/{Id:int}",
+				"invalid.policy",
+				HasAdditionalRouteFilter: true,
+				Target: "section#"),
+			"Target");
+	}
+
+	[Fact]
+	public async Task Bridge_rejects_an_invalid_targets_value_before_mapping()
+	{
+		await AssertInvalidRouteDeclarationAsync(
+			new ComponentDefinition(
+				"PackageConsumer.ZInvalidTargetsComponent",
+				"/invalid-targets/{Id:int}",
+				"invalid.policy",
+				HasAdditionalRouteFilter: true,
+				Targets: ["section", " "]),
+			"Targets");
+	}
+
+	[Fact]
 	public async Task Bridge_maps_nothing_when_metadata_construction_throws()
 	{
 		var fixture = DynamicComponentAssembly.Create(
@@ -601,6 +640,23 @@ public sealed class HtmxorAttributedRouteCatalogTests
 		return app;
 	}
 
+	private static async Task AssertInvalidRouteDeclarationAsync(
+		ComponentDefinition definition,
+		string expectedArgument)
+	{
+		var fixture = DynamicComponentAssembly.Create(definition);
+		await using var app = CreateApplication(out var group, out var componentBuilder, out _);
+
+		var exception = Assert.Throws<InvalidOperationException>(() =>
+			componentBuilder.AddHtmxorAttributedComponentEndpoints(
+				group,
+				fixture.Assembly,
+				fixture.Manifest));
+
+		Assert.Contains($"HtmxRoute named argument '{expectedArgument}'", exception.Message, StringComparison.Ordinal);
+		Assert.Empty(GetGeneratedEndpoints(app));
+	}
+
 	private static HttpRequestMessage CreateDirectRequest(
 		string path,
 		string currentUrl,
@@ -642,7 +698,10 @@ public sealed class HtmxorAttributedRouteCatalogTests
 		bool HasHtmxRoute = true,
 		IReadOnlyList<string>? StockRoutes = null,
 		bool ExplicitMethods = true,
-		IReadOnlyList<string>? Methods = null);
+		IReadOnlyList<string>? Methods = null,
+		string? CurrentUrl = null,
+		string? Target = null,
+		IReadOnlyList<string>? Targets = null);
 
 	private sealed record DynamicComponentAssembly(Assembly Assembly, Type[] Types, string[] Manifest)
 	{
@@ -707,11 +766,11 @@ public sealed class HtmxorAttributedRouteCatalogTests
 			if (definition.HasAdditionalRouteFilter)
 			{
 				properties.Add(typeof(HtmxRouteAttribute).GetProperty(nameof(HtmxRouteAttribute.CurrentUrl))!);
-				values.Add("/orders");
+				values.Add(definition.CurrentUrl ?? "/orders");
 				properties.Add(typeof(HtmxRouteAttribute).GetProperty(nameof(HtmxRouteAttribute.Target))!);
-				values.Add("section#result");
+				values.Add(definition.Target ?? "section#result");
 				properties.Add(typeof(HtmxRouteAttribute).GetProperty(nameof(HtmxRouteAttribute.Targets))!);
-				values.Add(new[] { "section#result", "div#fallback" });
+				values.Add((definition.Targets ?? ["section#result", "div#fallback"]).ToArray());
 			}
 
 			type.SetCustomAttribute(new CustomAttributeBuilder(

--- a/test/Htmxor.Tests/Builder/HtmxorAttributedRouteCatalogTests.cs
+++ b/test/Htmxor.Tests/Builder/HtmxorAttributedRouteCatalogTests.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Reflection;
 using System.Reflection.Emit;
 using Microsoft.AspNetCore.Antiforgery;
@@ -7,6 +8,7 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Endpoints;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Htmxor.Builder;
@@ -82,6 +84,42 @@ public sealed class HtmxorAttributedRouteCatalogTests
 	}
 
 	[Fact]
+	public async Task Generated_endpoint_rejects_nonmatching_route_representation()
+	{
+		await using var app = CreateRequestApplication(out var group);
+		var route = new HtmxRouteAttribute("/issue-173")
+		{
+			CurrentUrl = "/orders",
+			Target = "section#result",
+			Targets = ["section#result", "div#fallback"],
+		};
+		group.MapHtmxorComponentEndpoint(
+			new HtmxorComponentRouteDescriptor(
+				typeof(RouteProbeComponent),
+				"/issue-173",
+				[route],
+				[HttpMethods.Get]),
+			[]);
+
+		await app.StartAsync();
+		using var client = app.GetTestClient();
+
+		using var matchingRequest = CreateDirectRequest(
+			"/catalog/issue-173",
+			"https://example.test/orders",
+			"section#result");
+		using var matchingResponse = await client.SendAsync(matchingRequest);
+		Assert.Equal(HttpStatusCode.OK, matchingResponse.StatusCode);
+
+		using var nonmatchingRequest = CreateDirectRequest(
+			"/catalog/issue-173",
+			"https://example.test/other",
+			"div#other");
+		using var nonmatchingResponse = await client.SendAsync(nonmatchingRequest);
+		Assert.Equal(HttpStatusCode.NotFound, nonmatchingResponse.StatusCode);
+	}
+
+	[Fact]
 	public void Build_rejects_a_route_declaration_outside_the_manifest()
 	{
 		var fixture = DynamicComponentAssembly.Create(
@@ -109,10 +147,35 @@ public sealed class HtmxorAttributedRouteCatalogTests
 		Assert.Empty(descriptors);
 	}
 
-	[Theory]
-	[InlineData(false)]
-	[InlineData(true)]
-	public async Task Bridge_maps_nothing_when_the_second_components_metadata_is_unsupported(bool throwsOnConstruction)
+	[Fact]
+	public async Task Bridge_maps_route_representation_filters()
+	{
+		var fixture = DynamicComponentAssembly.Create(
+			new("PackageConsumer.AValidComponent", "/valid/{Id:int}", "valid.policy"),
+			new(
+				"PackageConsumer.ZFilteredComponent",
+				"/invalid/{Id:int}",
+				"invalid.policy",
+				HasAdditionalRouteFilter: true));
+		await using var app = CreateApplication(out var group, out var componentBuilder, out _);
+
+		componentBuilder.AddHtmxorAttributedComponentEndpoints(
+			group,
+			fixture.Assembly,
+			fixture.Manifest);
+
+		var endpoint = Assert.Single(
+			GetGeneratedEndpoints(app),
+			endpoint => endpoint.Metadata.GetRequiredMetadata<ComponentTypeMetadata>().Type == fixture.Types[1]);
+		var route = endpoint.Metadata.GetRequiredMetadata<HtmxRouteAttribute>();
+		Assert.Equal("/orders", route.CurrentUrl);
+		Assert.Equal("section#result", route.Target);
+		Assert.Equal(new[] { "section#result", "div#fallback" }, route.Targets);
+		Assert.Same(route, endpoint.Metadata.GetRequiredMetadata<EndpointMetadata>().HxRoute);
+	}
+
+	[Fact]
+	public async Task Bridge_maps_nothing_when_metadata_construction_throws()
 	{
 		var fixture = DynamicComponentAssembly.Create(
 			new("PackageConsumer.AValidComponent", "/valid/{Id:int}", "valid.policy"),
@@ -120,8 +183,7 @@ public sealed class HtmxorAttributedRouteCatalogTests
 				"PackageConsumer.ZInvalidComponent",
 				"/invalid/{Id:int}",
 				"invalid.policy",
-				HasAdditionalRouteFilter: !throwsOnConstruction,
-				HasThrowingMetadata: throwsOnConstruction));
+				HasThrowingMetadata: true));
 		await using var app = CreateApplication(out var group, out var componentBuilder, out _);
 
 		var exception = Assert.Throws<InvalidOperationException>(() =>
@@ -509,6 +571,8 @@ public sealed class HtmxorAttributedRouteCatalogTests
 		Assert.Equal(
 			route["/catalog".Length..],
 			endpoint.Metadata.GetRequiredMetadata<HtmxRouteAttribute>().Template);
+		var routeMetadata = endpoint.Metadata.GetRequiredMetadata<HtmxRouteAttribute>();
+		Assert.Same(routeMetadata, endpoint.Metadata.GetRequiredMetadata<EndpointMetadata>().HxRoute);
 	}
 
 	private static WebApplication CreateApplication(
@@ -526,6 +590,30 @@ public sealed class HtmxorAttributedRouteCatalogTests
 		return app;
 	}
 
+	private static WebApplication CreateRequestApplication(out RouteGroupBuilder group)
+	{
+		var builder = WebApplication.CreateBuilder();
+		builder.WebHost.UseTestServer();
+		builder.Services.AddRazorComponents().AddHtmxor();
+		var app = builder.Build();
+		group = app.MapGroup("/catalog");
+		group.MapRazorComponents<global::Htmxor.TestApp.App>();
+		return app;
+	}
+
+	private static HttpRequestMessage CreateDirectRequest(
+		string path,
+		string currentUrl,
+		string target)
+	{
+		var request = new HttpRequestMessage(HttpMethod.Get, path);
+		request.Headers.TryAddWithoutValidation(Htmxor.Http.HtmxRequestHeaderNames.HtmxRequest, "true");
+		request.Headers.TryAddWithoutValidation(Htmxor.Http.HtmxRequestHeaderNames.RequestType, "partial");
+		request.Headers.TryAddWithoutValidation(Htmxor.Http.HtmxRequestHeaderNames.CurrentUrl, currentUrl);
+		request.Headers.TryAddWithoutValidation(Htmxor.Http.HtmxRequestHeaderNames.Target, target);
+		return request;
+	}
+
 	private static RouteEndpoint[] GetGeneratedEndpoints(WebApplication app)
 		=> ((IEndpointRouteBuilder)app).DataSources
 			.SelectMany(static dataSource => dataSource.Endpoints)
@@ -536,6 +624,13 @@ public sealed class HtmxorAttributedRouteCatalogTests
 	private sealed record GroupMetadata(string Value);
 
 	private sealed record TestAntiforgeryMetadata(bool RequiresValidation) : IAntiforgeryMetadata;
+
+	private sealed class RouteProbeComponent : ComponentBase
+	{
+		protected override void BuildRenderTree(
+			Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder builder)
+			=> builder.AddMarkupContent(0, "<div id=\"result\">route-probe</div>");
+	}
 
 	private sealed record ComponentDefinition(
 		string TypeName,
@@ -611,8 +706,12 @@ public sealed class HtmxorAttributedRouteCatalogTests
 			}
 			if (definition.HasAdditionalRouteFilter)
 			{
+				properties.Add(typeof(HtmxRouteAttribute).GetProperty(nameof(HtmxRouteAttribute.CurrentUrl))!);
+				values.Add("/orders");
 				properties.Add(typeof(HtmxRouteAttribute).GetProperty(nameof(HtmxRouteAttribute.Target))!);
-				values.Add("invalid-target");
+				values.Add("section#result");
+				properties.Add(typeof(HtmxRouteAttribute).GetProperty(nameof(HtmxRouteAttribute.Targets))!);
+				values.Add(new[] { "section#result", "div#fallback" });
 			}
 
 			type.SetCustomAttribute(new CustomAttributeBuilder(

--- a/test/Htmxor.Tests/Generators/HtmxorRouteDeclarationAnalyzerTests.cs
+++ b/test/Htmxor.Tests/Generators/HtmxorRouteDeclarationAnalyzerTests.cs
@@ -414,6 +414,35 @@ public sealed class HtmxorRouteDeclarationAnalyzerTests
 	}
 
 	[Theory]
+	[InlineData("CurrentUrl = \"ftp://example.test/orders\"", "CurrentUrl")]
+	[InlineData("Target = \"section#\"", "Target")]
+	[InlineData("Targets = [\"section\", \" \"]", "Targets")]
+	public async Task Invalid_route_representation_values_report_nonconfigurable_error(
+		string namedArgument,
+		string memberName)
+	{
+		var componentPath = ComponentPath("ItemComponent.razor");
+		var source = ComponentSource(
+			"ItemComponent",
+			componentPath,
+			$"[global::Htmxor.HtmxRouteAttribute(\"/items/{{Id:int}}\", Methods = [\"GET\"], {namedArgument})]",
+			"[global::Microsoft.AspNetCore.Authorization.AuthorizeAttribute(\"items.read\")]");
+
+		var diagnostics = await RunAnalyzerAsync(
+			new[] { source },
+			new[] { componentPath });
+
+		var diagnostic = Assert.Single(diagnostics);
+		Assert.Equal("HTMXOR001", diagnostic.Id);
+		Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+		Assert.Contains(
+			$"HtmxRoute named argument '{memberName}'",
+			diagnostic.GetMessage(),
+			StringComparison.Ordinal);
+		Assert.Contains(WellKnownDiagnosticTags.NotConfigurable, diagnostic.Descriptor.CustomTags);
+	}
+
+	[Theory]
 	[InlineData(
 		"[global::Htmxor.HtmxRouteAttribute(\"/items/{Id:int}\", Methods = [\"TRACE\"])]",
 		"[global::Microsoft.AspNetCore.Authorization.AuthorizeAttribute(\"items.read\")]",

--- a/test/Htmxor.Tests/Generators/HtmxorRouteDeclarationAnalyzerTests.cs
+++ b/test/Htmxor.Tests/Generators/HtmxorRouteDeclarationAnalyzerTests.cs
@@ -379,6 +379,40 @@ public sealed class HtmxorRouteDeclarationAnalyzerTests
 		Assert.Contains("anonymous", diagnostic.GetMessage(), StringComparison.Ordinal);
 	}
 
+	[Fact]
+	public async Task Route_representation_filters_are_supported_for_compiled_declarations()
+	{
+		var componentPath = ComponentPath("ItemComponent.razor");
+		var source = ComponentSource(
+			"ItemComponent",
+			componentPath,
+			"[global::Htmxor.HtmxRouteAttribute(\"/items/{Id:int}\", Methods = [\"GET\"], CurrentUrl = \"/orders\", Target = \"section#result\", Targets = [\"section#result\", \"div#fallback\"])]",
+			"[global::Microsoft.AspNetCore.Authorization.AuthorizeAttribute(\"items.read\")]");
+
+		var diagnostics = await RunAnalyzerAsync(
+			new[] { source },
+			new[] { componentPath });
+
+		Assert.Empty(diagnostics);
+	}
+
+	[Fact]
+	public async Task Null_targets_are_supported_for_compiled_declarations()
+	{
+		var componentPath = ComponentPath("ItemComponent.razor");
+		var source = ComponentSource(
+			"ItemComponent",
+			componentPath,
+			"[global::Htmxor.HtmxRouteAttribute(\"/items/{Id:int}\", Methods = [\"GET\"], Targets = null!)]",
+			"[global::Microsoft.AspNetCore.Authorization.AuthorizeAttribute(\"items.read\")]");
+
+		var diagnostics = await RunAnalyzerAsync(
+			new[] { source },
+			new[] { componentPath });
+
+		Assert.Empty(diagnostics);
+	}
+
 	[Theory]
 	[InlineData(
 		"[global::Htmxor.HtmxRouteAttribute(\"/items/{Id:int}\", Methods = [\"TRACE\"])]",
@@ -388,10 +422,6 @@ public sealed class HtmxorRouteDeclarationAnalyzerTests
 		"[global::Htmxor.HtmxRouteAttribute(\"/items/{Id:int}\", Methods = [\"GET\"])]\n[global::Htmxor.HtmxRouteAttribute(\"/other/{Id:int}\", Methods = [\"GET\"])]",
 		"[global::Microsoft.AspNetCore.Authorization.AuthorizeAttribute(\"items.read\")]",
 		"exactly one HtmxRoute")]
-	[InlineData(
-		"[global::Htmxor.HtmxRouteAttribute(\"/items/{Id:int}\", Methods = [\"GET\"], Target = \"result\")]",
-		"[global::Microsoft.AspNetCore.Authorization.AuthorizeAttribute(\"items.read\")]",
-		"Target")]
 	[InlineData(
 		"[global::Htmxor.HtmxRouteAttribute(\"/items/{Id:int}\", Methods = [\"GET\"])]",
 		"[global::Microsoft.AspNetCore.Authorization.AuthorizeAttribute(\"items.read\", Roles = \"admin\")]",

--- a/test/Htmxor.Tests/HtmxRouteAttributeTests.cs
+++ b/test/Htmxor.Tests/HtmxRouteAttributeTests.cs
@@ -95,4 +95,15 @@ public sealed class HtmxRouteAttributeTests
 		Assert.False(present.Equals(absent));
 		Assert.Equal(2, new HashSet<HtmxRouteAttribute> { absent, present }.Count);
 	}
+
+	[Fact]
+	public void Null_targets_are_normalized_to_empty()
+	{
+		var route = new HtmxRouteAttribute("/items")
+		{
+			Targets = null!,
+		};
+
+		Assert.Empty(route.Targets);
+	}
 }


### PR DESCRIPTION
Fixes #173. Carries Template, Methods, CurrentUrl, Target, and Targets through the packaged analyzer/generator, runtime catalog, generated endpoint metadata, and direct matcher. Adds compiler/runtime and packed .NET 10 TestServer coverage for Razor, matching code-behind, all-C# declarations, null Targets normalization, non-first Targets-only matching, rejection, and security/method preservation. Verification: repository fast and full profiles pass at commit 38f819edcda82aa74ea573a86ad37e71e7b3e948.