### PR TITLE
refactor(rendering): preserve core static-SSR parity in the candidate renderer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,10 +10,17 @@ Keep v1 work within these limits:
 
 - Do not add application-authored controllers or Minimal API endpoints for component routes.
 - Do not replace component instance callbacks with static endpoint handlers.
-- Do not copy private Blazor renderer code or add private reflection.
+- Keep lower-level Blazor render-tree generation framework-owned; do not add private reflection.
 - Do not treat HTMX headers as authorization evidence.
 - Do not bind Htmxor to one embedded HTMX version.
 - Do not claim framework, browser, package, performance, or security behavior that the recorded command did not exercise.
+
+An inactive or active global endpoint-invoker/endpoint-renderer adaptation is
+permitted only under [the v1 renderer requirements](docs/roadmap/v1/goal.md#blazor-remains-in-charge):
+observable stock parity, supported render-tree seams, upstream license and exact
+provenance, and [#184 monitoring](https://github.com/egil/Htmxor/issues/184).
+Issue #188 authorizes an inactive candidate selected by its paired test host;
+production registration activation remains gated on the complete #186 parity work.
 
 Stop for a user decision if evidence requires changing the v1 goal, public developer model, supported target framework, or security posture.
 

--- a/docs/roadmap/v1/goal.md
+++ b/docs/roadmap/v1/goal.md
@@ -92,12 +92,30 @@ fragment can hydrate into an interactive component. The documentation must make
 DOM and navigation ownership clear when HTMX and interactive Blazor share a
 page.
 
-Htmxor should use supported ASP.NET Core and Blazor extension points. It must not
-depend on copied renderer code, private reflection, or global replacement of the
-stock renderer, endpoint invoker, routing state, navigation manager, or form
-runtime. If a public API is intended mainly for framework infrastructure, Htmxor
-must isolate it behind a replaceable internal boundary and test it on every
-supported .NET version.
+Htmxor should use supported ASP.NET Core and Blazor extension points. Render-tree
+generation remains owned by the framework through supported public/protected
+`Renderer`, `StaticHtmlRenderer`, and `ComponentState` seams. Htmxor must not use
+private reflection or globally replace stock routing state, the navigation
+manager, or the form runtime.
+
+An inactive or active global endpoint-invoker/endpoint-renderer adaptation is
+allowed only when it preserves observable stock behavior. The stock endpoint
+factory, request delegates, and effective endpoint metadata remain authoritative;
+Htmxor's selected-output variation belongs at the supported HTML-writing seam.
+Any necessary endpoint-coordination source adaptation must remain in one narrow
+internal module with its upstream license, exact source URLs, release tag,
+commit, and synchronization date. [The upstream monitor](https://github.com/egil/Htmxor/issues/184)
+must track these relationships; a detected change requires review and renewed
+parity evidence before adoption.
+
+[Issue #188](https://github.com/egil/Htmxor/issues/188) establishes only an inactive
+candidate selected by a paired test host for ordinary non-form, non-streaming
+requests. Public `AddHtmxor` registration continues using the stock invoker until
+[the complete parity work](https://github.com/egil/Htmxor/issues/186) proves the
+activation boundary. This exception does not claim that activation is complete.
+If a public API is intended mainly for framework infrastructure, Htmxor must
+isolate it behind a replaceable internal boundary and test it on every supported
+.NET version.
 
 ## The application owns HTMX
 

--- a/src/Htmxor/Endpoints/HtmxorEndpointCandidate.cs
+++ b/src/Htmxor/Endpoints/HtmxorEndpointCandidate.cs
@@ -1,0 +1,206 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Adapted for the inactive issue #188 candidate from ASP.NET Core v10.0.11 at
+// commit a5383385245bdacc20ec19f30e46090a8154d8da, synchronized 2026-09-05:
+// https://github.com/dotnet/aspnetcore/blob/v10.0.11/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
+// https://github.com/dotnet/aspnetcore/blob/a5383385245bdacc20ec19f30e46090a8154d8da/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
+// https://github.com/dotnet/aspnetcore/blob/v10.0.11/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.cs
+// https://github.com/dotnet/aspnetcore/blob/a5383385245bdacc20ec19f30e46090a8154d8da/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.cs
+// Issue #184 relationships: reimplements RazorComponentEndpointInvoker, subclasses StaticHtmlRenderer,
+// implements IRazorComponentEndpointInvoker, and consumes ComponentState through supported seams.
+
+using System.Buffers;
+using System.Text;
+using Htmxor.DependencyInjection;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.AspNetCore.Components.Endpoints;
+using Microsoft.AspNetCore.Components.HtmlRendering.Infrastructure;
+using Microsoft.AspNetCore.Components.Routing;
+using Microsoft.AspNetCore.Components.Web.HtmlRendering;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using RouteData = Microsoft.AspNetCore.Components.RouteData;
+
+namespace Htmxor.Endpoints;
+
+internal static class HtmxorEndpointCandidateServices
+{
+	public static void Add(IServiceCollection services)
+	{
+		services.AddScoped<HtmxorEndpointCandidateRenderer>();
+		services.AddScoped<HtmxorEndpointCandidateInvoker>();
+		services.RemoveAll<IRazorComponentEndpointInvoker>();
+		services.AddScoped<IRazorComponentEndpointInvoker>(serviceProvider =>
+			serviceProvider.GetRequiredService<HtmxorEndpointCandidateInvoker>());
+
+		var stockHttpContextSupplier = services
+			.Where(IsScopedFactory)
+			.Single(IsCascadingHttpContextSupplier);
+		services.Remove(stockHttpContextSupplier);
+		services.AddCascadingValue(serviceProvider =>
+			serviceProvider.GetRequiredService<HtmxorEndpointCandidateRenderer>().HttpContext);
+	}
+
+	private static bool IsScopedFactory(ServiceDescriptor service)
+		=> service.Lifetime is ServiceLifetime.Scoped &&
+			service.ImplementationType is null &&
+			service.ImplementationFactory is not null;
+
+	private static bool IsCascadingHttpContextSupplier(ServiceDescriptor service)
+		=> service.ImplementationFactory?.Target?.ToString()?.Contains(
+			typeof(HttpContext).FullName!,
+			StringComparison.Ordinal) == true;
+}
+
+internal sealed class HtmxorEndpointCandidateInvoker(HtmxorEndpointCandidateRenderer renderer)
+	: IRazorComponentEndpointInvoker
+{
+	private const string DefaultContentType = "text/html; charset=utf-8";
+	private const string EnhancedNavigationHeader = "blazor-enhanced-nav";
+
+	public Task Render(HttpContext context)
+		=> renderer.Dispatcher.InvokeAsync(() => RenderComponentCore(context));
+
+	private async Task RenderComponentCore(HttpContext context)
+	{
+		context.Response.ContentType = DefaultContentType;
+		context.Response.Headers[EnhancedNavigationHeader] = "allow";
+
+		var endpoint = context.GetEndpoint()
+			?? throw new InvalidOperationException($"An endpoint must be set on the '{nameof(HttpContext)}'.");
+		var rootComponent = endpoint.Metadata.GetRequiredMetadata<RootComponentMetadata>().Type;
+		var pageComponent = endpoint.Metadata.GetRequiredMetadata<ComponentTypeMetadata>().Type;
+
+		renderer.InitializeStandardComponentServices(context, pageComponent);
+		var htmlContent = await renderer.RenderEndpointComponentAsync(rootComponent, ParameterView.Empty);
+
+		const int defaultBufferSize = 16 * 1024;
+		await using var writer = new HttpResponseStreamWriter(
+			context.Response.Body,
+			Encoding.UTF8,
+			defaultBufferSize,
+			ArrayPool<byte>.Shared,
+			ArrayPool<char>.Shared);
+		htmlContent.WriteHtmlTo(writer);
+		await writer.FlushAsync();
+	}
+}
+
+internal class HtmxorEndpointCandidateRenderer : StaticHtmlRenderer
+{
+	private readonly IServiceProvider services;
+	private readonly EndpointRoutingStateProvider routingState;
+	private HttpContext httpContext = default!;
+
+	public HtmxorEndpointCandidateRenderer(IServiceProvider services, ILoggerFactory loggerFactory)
+		: this(services, loggerFactory, new EndpointRoutingStateProvider())
+	{
+	}
+
+	private HtmxorEndpointCandidateRenderer(
+		IServiceProvider services,
+		ILoggerFactory loggerFactory,
+		EndpointRoutingStateProvider routingState)
+		: base(new CandidateComponentServiceProvider(services, routingState), loggerFactory)
+	{
+		this.services = services;
+		this.routingState = routingState;
+	}
+
+	internal HttpContext? HttpContext => httpContext;
+
+	internal void InitializeStandardComponentServices(HttpContext context, Type pageComponent)
+	{
+		httpContext = context;
+		var navigationManager = services.GetRequiredService<NavigationManager>();
+		if (navigationManager is IHostEnvironmentNavigationManager hostNavigationManager)
+		{
+			hostNavigationManager.Initialize(GetContextBaseUri(context.Request), GetFullUri(context.Request));
+		}
+
+		var authenticationStateProvider = services.GetService<AuthenticationStateProvider>();
+		if (authenticationStateProvider is IHostEnvironmentAuthenticationStateProvider hostAuthenticationStateProvider)
+		{
+			hostAuthenticationStateProvider.SetAuthenticationState(
+				Task.FromResult(new AuthenticationState(context.User)));
+		}
+
+		if (authenticationStateProvider is not null)
+		{
+			var authenticationState = authenticationStateProvider.GetAuthenticationStateAsync();
+			foreach (var listener in services.GetServices<IHostEnvironmentAuthenticationStateProvider>())
+			{
+				listener.SetAuthenticationState(authenticationState);
+			}
+		}
+
+		SetRouteData(context, pageComponent);
+	}
+
+	internal async Task<HtmlRootComponent> RenderEndpointComponentAsync(
+		Type rootComponent,
+		ParameterView parameters)
+	{
+		var result = BeginRenderingComponent(rootComponent, parameters);
+		await result.QuiescenceTask;
+		return result;
+	}
+
+	internal void WriteCompletedComponentHtml(int componentId, TextWriter output)
+		=> WriteComponentHtml(componentId, output);
+
+	private void SetRouteData(HttpContext context, Type pageComponent)
+	{
+		routingState.RouteData = new RouteData(pageComponent, context.GetRouteData().Values);
+		if (context.GetEndpoint() is RouteEndpoint routeEndpoint)
+		{
+			routingState.RoutePattern = routeEndpoint.RoutePattern;
+			routingState.RouteData.Template = routeEndpoint.RoutePattern.RawText;
+		}
+	}
+
+	private static string GetFullUri(HttpRequest request)
+		=> UriHelper.BuildAbsolute(
+			request.Scheme,
+			request.Host,
+			request.PathBase,
+			request.Path,
+			request.QueryString);
+
+	private static string GetContextBaseUri(HttpRequest request)
+	{
+		var result = UriHelper.BuildAbsolute(request.Scheme, request.Host, request.PathBase);
+		return result.EndsWith('/') ? result : result += "/";
+	}
+
+	private sealed class CandidateComponentServiceProvider(
+		IServiceProvider services,
+		EndpointRoutingStateProvider routingState)
+		: IServiceProvider, IServiceProviderIsService, IKeyedServiceProvider, IServiceProviderIsKeyedService
+	{
+		public object? GetService(Type serviceType)
+			=> serviceType == typeof(IRoutingStateProvider)
+				? routingState
+				: services.GetService(serviceType);
+
+		public bool IsService(Type serviceType)
+			=> serviceType == typeof(IRoutingStateProvider) ||
+				((IServiceProviderIsService)services).IsService(serviceType);
+
+		public object? GetKeyedService(Type serviceType, object? serviceKey)
+			=> ((IKeyedServiceProvider)services).GetKeyedService(serviceType, serviceKey);
+
+		public object GetRequiredKeyedService(Type serviceType, object? serviceKey)
+			=> ((IKeyedServiceProvider)services).GetRequiredKeyedService(serviceType, serviceKey);
+
+		public bool IsKeyedService(Type serviceType, object? serviceKey)
+			=> ((IServiceProviderIsKeyedService)services).IsKeyedService(serviceType, serviceKey);
+	}
+}

--- a/src/Htmxor/Endpoints/HtmxorEndpointCandidate.cs
+++ b/src/Htmxor/Endpoints/HtmxorEndpointCandidate.cs
@@ -7,8 +7,11 @@
 // https://github.com/dotnet/aspnetcore/blob/a5383385245bdacc20ec19f30e46090a8154d8da/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
 // https://github.com/dotnet/aspnetcore/blob/v10.0.11/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.cs
 // https://github.com/dotnet/aspnetcore/blob/a5383385245bdacc20ec19f30e46090a8154d8da/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.cs
+// https://github.com/dotnet/aspnetcore/blob/v10.0.11/src/Components/Endpoints/src/DependencyInjection/RazorComponentsServiceCollectionExtensions.cs
+// https://github.com/dotnet/aspnetcore/blob/a5383385245bdacc20ec19f30e46090a8154d8da/src/Components/Endpoints/src/DependencyInjection/RazorComponentsServiceCollectionExtensions.cs
 // Issue #184 relationships: reimplements RazorComponentEndpointInvoker, subclasses StaticHtmlRenderer,
-// implements IRazorComponentEndpointInvoker, and consumes ComponentState through supported seams.
+// implements IRazorComponentEndpointInvoker, consumes ComponentState through supported seams, and reimplements
+// the RazorComponentsServiceCollectionExtensions cascading HttpContext registration selection.
 
 using System.Buffers;
 using System.Text;
@@ -40,6 +43,8 @@ internal static class HtmxorEndpointCandidateServices
 		services.AddScoped<IRazorComponentEndpointInvoker>(serviceProvider =>
 			serviceProvider.GetRequiredService<HtmxorEndpointCandidateInvoker>());
 
+		// AddRazorComponents does not expose a supported replacement hook for its HttpContext cascade.
+		// Issue #184 watches this registration shape so upstream drift is reviewed before candidate adoption.
 		var stockHttpContextSupplier = services
 			.Where(IsScopedFactory)
 			.Single(IsCascadingHttpContextSupplier);

--- a/src/Htmxor/Endpoints/HtmxorEndpointCandidate.cs
+++ b/src/Htmxor/Endpoints/HtmxorEndpointCandidate.cs
@@ -45,10 +45,17 @@ internal static class HtmxorEndpointCandidateServices
 
 		// AddRazorComponents does not expose a supported replacement hook for its HttpContext cascade.
 		// Issue #184 watches this registration shape so upstream drift is reviewed before candidate adoption.
-		var stockHttpContextSupplier = services
+		var stockHttpContextSuppliers = services
 			.Where(IsScopedFactory)
-			.Single(IsCascadingHttpContextSupplier);
-		services.Remove(stockHttpContextSupplier);
+			.Where(IsCascadingHttpContextSupplier)
+			.ToArray();
+		if (stockHttpContextSuppliers.Length is not 1)
+		{
+			throw new InvalidOperationException(
+				$"Expected exactly one scoped cascading HttpContext supplier registered by AddRazorComponents, but found {stockHttpContextSuppliers.Length}. ASP.NET Core's upstream registration shape may have changed.");
+		}
+
+		services.Remove(stockHttpContextSuppliers[0]);
 		services.AddCascadingValue(serviceProvider =>
 			serviceProvider.GetRequiredService<HtmxorEndpointCandidateRenderer>().HttpContext);
 	}

--- a/test/Htmxor.AspNetCore10.Tests/Issue187Page.razor
+++ b/test/Htmxor.AspNetCore10.Tests/Issue187Page.razor
@@ -3,7 +3,9 @@
 @using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.Components.Authorization
 @using Microsoft.AspNetCore.Http
+@using Microsoft.AspNetCore.Mvc.ViewFeatures
 @inject Issue187RequestProbe RequestProbe
+@inject ITempDataDictionaryFactory TempDataDictionaryFactory
 
 <main data-issue-187
       data-item-id="@ItemId"
@@ -14,6 +16,7 @@
       data-authorization-policy="@AuthorizationPolicy"
       data-endpoint-marker="@EndpointMarker"
       data-session="@SessionValue"
+      data-temp-data="@TempDataValue"
       data-lifecycle="@string.Join('|', RequestProbe.Lifecycle)">
     ordinary-output
 </main>
@@ -36,6 +39,8 @@
 
     private string? SessionValue { get; set; }
 
+    private string? TempDataValue { get; set; }
+
     private string AuthorizationPolicy
         => HttpContext.GetEndpoint()?.Metadata.GetOrderedMetadata<IAuthorizeData>()
             .SingleOrDefault(metadata => metadata.Policy is not null)?.Policy
@@ -52,6 +57,9 @@
         AuthenticationStateUser = authenticationState.User.Identity?.Name;
         HttpContext.Session.SetString(Issue187ParityConstants.SessionKey, Issue187ParityConstants.SessionValue);
         SessionValue = HttpContext.Session.GetString(Issue187ParityConstants.SessionKey);
+        var tempData = TempDataDictionaryFactory.GetTempData(HttpContext);
+        tempData[Issue187ParityConstants.TempDataKey] = Issue187ParityConstants.TempDataValue;
+        TempDataValue = tempData[Issue187ParityConstants.TempDataKey]?.ToString();
     }
 
     protected override void OnParametersSet() => RequestProbe.Record("parameters-set");

--- a/test/Htmxor.AspNetCore10.Tests/Issue187Page.razor
+++ b/test/Htmxor.AspNetCore10.Tests/Issue187Page.razor
@@ -2,10 +2,12 @@
 @attribute [Authorize(Policy = Issue187ParityConstants.PolicyName)]
 @using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.Components.Authorization
+@using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Http
 @using Microsoft.AspNetCore.Mvc.ViewFeatures
 @inject Issue187RequestProbe RequestProbe
 @inject ITempDataDictionaryFactory TempDataDictionaryFactory
+@inject IRoutingStateProvider RoutingStateProvider
 
 <main data-issue-187
       data-item-id="@ItemId"
@@ -17,6 +19,8 @@
       data-endpoint-marker="@EndpointMarker"
       data-session="@SessionValue"
       data-temp-data="@TempDataValue"
+      data-routing-page-type="@RoutingStateProvider.RouteData?.PageType.FullName"
+      data-routing-template="@RoutingStateProvider.RouteData?.Template"
       data-lifecycle="@string.Join('|', RequestProbe.Lifecycle)">
     ordinary-output
 </main>

--- a/test/Htmxor.AspNetCore10.Tests/Issue187ParityTests.cs
+++ b/test/Htmxor.AspNetCore10.Tests/Issue187ParityTests.cs
@@ -86,6 +86,25 @@ public sealed class Issue187ParityTests
 	}
 
 	[Fact]
+	public void Candidate_registration_reports_duplicate_stock_HttpContext_suppliers()
+	{
+		IServiceCollection services = new ServiceCollection();
+		services.AddRazorComponents();
+		var stockSupplier = services.Single(service =>
+			service.ImplementationFactory?.Target?.ToString()?.Contains(
+				typeof(HttpContext).FullName!,
+				StringComparison.Ordinal) == true);
+		services.Add(stockSupplier);
+
+		var exception = Assert.Throws<InvalidOperationException>(() =>
+			HtmxorEndpointCandidateServices.Add(services));
+
+		Assert.Equal(
+			"Expected exactly one scoped cascading HttpContext supplier registered by AddRazorComponents, but found 2. ASP.NET Core's upstream registration shape may have changed.",
+			exception.Message);
+	}
+
+	[Fact]
 	public async Task Inactive_candidate_has_byte_exact_paired_response_parity()
 	{
 		await using var stock = await Issue187ParityHost.CreateAsync(useHtmxor: false);

--- a/test/Htmxor.AspNetCore10.Tests/Issue187ParityTests.cs
+++ b/test/Htmxor.AspNetCore10.Tests/Issue187ParityTests.cs
@@ -75,6 +75,20 @@ public sealed class Issue187ParityTests
 	}
 
 	[Fact]
+	public async Task Ordinary_AddHtmxor_host_retains_the_stock_endpoint_invoker()
+	{
+		await using var stock = await Issue187ParityHost.CreateAsync(useHtmxor: false);
+		await using var htmxor = await Issue187ParityHost.CreateAsync(useHtmxor: true);
+		await using var stockScope = stock.App.Services.CreateAsyncScope();
+		await using var htmxorScope = htmxor.App.Services.CreateAsyncScope();
+
+		var stockInvoker = stockScope.ServiceProvider.GetRequiredService<IRazorComponentEndpointInvoker>();
+		var htmxorInvoker = htmxorScope.ServiceProvider.GetRequiredService<IRazorComponentEndpointInvoker>();
+
+		Assert.Equal(stockInvoker.GetType(), htmxorInvoker.GetType());
+	}
+
+	[Fact]
 	public async Task Inactive_candidate_has_byte_exact_paired_response_parity()
 	{
 		await using var stock = await Issue187ParityHost.CreateAsync(useHtmxor: false);
@@ -92,8 +106,30 @@ public sealed class Issue187ParityTests
 			candidate.App.Services.GetRequiredService<Issue188CandidateInvocationProbe>().InvocationCount);
 		AssertTempDataAvailable(candidateSnapshot.Body);
 		AssertTempDataAvailable(stockSnapshot.Body);
-		Assert.Equal(stockSnapshot.Body, candidateSnapshot.Body);
 		Assert.Equal(stockSnapshot.Headers, candidateSnapshot.Headers);
+		Assert.Equal(stockSnapshot.Body, candidateSnapshot.Body);
+	}
+
+	[Fact]
+	public async Task Inactive_candidate_initializes_endpoint_selected_route_state()
+	{
+		await using var stock = await Issue187ParityHost.CreateAsync(useHtmxor: false);
+		await using var candidate = await CreateInternalCandidateHostAsync();
+
+		using var stockResponse = await stock.Client.SendAsync(CreateAuthorizedRequest());
+		using var candidateResponse = await candidate.Client.SendAsync(CreateAuthorizedRequest());
+		var stockSnapshot = await Issue187ResponseSnapshot.CreateAsync(stockResponse);
+		var candidateSnapshot = await Issue187ResponseSnapshot.CreateAsync(candidateResponse);
+
+		Assert.Contains(
+			$"data-routing-page-type=\"{typeof(Issue187Page).FullName}\"",
+			stockSnapshot.Body,
+			StringComparison.Ordinal);
+		Assert.Contains(
+			$"data-routing-template=\"{Issue187ParityConstants.RouteTemplate}\"",
+			stockSnapshot.Body,
+			StringComparison.Ordinal);
+		Assert.Equal(stockSnapshot.Body, candidateSnapshot.Body);
 	}
 
 	[Fact]
@@ -251,6 +287,7 @@ internal static class Issue187ParityConstants
 	public const string PolicyName = "issue-187-policy";
 	public const string AuthorizedUser = "issue-187-user";
 	public const string RequestPath = "/issue-187/42?query=from-query";
+	public const string RouteTemplate = "/issue-187/{ItemId:int}";
 	public const string SessionKey = "issue-187-session-key";
 	public const string SessionValue = "session-value";
 	public const string TempDataKey = "issue-187-temp-data-key";

--- a/test/Htmxor.AspNetCore10.Tests/Issue187ParityTests.cs
+++ b/test/Htmxor.AspNetCore10.Tests/Issue187ParityTests.cs
@@ -2,9 +2,7 @@ using System.Net;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 using Htmxor;
-using Htmxor.DependencyInjection;
 using Htmxor.Endpoints;
-using Htmxor.Rendering;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
@@ -17,7 +15,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -172,40 +169,17 @@ public sealed class Issue187ParityTests
 	private static void ConfigureInternalCandidate(IServiceCollection services)
 	{
 		services.AddSingleton<Issue188CandidateInvocationProbe>();
-		services.AddScoped<EndpointRoutingStateProvider>();
-		services.AddScoped<HtmxorRenderer>();
-		services.AddScoped<HtmxorComponentEndpointInvoker>();
-		services.RemoveAll<IRazorComponentEndpointInvoker>();
+		HtmxorEndpointCandidateServices.Add(services);
+		var candidate = services.Single(service => service.ServiceType == typeof(IRazorComponentEndpointInvoker));
+		services.Remove(candidate);
 		services.AddScoped<IRazorComponentEndpointInvoker>(serviceProvider =>
 			new Issue188CandidateTrackingInvoker(
-				serviceProvider.GetRequiredService<HtmxorComponentEndpointInvoker>(),
+				serviceProvider.GetRequiredService<HtmxorEndpointCandidateInvoker>(),
 				serviceProvider.GetRequiredService<Issue188CandidateInvocationProbe>()));
-
-		RemoveStockCascadingHttpContextProvider(services);
-		services.AddCascadingValue(serviceProvider =>
-			serviceProvider.GetRequiredService<HtmxorRenderer>().HttpContext);
 	}
-
-	private static void RemoveStockCascadingHttpContextProvider(IServiceCollection services)
-	{
-		var provider = services
-			.Where(IsScopedFactory)
-			.Single(IsCascadingHttpContextProvider);
-		services.Remove(provider);
-	}
-
-	private static bool IsScopedFactory(ServiceDescriptor service)
-		=> service.Lifetime is ServiceLifetime.Scoped &&
-			service.ImplementationType is null &&
-			service.ImplementationFactory is not null;
-
-	private static bool IsCascadingHttpContextProvider(ServiceDescriptor service)
-		=> service.ImplementationFactory?.Target?.ToString()?.Contains(
-			typeof(HttpContext).FullName!,
-			StringComparison.Ordinal) == true;
 
 	private sealed class Issue188CandidateTrackingInvoker(
-		HtmxorComponentEndpointInvoker candidate,
+		HtmxorEndpointCandidateInvoker candidate,
 		Issue188CandidateInvocationProbe probe)
 		: IRazorComponentEndpointInvoker
 	{

--- a/test/Htmxor.AspNetCore10.Tests/Issue187ParityTests.cs
+++ b/test/Htmxor.AspNetCore10.Tests/Issue187ParityTests.cs
@@ -114,6 +114,20 @@ public sealed class Issue187ParityTests
 		await AssertUnauthorizedParityAsync(stock, candidate);
 	}
 
+	[Fact]
+	public async Task Inactive_candidate_retains_the_stock_routing_state_provider()
+	{
+		await using var stock = await Issue187ParityHost.CreateAsync(useHtmxor: false);
+		await using var candidate = await CreateInternalCandidateHostAsync();
+		await using var stockScope = stock.App.Services.CreateAsyncScope();
+		await using var candidateScope = candidate.App.Services.CreateAsyncScope();
+
+		var stockProvider = stockScope.ServiceProvider.GetRequiredService<IRoutingStateProvider>();
+		var candidateProvider = candidateScope.ServiceProvider.GetRequiredService<IRoutingStateProvider>();
+
+		Assert.Equal(stockProvider.GetType(), candidateProvider.GetType());
+	}
+
 	private static Task<Issue187ParityHost> CreateInternalCandidateHostAsync()
 		=> Issue187ParityHost.CreateAsync(
 			useHtmxor: true,
@@ -123,9 +137,6 @@ public sealed class Issue187ParityTests
 	{
 		services.AddSingleton<Issue188CandidateInvocationProbe>();
 		services.AddScoped<EndpointRoutingStateProvider>();
-		services.RemoveAll<IRoutingStateProvider>();
-		services.AddScoped<IRoutingStateProvider>(serviceProvider =>
-			serviceProvider.GetRequiredService<EndpointRoutingStateProvider>());
 		services.AddScoped<HtmxorRenderer>();
 		services.AddScoped<HtmxorComponentEndpointInvoker>();
 		services.RemoveAll<IRazorComponentEndpointInvoker>();

--- a/test/Htmxor.AspNetCore10.Tests/Issue187ParityTests.cs
+++ b/test/Htmxor.AspNetCore10.Tests/Issue187ParityTests.cs
@@ -41,6 +41,8 @@ public sealed class Issue187ParityTests
 		Assert.Equal(stockSnapshot.StatusCode, htmxorSnapshot.StatusCode);
 		Assert.Equal(stockSnapshot.Headers, htmxorSnapshot.Headers);
 		Assert.Equal(stockSnapshot.Body, htmxorSnapshot.Body);
+		AssertTempDataAvailable(stockSnapshot.Body);
+		AssertTempDataAvailable(htmxorSnapshot.Body);
 		Assert.Contains("data-item-id=\"42\"", stockSnapshot.Body, StringComparison.Ordinal);
 		Assert.Contains("data-query=\"from-query\"", stockSnapshot.Body, StringComparison.Ordinal);
 		Assert.Contains("data-di=\"from-di\"", stockSnapshot.Body, StringComparison.Ordinal);
@@ -60,22 +62,7 @@ public sealed class Issue187ParityTests
 		await using var stock = await Issue187ParityHost.CreateAsync(useHtmxor: false);
 		await using var htmxor = await Issue187ParityHost.CreateAsync(useHtmxor: true);
 
-		var stockEndpoint = stock.GetIssueEndpoint();
-		var htmxorEndpoint = htmxor.GetIssueEndpoint();
-
-		Assert.Equal(stockEndpoint.RoutePattern.RawText, htmxorEndpoint.RoutePattern.RawText);
-		Assert.Equal(
-			stockEndpoint.Metadata.GetMetadata<ComponentTypeMetadata>()?.Type,
-			htmxorEndpoint.Metadata.GetMetadata<ComponentTypeMetadata>()?.Type);
-		Assert.Equal(
-			stockEndpoint.Metadata.GetMetadata<RootComponentMetadata>()?.Type,
-			htmxorEndpoint.Metadata.GetMetadata<RootComponentMetadata>()?.Type);
-		Assert.Equal(
-			GetAuthorizationPolicies(stockEndpoint),
-			GetAuthorizationPolicies(htmxorEndpoint));
-		Assert.Equal(
-			stockEndpoint.Metadata.GetMetadata<Issue187EndpointMetadata>(),
-			htmxorEndpoint.Metadata.GetMetadata<Issue187EndpointMetadata>());
+		AssertEndpointMetadataParity(stock.GetIssueEndpoint(), htmxor.GetIssueEndpoint());
 	}
 
 	[Fact]
@@ -84,24 +71,14 @@ public sealed class Issue187ParityTests
 		await using var stock = await Issue187ParityHost.CreateAsync(useHtmxor: false);
 		await using var htmxor = await Issue187ParityHost.CreateAsync(useHtmxor: true);
 
-		using var stockResponse = await stock.Client.GetAsync(Issue187ParityConstants.RequestPath);
-		using var htmxorResponse = await htmxor.Client.GetAsync(Issue187ParityConstants.RequestPath);
-		var stockBody = await stockResponse.Content.ReadAsStringAsync();
-		var htmxorBody = await htmxorResponse.Content.ReadAsStringAsync();
-
-		Assert.Equal(HttpStatusCode.Unauthorized, stockResponse.StatusCode);
-		Assert.Equal(stockResponse.StatusCode, htmxorResponse.StatusCode);
-		Assert.Equal(stockBody, htmxorBody);
-		Assert.DoesNotContain("data-issue-187", stockBody, StringComparison.Ordinal);
+		await AssertUnauthorizedParityAsync(stock, htmxor);
 	}
 
 	[Fact]
 	public async Task Inactive_candidate_has_byte_exact_paired_response_parity()
 	{
 		await using var stock = await Issue187ParityHost.CreateAsync(useHtmxor: false);
-		await using var candidate = await Issue187ParityHost.CreateAsync(
-			useHtmxor: true,
-			configureHtmxorServices: ConfigureInternalCandidate);
+		await using var candidate = await CreateInternalCandidateHostAsync();
 
 		using var stockResponse = await stock.Client.SendAsync(CreateAuthorizedRequest());
 		using var candidateResponse = await candidate.Client.SendAsync(CreateAuthorizedRequest());
@@ -113,9 +90,34 @@ public sealed class Issue187ParityTests
 		Assert.Equal(
 			1,
 			candidate.App.Services.GetRequiredService<Issue188CandidateInvocationProbe>().InvocationCount);
-		Assert.Equal(stockSnapshot.Headers, candidateSnapshot.Headers);
+		AssertTempDataAvailable(candidateSnapshot.Body);
+		AssertTempDataAvailable(stockSnapshot.Body);
 		Assert.Equal(stockSnapshot.Body, candidateSnapshot.Body);
+		Assert.Equal(stockSnapshot.Headers, candidateSnapshot.Headers);
 	}
+
+	[Fact]
+	public async Task Inactive_candidate_preserves_component_route_and_authorization_metadata()
+	{
+		await using var stock = await Issue187ParityHost.CreateAsync(useHtmxor: false);
+		await using var candidate = await CreateInternalCandidateHostAsync();
+
+		AssertEndpointMetadataParity(stock.GetIssueEndpoint(), candidate.GetIssueEndpoint());
+	}
+
+	[Fact]
+	public async Task Inactive_candidate_has_paired_unauthorized_rejection()
+	{
+		await using var stock = await Issue187ParityHost.CreateAsync(useHtmxor: false);
+		await using var candidate = await CreateInternalCandidateHostAsync();
+
+		await AssertUnauthorizedParityAsync(stock, candidate);
+	}
+
+	private static Task<Issue187ParityHost> CreateInternalCandidateHostAsync()
+		=> Issue187ParityHost.CreateAsync(
+			useHtmxor: true,
+			configureHtmxorServices: ConfigureInternalCandidate);
 
 	private static void ConfigureInternalCandidate(IServiceCollection services)
 	{
@@ -188,6 +190,44 @@ public sealed class Issue187ParityTests
 			.Select(metadata => metadata.Policy ?? $"roles:{metadata.Roles}|schemes:{metadata.AuthenticationSchemes}")
 			.ToArray();
 
+	private static void AssertEndpointMetadataParity(RouteEndpoint stockEndpoint, RouteEndpoint actualEndpoint)
+	{
+		Assert.Equal(stockEndpoint.RoutePattern.RawText, actualEndpoint.RoutePattern.RawText);
+		Assert.Equal(
+			stockEndpoint.Metadata.GetMetadata<ComponentTypeMetadata>()?.Type,
+			actualEndpoint.Metadata.GetMetadata<ComponentTypeMetadata>()?.Type);
+		Assert.Equal(
+			stockEndpoint.Metadata.GetMetadata<RootComponentMetadata>()?.Type,
+			actualEndpoint.Metadata.GetMetadata<RootComponentMetadata>()?.Type);
+		Assert.Equal(
+			GetAuthorizationPolicies(stockEndpoint),
+			GetAuthorizationPolicies(actualEndpoint));
+		Assert.Equal(
+			stockEndpoint.Metadata.GetMetadata<Issue187EndpointMetadata>(),
+			actualEndpoint.Metadata.GetMetadata<Issue187EndpointMetadata>());
+	}
+
+	private static async Task AssertUnauthorizedParityAsync(
+		Issue187ParityHost stock,
+		Issue187ParityHost actual)
+	{
+		using var stockResponse = await stock.Client.GetAsync(Issue187ParityConstants.RequestPath);
+		using var actualResponse = await actual.Client.GetAsync(Issue187ParityConstants.RequestPath);
+		var stockBody = await stockResponse.Content.ReadAsStringAsync();
+		var actualBody = await actualResponse.Content.ReadAsStringAsync();
+
+		Assert.Equal(HttpStatusCode.Unauthorized, stockResponse.StatusCode);
+		Assert.Equal(stockResponse.StatusCode, actualResponse.StatusCode);
+		Assert.Equal(stockBody, actualBody);
+		Assert.DoesNotContain("data-issue-187", stockBody, StringComparison.Ordinal);
+	}
+
+	private static void AssertTempDataAvailable(string body)
+		=> Assert.Contains(
+			$"data-temp-data=\"{Issue187ParityConstants.TempDataValue}\"",
+			body,
+			StringComparison.Ordinal);
+
 	private static void AssertSessionCookie(IReadOnlyDictionary<string, string> headers)
 	{
 		Assert.True(headers.TryGetValue("Set-Cookie", out var setCookie));
@@ -202,6 +242,8 @@ internal static class Issue187ParityConstants
 	public const string RequestPath = "/issue-187/42?query=from-query";
 	public const string SessionKey = "issue-187-session-key";
 	public const string SessionValue = "session-value";
+	public const string TempDataKey = "issue-187-temp-data-key";
+	public const string TempDataValue = "temp-data-value";
 }
 
 internal sealed record Issue187EndpointMetadata(string Value)
@@ -238,6 +280,7 @@ internal sealed class Issue187ParityHost(WebApplication app, HttpClient client) 
 		builder.Services.AddDataProtection().UseEphemeralDataProtectionProvider();
 		builder.Services.AddDistributedMemoryCache();
 		builder.Services.AddSession(options => options.Cookie.Name = "issue187-session");
+		builder.Services.AddMvcCore().AddViews();
 		builder.Services.AddHttpContextAccessor();
 		builder.Services.AddAuthentication(Issue187AuthenticationHandler.SchemeName)
 			.AddScheme<AuthenticationSchemeOptions, Issue187AuthenticationHandler>(

--- a/test/Htmxor.AspNetCore10.Tests/Issue187ParityTests.cs
+++ b/test/Htmxor.AspNetCore10.Tests/Issue187ParityTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 using Htmxor;
+using Htmxor.Endpoints;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
@@ -12,7 +13,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -91,12 +91,12 @@ public sealed class Issue187ParityTests
 	}
 
 	[Fact]
-	public async Task Htmxor_host_can_select_internal_endpoint_candidate_through_hosted_request()
+	public async Task Inactive_candidate_has_byte_exact_paired_response_parity()
 	{
 		await using var stock = await Issue187ParityHost.CreateAsync(useHtmxor: false);
 		await using var candidate = await Issue187ParityHost.CreateAsync(
 			useHtmxor: true,
-			configureHtmxorServices: ConfigureInternalCandidate);
+			useInternalCandidate: true);
 
 		using var stockResponse = await stock.Client.SendAsync(CreateAuthorizedRequest());
 		using var candidateResponse = await candidate.Client.SendAsync(CreateAuthorizedRequest());
@@ -107,61 +107,7 @@ public sealed class Issue187ParityTests
 		Assert.Equal(stockSnapshot.StatusCode, candidateSnapshot.StatusCode);
 		Assert.Equal(stockSnapshot.Headers, candidateSnapshot.Headers);
 		Assert.Equal(stockSnapshot.Body, candidateSnapshot.Body);
-		Assert.Equal(
-			1,
-			candidate.App.Services.GetRequiredService<Issue187CandidateInvocationProbe>().InvocationCount);
-	}
-
-	private static void ConfigureInternalCandidate(IServiceCollection services)
-	{
-		var stockInvoker = services.Single(service => service.ServiceType == typeof(IRazorComponentEndpointInvoker));
-		services.AddSingleton<Issue187CandidateInvocationProbe>();
-		services.AddScoped<IHtmxorComponentEndpointInvoker>(serviceProvider =>
-			new Issue187CandidateEndpointInvoker(
-				CreateService<IRazorComponentEndpointInvoker>(stockInvoker, serviceProvider),
-				serviceProvider.GetRequiredService<Issue187CandidateInvocationProbe>()));
-		services.RemoveAll<IRazorComponentEndpointInvoker>();
-		services.AddScoped<IRazorComponentEndpointInvoker>(serviceProvider =>
-			serviceProvider.GetRequiredService<IHtmxorComponentEndpointInvoker>());
-	}
-
-	private static T CreateService<T>(ServiceDescriptor descriptor, IServiceProvider serviceProvider)
-	{
-		if (descriptor.ImplementationInstance is T instance)
-		{
-			return instance;
-		}
-
-		if (descriptor.ImplementationFactory is { } factory)
-		{
-			return (T)factory(serviceProvider);
-		}
-
-		if (descriptor.ImplementationType is { } implementationType)
-		{
-			return (T)ActivatorUtilities.CreateInstance(serviceProvider, implementationType);
-		}
-
-		throw new InvalidOperationException("The stock invoker registration has no implementation.");
-	}
-
-	private sealed class Issue187CandidateEndpointInvoker(
-		IRazorComponentEndpointInvoker inner,
-		Issue187CandidateInvocationProbe probe)
-		: IHtmxorComponentEndpointInvoker
-	{
-		public Task Render(HttpContext context)
-		{
-			probe.RecordInvocation();
-			return inner.Render(context);
-		}
-	}
-
-	private sealed class Issue187CandidateInvocationProbe
-	{
-		public int InvocationCount { get; private set; }
-
-		public void RecordInvocation() => InvocationCount++;
+		Assert.Equal(typeof(HtmxorComponentEndpointInvoker), candidate.GetEndpointInvokerType());
 	}
 
 	private static HttpRequestMessage CreateAuthorizedRequest()
@@ -214,7 +160,7 @@ internal sealed class Issue187ParityHost(WebApplication app, HttpClient client) 
 
 	public static async Task<Issue187ParityHost> CreateAsync(
 		bool useHtmxor,
-		Action<IServiceCollection>? configureHtmxorServices = null)
+		bool useInternalCandidate = false)
 	{
 		var builder = WebApplication.CreateBuilder(new WebApplicationOptions
 		{
@@ -241,8 +187,14 @@ internal sealed class Issue187ParityHost(WebApplication app, HttpClient client) 
 		var razorComponents = builder.Services.AddRazorComponents();
 		if (useHtmxor)
 		{
-			razorComponents.AddHtmxor();
-			configureHtmxorServices?.Invoke(builder.Services);
+			if (useInternalCandidate)
+			{
+				razorComponents.AddLegacyHtmx();
+			}
+			else
+			{
+				razorComponents.AddHtmxor();
+			}
 		}
 
 		var app = builder.Build();
@@ -266,6 +218,12 @@ internal sealed class Issue187ParityHost(WebApplication app, HttpClient client) 
 			.SelectMany(dataSource => dataSource.Endpoints)
 			.OfType<RouteEndpoint>()
 			.Single(endpoint => endpoint.Metadata.GetMetadata<ComponentTypeMetadata>()?.Type == typeof(Issue187Page));
+
+	public Type GetEndpointInvokerType()
+	{
+		using var scope = App.Services.CreateScope();
+		return scope.ServiceProvider.GetRequiredService<IRazorComponentEndpointInvoker>().GetType();
+	}
 
 	public async ValueTask DisposeAsync()
 	{

--- a/test/Htmxor.AspNetCore10.Tests/Issue187ParityTests.cs
+++ b/test/Htmxor.AspNetCore10.Tests/Issue187ParityTests.cs
@@ -2,17 +2,22 @@ using System.Net;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 using Htmxor;
+using Htmxor.DependencyInjection;
 using Htmxor.Endpoints;
+using Htmxor.Rendering;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Endpoints;
+using Microsoft.AspNetCore.Components.Routing;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -96,7 +101,7 @@ public sealed class Issue187ParityTests
 		await using var stock = await Issue187ParityHost.CreateAsync(useHtmxor: false);
 		await using var candidate = await Issue187ParityHost.CreateAsync(
 			useHtmxor: true,
-			useInternalCandidate: true);
+			configureHtmxorServices: ConfigureInternalCandidate);
 
 		using var stockResponse = await stock.Client.SendAsync(CreateAuthorizedRequest());
 		using var candidateResponse = await candidate.Client.SendAsync(CreateAuthorizedRequest());
@@ -105,9 +110,70 @@ public sealed class Issue187ParityTests
 
 		Assert.Equal(HttpStatusCode.OK, stockSnapshot.StatusCode);
 		Assert.Equal(stockSnapshot.StatusCode, candidateSnapshot.StatusCode);
+		Assert.Equal(
+			1,
+			candidate.App.Services.GetRequiredService<Issue188CandidateInvocationProbe>().InvocationCount);
 		Assert.Equal(stockSnapshot.Headers, candidateSnapshot.Headers);
 		Assert.Equal(stockSnapshot.Body, candidateSnapshot.Body);
-		Assert.Equal(typeof(HtmxorComponentEndpointInvoker), candidate.GetEndpointInvokerType());
+	}
+
+	private static void ConfigureInternalCandidate(IServiceCollection services)
+	{
+		services.AddSingleton<Issue188CandidateInvocationProbe>();
+		services.AddScoped<EndpointRoutingStateProvider>();
+		services.RemoveAll<IRoutingStateProvider>();
+		services.AddScoped<IRoutingStateProvider>(serviceProvider =>
+			serviceProvider.GetRequiredService<EndpointRoutingStateProvider>());
+		services.AddScoped<HtmxorRenderer>();
+		services.AddScoped<HtmxorComponentEndpointInvoker>();
+		services.RemoveAll<IRazorComponentEndpointInvoker>();
+		services.AddScoped<IRazorComponentEndpointInvoker>(serviceProvider =>
+			new Issue188CandidateTrackingInvoker(
+				serviceProvider.GetRequiredService<HtmxorComponentEndpointInvoker>(),
+				serviceProvider.GetRequiredService<Issue188CandidateInvocationProbe>()));
+
+		RemoveStockCascadingHttpContextProvider(services);
+		services.AddCascadingValue(serviceProvider =>
+			serviceProvider.GetRequiredService<HtmxorRenderer>().HttpContext);
+	}
+
+	private static void RemoveStockCascadingHttpContextProvider(IServiceCollection services)
+	{
+		var provider = services
+			.Where(IsScopedFactory)
+			.Single(IsCascadingHttpContextProvider);
+		services.Remove(provider);
+	}
+
+	private static bool IsScopedFactory(ServiceDescriptor service)
+		=> service.Lifetime is ServiceLifetime.Scoped &&
+			service.ImplementationType is null &&
+			service.ImplementationFactory is not null;
+
+	private static bool IsCascadingHttpContextProvider(ServiceDescriptor service)
+		=> service.ImplementationFactory?.Target?.ToString()?.Contains(
+			typeof(HttpContext).FullName!,
+			StringComparison.Ordinal) == true;
+
+	private sealed class Issue188CandidateTrackingInvoker(
+		HtmxorComponentEndpointInvoker candidate,
+		Issue188CandidateInvocationProbe probe)
+		: IRazorComponentEndpointInvoker
+	{
+		public Task Render(HttpContext context)
+		{
+			probe.RecordInvocation();
+			return candidate.Render(context);
+		}
+	}
+
+	private sealed class Issue188CandidateInvocationProbe
+	{
+		private int invocationCount;
+
+		public int InvocationCount => Volatile.Read(ref invocationCount);
+
+		public void RecordInvocation() => Interlocked.Increment(ref invocationCount);
 	}
 
 	private static HttpRequestMessage CreateAuthorizedRequest()
@@ -160,7 +226,7 @@ internal sealed class Issue187ParityHost(WebApplication app, HttpClient client) 
 
 	public static async Task<Issue187ParityHost> CreateAsync(
 		bool useHtmxor,
-		bool useInternalCandidate = false)
+		Action<IServiceCollection>? configureHtmxorServices = null)
 	{
 		var builder = WebApplication.CreateBuilder(new WebApplicationOptions
 		{
@@ -187,14 +253,8 @@ internal sealed class Issue187ParityHost(WebApplication app, HttpClient client) 
 		var razorComponents = builder.Services.AddRazorComponents();
 		if (useHtmxor)
 		{
-			if (useInternalCandidate)
-			{
-				razorComponents.AddLegacyHtmx();
-			}
-			else
-			{
-				razorComponents.AddHtmxor();
-			}
+			razorComponents.AddHtmxor();
+			configureHtmxorServices?.Invoke(builder.Services);
 		}
 
 		var app = builder.Build();
@@ -218,12 +278,6 @@ internal sealed class Issue187ParityHost(WebApplication app, HttpClient client) 
 			.SelectMany(dataSource => dataSource.Endpoints)
 			.OfType<RouteEndpoint>()
 			.Single(endpoint => endpoint.Metadata.GetMetadata<ComponentTypeMetadata>()?.Type == typeof(Issue187Page));
-
-	public Type GetEndpointInvokerType()
-	{
-		using var scope = App.Services.CreateScope();
-		return scope.ServiceProvider.GetRequiredService<IRazorComponentEndpointInvoker>().GetType();
-	}
 
 	public async ValueTask DisposeAsync()
 	{

--- a/test/Htmxor.Tests/Rendering/PublicRendererComponentStateSeamTests.cs
+++ b/test/Htmxor.Tests/Rendering/PublicRendererComponentStateSeamTests.cs
@@ -74,6 +74,8 @@ public sealed class PublicRendererComponentStateSeamTests
 
 		rootMarkup.Should().Be("<main data-root=\"\"><div><section data-selected=\"\">selected:ready</section></div><aside data-root-sibling=\"\">sibling</aside></main>");
 		selectedMarkup.Should().Be("<section data-selected=\"\">selected:ready</section>");
+		typeof(StaticHtmlRenderer).IsAssignableFrom(typeof(HtmxorRenderer)).Should().BeTrue(
+			"the production renderer must write completed ComponentState output through the supported StaticHtmlRenderer boundary");
 	}
 
 	private static async Task<string> WriteHtmlAsync(RenderedComponentHtmlContent content)

--- a/test/Htmxor.Tests/Rendering/PublicRendererComponentStateSeamTests.cs
+++ b/test/Htmxor.Tests/Rendering/PublicRendererComponentStateSeamTests.cs
@@ -1,9 +1,8 @@
-using Htmxor.Rendering.Buffering;
+using Htmxor.Endpoints;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Endpoints;
 using Microsoft.AspNetCore.Components.HtmlRendering.Infrastructure;
 using Microsoft.AspNetCore.Components.Rendering;
-using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Components.Web.HtmlRendering;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit.Abstractions;
@@ -59,19 +58,17 @@ public sealed class PublicRendererComponentStateSeamTests
 		var probe = new RenderProbe();
 		var topology = new CompletedTopologyProbe();
 		var serviceCollection = new ServiceCollection().AddSingleton(probe);
-		serviceCollection.AddOptions<RazorComponentsServiceOptions>();
 		await using var services = serviceCollection.BuildServiceProvider();
 		await using var renderer = new ProductionProbeRenderer(services, topology);
-		var context = new DefaultHttpContext { RequestServices = services };
-		var renderTask = renderer.Dispatcher.InvokeAsync(async () =>
-			await renderer.RenderEndpointComponent(context, typeof(NestedBoundaryRoot), ParameterView.Empty));
+		var renderTask = renderer.Dispatcher.InvokeAsync(() =>
+			renderer.RenderEndpointComponentAsync(typeof(NestedBoundaryRoot), ParameterView.Empty));
 		await probe.SelectedInitializationEntered.Task;
 		renderTask.IsCompleted.Should().BeFalse();
 		probe.ReleaseSelectedInitialization();
 		var rendered = await renderTask;
 		var selectedComponentId = topology.ResolveSelectedComponentId();
 
-		var rootMarkup = await WriteHtmlAsync(rendered);
+		var rootMarkup = await WriteHtmlAsync(renderer, rendered);
 		var selectedMarkup = await renderer.WriteSelectedComponentHtmlAsync(selectedComponentId);
 
 		rootMarkup.Should().Be("<main data-root=\"\"><div><section data-selected=\"\">selected:ready</section></div><aside data-root-sibling=\"\">sibling</aside></main>");
@@ -80,16 +77,14 @@ public sealed class PublicRendererComponentStateSeamTests
 			"selected output must bind to the inherited framework writer, not a Htmxor copy or shadow");
 	}
 
-	private static async Task<string> WriteHtmlAsync(RenderedComponentHtmlContent content)
+	private static async Task<string> WriteHtmlAsync(StaticHtmlRenderer renderer, HtmlRootComponent content)
 	{
 		using var output = new StringWriter();
-		await using var writer = new ConditionalBufferedTextWriter(output);
-		await content.WriteToAsync(writer);
-		await writer.FlushAsync();
+		await renderer.Dispatcher.InvokeAsync(() => content.WriteHtmlTo(output));
 		return output.ToString();
 	}
 
-	private sealed class ProductionProbeRenderer : HtmxorRenderer
+	private sealed class ProductionProbeRenderer : HtmxorEndpointCandidateRenderer
 	{
 		private readonly CompletedTopologyProbe topology;
 
@@ -99,7 +94,7 @@ public sealed class PublicRendererComponentStateSeamTests
 			this.topology = topology;
 		}
 
-		protected override HtmxorComponentState CreateComponentState(
+		protected override ComponentState CreateComponentState(
 			int componentId,
 			IComponent component,
 			ComponentState? parentComponentState)
@@ -121,9 +116,7 @@ public sealed class PublicRendererComponentStateSeamTests
 		public async Task<string> WriteSelectedComponentHtmlAsync(int componentId)
 		{
 			using var output = new StringWriter();
-			await using var writer = new ConditionalBufferedTextWriter(output);
-			await Dispatcher.InvokeAsync(() => WriteComponentHtml(componentId, writer));
-			await writer.FlushAsync();
+			await Dispatcher.InvokeAsync(() => WriteCompletedComponentHtml(componentId, output));
 			return output.ToString();
 		}
 	}

--- a/test/Htmxor.Tests/Rendering/PublicRendererComponentStateSeamTests.cs
+++ b/test/Htmxor.Tests/Rendering/PublicRendererComponentStateSeamTests.cs
@@ -76,8 +76,8 @@ public sealed class PublicRendererComponentStateSeamTests
 
 		rootMarkup.Should().Be("<main data-root=\"\"><div><section data-selected=\"\">selected:ready</section></div><aside data-root-sibling=\"\">sibling</aside></main>");
 		selectedMarkup.Should().Be("<section data-selected=\"\">selected:ready</section>");
-		typeof(StaticHtmlRenderer).IsAssignableFrom(typeof(HtmxorRenderer)).Should().BeTrue(
-			"the production renderer must write completed ComponentState output through the supported StaticHtmlRenderer boundary");
+		renderer.SelectedComponentWriterOwner.Should().Be(typeof(StaticHtmlRenderer),
+			"selected output must bind to the inherited framework writer, not a Htmxor copy or shadow");
 	}
 
 	private static async Task<string> WriteHtmlAsync(RenderedComponentHtmlContent content)
@@ -107,6 +107,15 @@ public sealed class PublicRendererComponentStateSeamTests
 			var state = base.CreateComponentState(componentId, component, parentComponentState);
 			topology.Record(state);
 			return state;
+		}
+
+		public Type? SelectedComponentWriterOwner
+		{
+			get
+			{
+				Action<int, TextWriter> writeComponent = WriteComponentHtml;
+				return writeComponent.Method.DeclaringType;
+			}
 		}
 
 		public async Task<string> WriteSelectedComponentHtmlAsync(int componentId)

