### PR TITLE
spike(rendering): prove selected component HTML emission through public .NET 10 APIs

### DIFF
--- a/test/Htmxor.Tests/Rendering/PublicRendererComponentStateSeamTests.cs
+++ b/test/Htmxor.Tests/Rendering/PublicRendererComponentStateSeamTests.cs
@@ -26,9 +26,9 @@ public sealed class PublicRendererComponentStateSeamTests
 			root.QuiescenceTask.IsCompleted.Should().BeFalse();
 			probe.ReleaseSelectedInitialization();
 			await root.QuiescenceTask;
-			var completedEvents = probe.Events.ToArray();
+			var selectedComponentId = renderer.ResolveSelectedComponentIdFromCompletedTopology();
 			var rootMarkup = renderer.WriteRootComponentHtml();
-			var selectedMarkup = renderer.WriteSelectedComponentHtml();
+			var selectedMarkup = renderer.WriteSelectedComponentHtml(selectedComponentId);
 
 			rootMarkup.Should().Be("<main data-root=\"\"><div><section data-selected=\"\">selected:ready</section></div><aside data-root-sibling=\"\">sibling</aside></main>");
 			rootMarkup.Should().Contain("data-root");
@@ -36,13 +36,14 @@ public sealed class PublicRendererComponentStateSeamTests
 			selectedMarkup.Should().Be("<section data-selected=\"\">selected:ready</section>");
 			selectedMarkup.Should().NotContain("data-root");
 			selectedMarkup.Should().NotContain("data-root-sibling");
+			var completedEvents = probe.Events.ToArray();
 			completedEvents.Count(eventName => eventName == "lifecycle:root").Should().Be(1);
 			completedEvents.Count(eventName => eventName == "lifecycle:container").Should().Be(1);
 			completedEvents.Count(eventName => eventName == "lifecycle:selected").Should().Be(1);
 			completedEvents.Count(eventName => eventName == "lifecycle:sibling").Should().Be(1);
 			completedEvents.Count(eventName => eventName == "data-ready:selected").Should().Be(1);
-			completedEvents.Should().Contain("data:selected");
-			completedEvents.Should().Contain("data:sibling");
+			completedEvents.Count(eventName => eventName == "data:selected").Should().Be(2);
+			completedEvents.Count(eventName => eventName == "data:sibling").Should().Be(1);
 			output.WriteLine($"Selected component output: {selectedMarkup}");
 			output.WriteLine($"Completed lifecycle and data work: {string.Join(", ", probe.Events)}");
 		});
@@ -51,16 +52,26 @@ public sealed class PublicRendererComponentStateSeamTests
 	private sealed class ProbeRenderer : StaticHtmlRenderer
 	{
 		private int rootComponentId = -1;
-		private int selectedComponentId = -1;
+		private readonly List<ComponentState> componentStates = [];
 		public ProbeRenderer(IServiceProvider services) : base(services, NullLoggerFactory.Instance) { }
 		protected override ComponentState CreateComponentState(int componentId, IComponent component, ComponentState? parentComponentState)
 		{
 			if (component is NestedBoundaryRoot) rootComponentId = componentId;
-			if (component is SelectedBoundary) selectedComponentId = componentId;
-			return base.CreateComponentState(componentId, component, parentComponentState);
+			var state = base.CreateComponentState(componentId, component, parentComponentState);
+			componentStates.Add(state);
+			return state;
 		}
 		public string WriteRootComponentHtml() => WriteComponentHtml(rootComponentId);
-		public string WriteSelectedComponentHtml() => WriteComponentHtml(selectedComponentId);
+		public string WriteSelectedComponentHtml(int componentId) => WriteComponentHtml(componentId);
+		public int ResolveSelectedComponentIdFromCompletedTopology()
+		{
+			var selected = componentStates.Single(state => state.Component is SelectedBoundary);
+			selected.ParentComponentState.Should().NotBeNull();
+			selected.ParentComponentState!.Component.Should().BeOfType<NestedBoundaryContainer>();
+			selected.ParentComponentState.ParentComponentState.Should().NotBeNull();
+			selected.ParentComponentState.ParentComponentState!.Component.Should().BeOfType<NestedBoundaryRoot>();
+			return selected.ComponentId;
+		}
 		private string WriteComponentHtml(int componentId)
 		{
 			componentId.Should().NotBe(-1);

--- a/test/Htmxor.Tests/Rendering/PublicRendererComponentStateSeamTests.cs
+++ b/test/Htmxor.Tests/Rendering/PublicRendererComponentStateSeamTests.cs
@@ -22,18 +22,27 @@ public sealed class PublicRendererComponentStateSeamTests
 		await renderer.Dispatcher.InvokeAsync(async () =>
 		{
 			var root = renderer.BeginRenderingComponent(typeof(NestedBoundaryRoot), ParameterView.Empty);
+			await probe.SelectedInitializationEntered.Task;
+			root.QuiescenceTask.IsCompleted.Should().BeFalse();
+			probe.ReleaseSelectedInitialization();
 			await root.QuiescenceTask;
+			var completedEvents = probe.Events.ToArray();
+			var rootMarkup = renderer.WriteRootComponentHtml();
 			var selectedMarkup = renderer.WriteSelectedComponentHtml();
 
-			selectedMarkup.Should().Be("<section data-selected=\"\">selected</section>");
+			rootMarkup.Should().Be("<main data-root=\"\"><div><section data-selected=\"\">selected:ready</section></div><aside data-root-sibling=\"\">sibling</aside></main>");
+			rootMarkup.Should().Contain("data-root");
+			rootMarkup.Should().Contain("data-root-sibling");
+			selectedMarkup.Should().Be("<section data-selected=\"\">selected:ready</section>");
 			selectedMarkup.Should().NotContain("data-root");
 			selectedMarkup.Should().NotContain("data-root-sibling");
-			probe.Events.Should().Contain("lifecycle:root");
-			probe.Events.Should().Contain("lifecycle:container");
-			probe.Events.Should().Contain("lifecycle:selected");
-			probe.Events.Should().Contain("lifecycle:sibling");
-			probe.Events.Should().Contain("data:selected");
-			probe.Events.Should().Contain("data:sibling");
+			completedEvents.Count(eventName => eventName == "lifecycle:root").Should().Be(1);
+			completedEvents.Count(eventName => eventName == "lifecycle:container").Should().Be(1);
+			completedEvents.Count(eventName => eventName == "lifecycle:selected").Should().Be(1);
+			completedEvents.Count(eventName => eventName == "lifecycle:sibling").Should().Be(1);
+			completedEvents.Count(eventName => eventName == "data-ready:selected").Should().Be(1);
+			completedEvents.Should().Contain("data:selected");
+			completedEvents.Should().Contain("data:sibling");
 			output.WriteLine($"Selected component output: {selectedMarkup}");
 			output.WriteLine($"Completed lifecycle and data work: {string.Join(", ", probe.Events)}");
 		});
@@ -41,18 +50,22 @@ public sealed class PublicRendererComponentStateSeamTests
 
 	private sealed class ProbeRenderer : StaticHtmlRenderer
 	{
+		private int rootComponentId = -1;
 		private int selectedComponentId = -1;
 		public ProbeRenderer(IServiceProvider services) : base(services, NullLoggerFactory.Instance) { }
 		protected override ComponentState CreateComponentState(int componentId, IComponent component, ComponentState? parentComponentState)
 		{
+			if (component is NestedBoundaryRoot) rootComponentId = componentId;
 			if (component is SelectedBoundary) selectedComponentId = componentId;
 			return base.CreateComponentState(componentId, component, parentComponentState);
 		}
-		public string WriteSelectedComponentHtml()
+		public string WriteRootComponentHtml() => WriteComponentHtml(rootComponentId);
+		public string WriteSelectedComponentHtml() => WriteComponentHtml(selectedComponentId);
+		private string WriteComponentHtml(int componentId)
 		{
-			selectedComponentId.Should().NotBe(-1);
+			componentId.Should().NotBe(-1);
 			using var writer = new StringWriter();
-			WriteComponentHtml(selectedComponentId, writer);
+			WriteComponentHtml(componentId, writer);
 			return writer.ToString();
 		}
 	}
@@ -78,9 +91,15 @@ public sealed class PublicRendererComponentStateSeamTests
 	private sealed class SelectedBoundary : ObservedComponent
 	{
 		protected override string Name => "selected";
+		protected override async Task OnInitializedAsync()
+		{
+			await base.OnInitializedAsync();
+			await Probe.WaitForSelectedInitializationAsync();
+			Probe.RecordDataReady(Name);
+		}
 		protected override void BuildRenderTree(RenderTreeBuilder builder)
 		{
-			builder.OpenElement(0, "section"); builder.AddAttribute(1, "data-selected", ""); builder.AddContent(2, Probe.Read(Name)); builder.CloseElement();
+			builder.OpenElement(0, "section"); builder.AddAttribute(1, "data-selected", ""); builder.AddContent(2, Probe.Read(Name)); builder.AddContent(3, ":ready"); builder.CloseElement();
 		}
 	}
 	private sealed class RootSibling : ObservedComponent
@@ -99,8 +118,17 @@ public sealed class PublicRendererComponentStateSeamTests
 	}
 	private sealed class RenderProbe
 	{
+		public TaskCompletionSource SelectedInitializationEntered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+		private readonly TaskCompletionSource selectedInitializationRelease = new(TaskCreationOptions.RunContinuationsAsynchronously);
 		public List<string> Events { get; } = [];
 		public string Read(string component) { Events.Add($"data:{component}"); return component; }
 		public void RecordLifecycle(string component) => Events.Add($"lifecycle:{component}");
+		public void RecordDataReady(string component) => Events.Add($"data-ready:{component}");
+		public async Task WaitForSelectedInitializationAsync()
+		{
+			SelectedInitializationEntered.TrySetResult();
+			await selectedInitializationRelease.Task;
+		}
+		public void ReleaseSelectedInitialization() => selectedInitializationRelease.TrySetResult();
 	}
 }