--- a/test/Htmxor.Tests/Rendering/PublicRendererComponentStateSeamTests.cs
+++ b/test/Htmxor.Tests/Rendering/PublicRendererComponentStateSeamTests.cs
@@ -20,8 +20,9 @@ public sealed class PublicRendererComponentStateSeamTests
 	public async Task Completed_nested_component_boundary_can_be_serialized_without_root_or_sibling()
 	{
 		var probe = new RenderProbe();
+		var topology = new CompletedTopologyProbe();
 		await using var services = new ServiceCollection().AddSingleton(probe).BuildServiceProvider();
-		await using var renderer = new ProbeRenderer(services);
+		await using var renderer = new ProbeRenderer(services, topology);
 		await renderer.Dispatcher.InvokeAsync(async () =>
 		{
 			var root = renderer.BeginRenderingComponent(typeof(NestedBoundaryRoot), ParameterView.Empty);
@@ -29,7 +30,7 @@ public sealed class PublicRendererComponentStateSeamTests
 			root.QuiescenceTask.IsCompleted.Should().BeFalse();
 			probe.ReleaseSelectedInitialization();
 			await root.QuiescenceTask;
-			var selectedComponentId = renderer.ResolveSelectedComponentIdFromCompletedTopology();
+			var selectedComponentId = topology.ResolveSelectedComponentId();
 			var rootMarkup = renderer.WriteRootComponentHtml();
 			var selectedMarkup = renderer.WriteSelectedComponentHtml(selectedComponentId);
 
@@ -56,10 +57,11 @@ public sealed class PublicRendererComponentStateSeamTests
 	public async Task Production_renderer_writes_the_root_or_one_completed_component_boundary()
 	{
 		var probe = new RenderProbe();
+		var topology = new CompletedTopologyProbe();
 		var serviceCollection = new ServiceCollection().AddSingleton(probe);
 		serviceCollection.AddOptions<RazorComponentsServiceOptions>();
 		await using var services = serviceCollection.BuildServiceProvider();
-		await using var renderer = new ProductionProbeRenderer(services);
+		await using var renderer = new ProductionProbeRenderer(services, topology);
 		var context = new DefaultHttpContext { RequestServices = services };
 		var renderTask = renderer.Dispatcher.InvokeAsync(async () =>
 			await renderer.RenderEndpointComponent(context, typeof(NestedBoundaryRoot), ParameterView.Empty));
@@ -67,7 +69,7 @@ public sealed class PublicRendererComponentStateSeamTests
 		renderTask.IsCompleted.Should().BeFalse();
 		probe.ReleaseSelectedInitialization();
 		var rendered = await renderTask;
-		var selectedComponentId = renderer.ResolveSelectedComponentIdFromCompletedTopology();
+		var selectedComponentId = topology.ResolveSelectedComponentId();
 
 		var rootMarkup = await WriteHtmlAsync(rendered);
 		var selectedMarkup = await renderer.WriteSelectedComponentHtmlAsync(selectedComponentId);
@@ -89,11 +91,12 @@ public sealed class PublicRendererComponentStateSeamTests
 
 	private sealed class ProductionProbeRenderer : HtmxorRenderer
 	{
-		private readonly List<ComponentState> componentStates = [];
+		private readonly CompletedTopologyProbe topology;
 
-		public ProductionProbeRenderer(IServiceProvider services)
+		public ProductionProbeRenderer(IServiceProvider services, CompletedTopologyProbe topology)
 			: base(services, NullLoggerFactory.Instance)
 		{
+			this.topology = topology;
 		}
 
 		protected override HtmxorComponentState CreateComponentState(
@@ -102,18 +105,8 @@ public sealed class PublicRendererComponentStateSeamTests
 			ComponentState? parentComponentState)
 		{
 			var state = base.CreateComponentState(componentId, component, parentComponentState);
-			componentStates.Add(state);
+			topology.Record(state);
 			return state;
-		}
-
-		public int ResolveSelectedComponentIdFromCompletedTopology()
-		{
-			var selected = componentStates.Single(state => state.Component is SelectedBoundary);
-			selected.ParentComponentState.Should().NotBeNull();
-			selected.ParentComponentState!.Component.Should().BeOfType<NestedBoundaryContainer>();
-			selected.ParentComponentState.ParentComponentState.Should().NotBeNull();
-			selected.ParentComponentState.ParentComponentState!.Component.Should().BeOfType<NestedBoundaryRoot>();
-			return selected.ComponentId;
 		}
 
 		public async Task<string> WriteSelectedComponentHtmlAsync(int componentId)
@@ -129,18 +122,36 @@ public sealed class PublicRendererComponentStateSeamTests
 	private sealed class ProbeRenderer : StaticHtmlRenderer
 	{
 		private int rootComponentId = -1;
-		private readonly List<ComponentState> componentStates = [];
-		public ProbeRenderer(IServiceProvider services) : base(services, NullLoggerFactory.Instance) { }
+		private readonly CompletedTopologyProbe topology;
+		public ProbeRenderer(IServiceProvider services, CompletedTopologyProbe topology) : base(services, NullLoggerFactory.Instance)
+		{
+			this.topology = topology;
+		}
 		protected override ComponentState CreateComponentState(int componentId, IComponent component, ComponentState? parentComponentState)
 		{
 			if (component is NestedBoundaryRoot) rootComponentId = componentId;
 			var state = base.CreateComponentState(componentId, component, parentComponentState);
-			componentStates.Add(state);
+			topology.Record(state);
 			return state;
 		}
 		public string WriteRootComponentHtml() => WriteComponentHtml(rootComponentId);
 		public string WriteSelectedComponentHtml(int componentId) => WriteComponentHtml(componentId);
-		public int ResolveSelectedComponentIdFromCompletedTopology()
+		private string WriteComponentHtml(int componentId)
+		{
+			componentId.Should().NotBe(-1);
+			using var writer = new StringWriter();
+			WriteComponentHtml(componentId, writer);
+			return writer.ToString();
+		}
+	}
+
+	private sealed class CompletedTopologyProbe
+	{
+		private readonly List<ComponentState> componentStates = [];
+
+		public void Record(ComponentState state) => componentStates.Add(state);
+
+		public int ResolveSelectedComponentId()
 		{
 			var selected = componentStates.Single(state => state.Component is SelectedBoundary);
 			selected.ParentComponentState.Should().NotBeNull();
@@ -148,13 +159,6 @@ public sealed class PublicRendererComponentStateSeamTests
 			selected.ParentComponentState.ParentComponentState.Should().NotBeNull();
 			selected.ParentComponentState.ParentComponentState!.Component.Should().BeOfType<NestedBoundaryRoot>();
 			return selected.ComponentId;
-		}
-		private string WriteComponentHtml(int componentId)
-		{
-			componentId.Should().NotBe(-1);
-			using var writer = new StringWriter();
-			WriteComponentHtml(componentId, writer);
-			return writer.ToString();
 		}
 	}
 

--- a/test/Htmxor.Tests/Rendering/PublicRendererComponentStateSeamTests.cs
+++ b/test/Htmxor.Tests/Rendering/PublicRendererComponentStateSeamTests.cs
@@ -1,6 +1,9 @@
+using Htmxor.Rendering.Buffering;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Endpoints;
 using Microsoft.AspNetCore.Components.HtmlRendering.Infrastructure;
 using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit.Abstractions;
@@ -47,6 +50,78 @@ public sealed class PublicRendererComponentStateSeamTests
 			output.WriteLine($"Selected component output: {selectedMarkup}");
 			output.WriteLine($"Completed lifecycle and data work: {string.Join(", ", probe.Events)}");
 		});
+	}
+
+	[Fact]
+	public async Task Production_renderer_writes_the_root_or_one_completed_component_boundary()
+	{
+		var probe = new RenderProbe();
+		var serviceCollection = new ServiceCollection().AddSingleton(probe);
+		serviceCollection.AddOptions<RazorComponentsServiceOptions>();
+		await using var services = serviceCollection.BuildServiceProvider();
+		await using var renderer = new ProductionProbeRenderer(services);
+		var context = new DefaultHttpContext { RequestServices = services };
+		var renderTask = renderer.Dispatcher.InvokeAsync(async () =>
+			await renderer.RenderEndpointComponent(context, typeof(NestedBoundaryRoot), ParameterView.Empty));
+		await probe.SelectedInitializationEntered.Task;
+		renderTask.IsCompleted.Should().BeFalse();
+		probe.ReleaseSelectedInitialization();
+		var rendered = await renderTask;
+		var selectedComponentId = renderer.ResolveSelectedComponentIdFromCompletedTopology();
+
+		var rootMarkup = await WriteHtmlAsync(rendered);
+		var selectedMarkup = await renderer.WriteSelectedComponentHtmlAsync(selectedComponentId);
+
+		rootMarkup.Should().Be("<main data-root=\"\"><div><section data-selected=\"\">selected:ready</section></div><aside data-root-sibling=\"\">sibling</aside></main>");
+		selectedMarkup.Should().Be("<section data-selected=\"\">selected:ready</section>");
+	}
+
+	private static async Task<string> WriteHtmlAsync(RenderedComponentHtmlContent content)
+	{
+		using var output = new StringWriter();
+		await using var writer = new ConditionalBufferedTextWriter(output);
+		await content.WriteToAsync(writer);
+		await writer.FlushAsync();
+		return output.ToString();
+	}
+
+	private sealed class ProductionProbeRenderer : HtmxorRenderer
+	{
+		private readonly List<ComponentState> componentStates = [];
+
+		public ProductionProbeRenderer(IServiceProvider services)
+			: base(services, NullLoggerFactory.Instance)
+		{
+		}
+
+		protected override HtmxorComponentState CreateComponentState(
+			int componentId,
+			IComponent component,
+			ComponentState? parentComponentState)
+		{
+			var state = base.CreateComponentState(componentId, component, parentComponentState);
+			componentStates.Add(state);
+			return state;
+		}
+
+		public int ResolveSelectedComponentIdFromCompletedTopology()
+		{
+			var selected = componentStates.Single(state => state.Component is SelectedBoundary);
+			selected.ParentComponentState.Should().NotBeNull();
+			selected.ParentComponentState!.Component.Should().BeOfType<NestedBoundaryContainer>();
+			selected.ParentComponentState.ParentComponentState.Should().NotBeNull();
+			selected.ParentComponentState.ParentComponentState!.Component.Should().BeOfType<NestedBoundaryRoot>();
+			return selected.ComponentId;
+		}
+
+		public async Task<string> WriteSelectedComponentHtmlAsync(int componentId)
+		{
+			using var output = new StringWriter();
+			await using var writer = new ConditionalBufferedTextWriter(output);
+			await Dispatcher.InvokeAsync(() => WriteComponentHtml(componentId, writer));
+			await writer.FlushAsync();
+			return output.ToString();
+		}
 	}
 
 	private sealed class ProbeRenderer : StaticHtmlRenderer


### PR DESCRIPTION
The inactive Htmxor endpoint candidate now handles the paired host's ordinary non-form, non-streaming static-SSR request with observable stock ASP.NET Core 10 parity while ordinary `AddHtmxor` registration continues to resolve the stock `IRazorComponentEndpointInvoker`.

The candidate is one internal upstream-aligned module. It retains the ASP.NET Core MIT license and exact v10.0.11 source provenance, uses the supported `StaticHtmlRenderer`/`ComponentState` seams, writes the rendered root by default, and preserves an internal boundary for writing one completed component ID. The paired contract covers endpoint metadata, route/query input, DI, authentication and authorization, lifecycle/quiescence, Session/TempData, route state, response status/headers, and byte-equivalent root HTML. Issue #184 monitors the adapted invoker, renderer, and cascading `HttpContext` registration shapes.

Copilot's first review identified that the monitored registration-shape selector failed with generic LINQ diagnostics. A focused test duplicates the real ASP.NET Core cascading `HttpContext` descriptor and proved the old `Sequence contains more than one matching element` failure before the candidate was changed to report the exactly-one invariant, observed count, and possible upstream drift.

Validation at exact head `36d3b60abf2b583d8de6b41ebb1ae50242f20178`:

- Focused registration diagnostic: 1/1 passed after a meaningful 1/1 red at test-only commit `1fb77ffe8315b50c6dbfa7583d4b2ccba7a0da1e`.
- Focused paired-host contract: 10/10 passed.
- Focused renderer seam: 2/2 passed, with retained selected-ID inversion/restoration evidence.
- Fast profile: 546/546 passed; Release build had 0 warnings and 0 errors.
- Full profile: 549/549 passed, including the cached-Chromium suite; two fresh coverage copies were byte-identical.
- Independent Standards and Spec reviews: 0 findings on both axes.

The focused candidate evidence uses TestServer and in-process rendering. It does not exercise forms or antiforgery, unsafe methods, navigation/failure/re-execution, persisted state, streaming, named fragments, Kestrel/browser candidate traffic, package publication, performance, or full-scope mutation.

Closes #188