--- a/test/Htmxor.Tests/Rendering/PublicRendererComponentStateSeamTests.cs
+++ b/test/Htmxor.Tests/Rendering/PublicRendererComponentStateSeamTests.cs
@@ -1,0 +1,106 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.HtmlRendering.Infrastructure;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit.Abstractions;
+
+namespace Htmxor.Rendering;
+
+public sealed class PublicRendererComponentStateSeamTests
+{
+	private readonly ITestOutputHelper output;
+
+	public PublicRendererComponentStateSeamTests(ITestOutputHelper output) => this.output = output;
+
+	[Fact]
+	public async Task Completed_nested_component_boundary_can_be_serialized_without_root_or_sibling()
+	{
+		var probe = new RenderProbe();
+		await using var services = new ServiceCollection().AddSingleton(probe).BuildServiceProvider();
+		await using var renderer = new ProbeRenderer(services);
+		await renderer.Dispatcher.InvokeAsync(async () =>
+		{
+			var root = renderer.BeginRenderingComponent(typeof(NestedBoundaryRoot), ParameterView.Empty);
+			await root.QuiescenceTask;
+			var selectedMarkup = renderer.WriteSelectedComponentHtml();
+
+			selectedMarkup.Should().Be("<section data-selected=\"\">selected</section>");
+			selectedMarkup.Should().NotContain("data-root");
+			selectedMarkup.Should().NotContain("data-root-sibling");
+			probe.Events.Should().Contain("lifecycle:root");
+			probe.Events.Should().Contain("lifecycle:container");
+			probe.Events.Should().Contain("lifecycle:selected");
+			probe.Events.Should().Contain("lifecycle:sibling");
+			probe.Events.Should().Contain("data:selected");
+			probe.Events.Should().Contain("data:sibling");
+			output.WriteLine($"Selected component output: {selectedMarkup}");
+			output.WriteLine($"Completed lifecycle and data work: {string.Join(", ", probe.Events)}");
+		});
+	}
+
+	private sealed class ProbeRenderer : StaticHtmlRenderer
+	{
+		private int selectedComponentId = -1;
+		public ProbeRenderer(IServiceProvider services) : base(services, NullLoggerFactory.Instance) { }
+		protected override ComponentState CreateComponentState(int componentId, IComponent component, ComponentState? parentComponentState)
+		{
+			if (component is SelectedBoundary) selectedComponentId = componentId;
+			return base.CreateComponentState(componentId, component, parentComponentState);
+		}
+		public string WriteSelectedComponentHtml()
+		{
+			selectedComponentId.Should().NotBe(-1);
+			using var writer = new StringWriter();
+			WriteComponentHtml(selectedComponentId, writer);
+			return writer.ToString();
+		}
+	}
+
+	private sealed class NestedBoundaryRoot : ObservedComponent
+	{
+		protected override string Name => "root";
+		protected override void BuildRenderTree(RenderTreeBuilder builder)
+		{
+			builder.OpenElement(0, "main"); builder.AddAttribute(1, "data-root", "");
+			builder.OpenComponent<NestedBoundaryContainer>(2); builder.CloseComponent();
+			builder.OpenComponent<RootSibling>(3); builder.CloseComponent(); builder.CloseElement();
+		}
+	}
+	private sealed class NestedBoundaryContainer : ObservedComponent
+	{
+		protected override string Name => "container";
+		protected override void BuildRenderTree(RenderTreeBuilder builder)
+		{
+			builder.OpenElement(0, "div"); builder.OpenComponent<SelectedBoundary>(1); builder.CloseComponent(); builder.CloseElement();
+		}
+	}
+	private sealed class SelectedBoundary : ObservedComponent
+	{
+		protected override string Name => "selected";
+		protected override void BuildRenderTree(RenderTreeBuilder builder)
+		{
+			builder.OpenElement(0, "section"); builder.AddAttribute(1, "data-selected", ""); builder.AddContent(2, Probe.Read(Name)); builder.CloseElement();
+		}
+	}
+	private sealed class RootSibling : ObservedComponent
+	{
+		protected override string Name => "sibling";
+		protected override void BuildRenderTree(RenderTreeBuilder builder)
+		{
+			builder.OpenElement(0, "aside"); builder.AddAttribute(1, "data-root-sibling", ""); builder.AddContent(2, Probe.Read(Name)); builder.CloseElement();
+		}
+	}
+	private abstract class ObservedComponent : ComponentBase
+	{
+		[Inject] protected RenderProbe Probe { get; set; } = default!;
+		protected abstract string Name { get; }
+		protected override void OnInitialized() => Probe.RecordLifecycle(Name);
+	}
+	private sealed class RenderProbe
+	{
+		public List<string> Events { get; } = [];
+		public string Read(string component) { Events.Add($"data:{component}"); return component; }
+		public void RecordLifecycle(string component) => Events.Add($"lifecycle:{component}");
+	}
+}


### PR DESCRIPTION
## Parent

#153

## Binding scope

The governing amendment is [the approved scope decision](https://github.com/egil/Htmxor/pull/185#issuecomment-5546641196). This PR is a generic public/protected .NET 10 renderer-seam characterization. Real named `HtmxFragment` topology, stable `Name`, named parent/child selection, and the end-user child-only selection contract remain deferred to #168/#169.

## Protected behavior

When normal nested generic rendering reaches quiescence, Htmxor can resolve a selected nested component boundary from completed `Renderer`/`StaticHtmlRenderer`/`ComponentState` state and serialize exactly that component HTML, excluding root, ancestor, and sibling output.

The proof does not use private reflection or manually invoke application `RenderFragment` delegates. The supported seam already exists at the behavior start, so this is a green-baseline characterization rather than fabricated red evidence.

## Change

- Adds one focused `StaticHtmlRenderer` test fixture.
- Proves normal nested lifecycle/data work reaches quiescence.
- Resolves the selected component through completed `ComponentState` parent topology.
- Verifies exact selected output, root output, and root/ancestor/sibling exclusion.
- Verifies post-serialization lifecycle/data counts remain exact.

No production code or public fragment API changed.

## Verification

- Base: `b5453e4f62e898110d06e2b837a2366065a69514`
- Candidate: `9e4c033ca13202368987705628166939a2ab1c38`
- Focused Release test: 1 discovered, 1 executed, 1 passed.
- Affected Htmxor Release tests: 374 discovered, 374 executed, 374 passed.
- Full profile command: `dotnet run --project eng/Htmxor.Quality/Htmxor.Quality.csproj -- check --profile full`
- User-executed interactive WSL full profile: Quality 119/119, ASP.NET Core 45/45, Htmxor 374/374; zero failures, skips, errors, or timeouts; zero Release warnings/errors.
- Two coverage copies match with SHA-256 `b6309f378fd6966563e7c332320c36f7a66b3743f38c6743bf6aa8790c1ab35b`.
- SDK 10.0.400; .NET/ASP.NET Core runtime 10.0.11; ASP.NET Core source tag `v10.0.11`, commit `a5383385245bdacc20ec19f30e46090a8154d8da`.
- CI run [383](https://github.com/egil/Htmxor/actions/runs/33922319680): required jobs passed, including fast and full verification, browser build/provisioning, package validation, Infer#, CodeQL, and dependency review. Scheduled full-scope mutation and deployment were skipped per policy.

## Production handoff

Issue #186 owns replacement of `IRazorComponentEndpointInvoker` and stock-parity endpoint renderer behavior. This PR only proves the renderer seam; it does not implement that integration.

Full-scope mutation, package publication, release, and deployment remain out of scope.

Closes #185