### PR TITLE
fix(rendering): preserve candidate navigation failure parity

### DIFF
--- a/src/Htmxor/Endpoints/HtmxorEndpointCandidate.cs
+++ b/src/Htmxor/Endpoints/HtmxorEndpointCandidate.cs
@@ -109,7 +109,16 @@ internal sealed class HtmxorEndpointCandidateInvoker(HtmxorEndpointCandidateRend
 		}
 
 		renderer.InitializeStandardComponentServices(context, pageComponent, request.HandlerName, request.Form);
-		var htmlContent = await renderer.RenderEndpointComponentAsync(rootComponent, ParameterView.Empty);
+		HtmlRootComponent htmlContent;
+		try
+		{
+			htmlContent = await renderer.RenderEndpointComponentAsync(rootComponent, ParameterView.Empty);
+		}
+		catch (NavigationException navigationException)
+		{
+			context.Response.Redirect(navigationException.Location);
+			return;
+		}
 		if (request.IsPost)
 		{
 			await renderer.DispatchSubmitEventAsync(request.HandlerName, out var isBadRequest);

--- a/src/Htmxor/Endpoints/HtmxorEndpointCandidate.cs
+++ b/src/Htmxor/Endpoints/HtmxorEndpointCandidate.cs
@@ -29,6 +29,7 @@ using Microsoft.AspNetCore.Components.Endpoints;
 using Microsoft.AspNetCore.Components.HtmlRendering.Infrastructure;
 using Microsoft.AspNetCore.Components.Routing;
 using Microsoft.AspNetCore.Components.Web.HtmlRendering;
+using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Routing;
@@ -92,7 +93,10 @@ internal sealed class HtmxorEndpointCandidateInvoker(HtmxorEndpointCandidateRend
 	private async Task RenderComponentCore(HttpContext context)
 	{
 		context.Response.ContentType = DefaultContentType;
-		context.Response.Headers[EnhancedNavigationHeader] = "allow";
+		if (context.Features.Get<IStatusCodeReExecuteFeature>() is null)
+		{
+			context.Response.Headers[EnhancedNavigationHeader] = "allow";
+		}
 
 		var endpoint = context.GetEndpoint()
 			?? throw new InvalidOperationException($"An endpoint must be set on the '{nameof(HttpContext)}'.");

--- a/src/Htmxor/Endpoints/HtmxorEndpointCandidate.cs
+++ b/src/Htmxor/Endpoints/HtmxorEndpointCandidate.cs
@@ -183,6 +183,7 @@ internal partial class HtmxorEndpointCandidateRenderer : StaticHtmlRenderer
 		HttpContext context, Type pageComponent, string? handler = null, IFormCollection? form = null)
 	{
 		httpContext = context;
+		notFoundEventArgs = null;
 		var navigationManager = services.GetRequiredService<NavigationManager>();
 		if (navigationManager is IHostEnvironmentNavigationManager hostNavigationManager)
 		{

--- a/src/Htmxor/Endpoints/HtmxorEndpointCandidate.cs
+++ b/src/Htmxor/Endpoints/HtmxorEndpointCandidate.cs
@@ -134,6 +134,12 @@ internal sealed class HtmxorEndpointCandidateInvoker(HtmxorEndpointCandidateRend
 
 		context.RequestServices.GetRequiredService<HtmxorEndpointCandidateFormServices>()
 			.DisableTokenGenerationForCompletedResponse(context, endpoint);
+		if (renderer.NotFoundEventArgs is not null)
+		{
+			context.Response.StatusCode = StatusCodes.Status404NotFound;
+			context.Response.ContentType = null;
+			return;
+		}
 
 		const int defaultBufferSize = 16 * 1024;
 		await using var writer = new HttpResponseStreamWriter(
@@ -152,6 +158,7 @@ internal partial class HtmxorEndpointCandidateRenderer : StaticHtmlRenderer
 	private readonly IServiceProvider services;
 	private readonly EndpointRoutingStateProvider routingState;
 	private HttpContext httpContext = default!;
+	private NotFoundEventArgs? notFoundEventArgs;
 
 	public HtmxorEndpointCandidateRenderer(IServiceProvider services, ILoggerFactory loggerFactory)
 		: this(services, loggerFactory, new EndpointRoutingStateProvider())
@@ -170,6 +177,8 @@ internal partial class HtmxorEndpointCandidateRenderer : StaticHtmlRenderer
 
 	internal HttpContext? HttpContext => httpContext;
 
+	internal NotFoundEventArgs? NotFoundEventArgs => notFoundEventArgs;
+
 	internal void InitializeStandardComponentServices(
 		HttpContext context, Type pageComponent, string? handler = null, IFormCollection? form = null)
 	{
@@ -179,6 +188,7 @@ internal partial class HtmxorEndpointCandidateRenderer : StaticHtmlRenderer
 		{
 			hostNavigationManager.Initialize(GetContextBaseUri(context.Request), GetFullUri(context.Request));
 		}
+		navigationManager.OnNotFound += (_, args) => notFoundEventArgs = args;
 
 		var authenticationStateProvider = services.GetService<AuthenticationStateProvider>();
 		if (authenticationStateProvider is IHostEnvironmentAuthenticationStateProvider hostAuthenticationStateProvider)

--- a/test/Htmxor.AspNetCore10.Tests/Issue187ParityTests.cs
+++ b/test/Htmxor.AspNetCore10.Tests/Issue187ParityTests.cs
@@ -362,6 +362,7 @@ internal sealed class Issue187ParityHost(WebApplication app, HttpClient client) 
 
 	private static void ConfigurePipeline(WebApplication app, Issue187ParityHostOptions options)
 	{
+		options.BeforeSession?.Invoke(app);
 		app.UseSession();
 		app.UseAuthentication();
 		app.UseAuthorization();
@@ -471,6 +472,8 @@ internal sealed class Issue187ParityHostOptions
 	public Action<RazorComponentsEndpointConventionBuilder> ConfigureEndpoints { get; init; } = _ => { };
 
 	public Action<IServiceCollection>? ConfigureServices { get; init; }
+
+	public Action<WebApplication>? BeforeSession { get; init; }
 
 	public Action<WebApplication>? BeforeAntiforgery { get; init; }
 

--- a/test/Htmxor.AspNetCore10.Tests/Issue187ParityTests.cs
+++ b/test/Htmxor.AspNetCore10.Tests/Issue187ParityTests.cs
@@ -311,11 +311,18 @@ internal sealed class Issue187ParityHost(WebApplication app, HttpClient client) 
 		bool useHtmxor,
 		Action<IServiceCollection>? configureHtmxorServices = null,
 		Issue187ParityHostOptions? options = null)
+		=> await CreateAsync<Issue187App>(useHtmxor, configureHtmxorServices, options);
+
+	public static async Task<Issue187ParityHost> CreateAsync<TRootComponent>(
+		bool useHtmxor,
+		Action<IServiceCollection>? configureHtmxorServices = null,
+		Issue187ParityHostOptions? options = null)
+		where TRootComponent : IComponent
 	{
 		options ??= new();
 		var builder = WebApplication.CreateBuilder(new WebApplicationOptions
 		{
-			ApplicationName = typeof(Issue187App).Assembly.GetName().Name,
+			ApplicationName = typeof(TRootComponent).Assembly.GetName().Name,
 			EnvironmentName = options.EnvironmentName,
 		});
 		builder.WebHost.UseTestServer();
@@ -348,7 +355,7 @@ internal sealed class Issue187ParityHost(WebApplication app, HttpClient client) 
 		options.ConfigureServices?.Invoke(builder.Services);
 		var app = builder.Build();
 		ConfigurePipeline(app, options);
-		var endpoints = app.MapRazorComponents<Issue187App>()
+		var endpoints = app.MapRazorComponents<TRootComponent>()
 			.WithMetadata(Issue187EndpointMetadata.Instance);
 		options.ConfigureEndpoints(endpoints);
 		if (useHtmxor)

--- a/test/Htmxor.AspNetCore10.Tests/Issue190ExceptionHandlerParityTests.cs
+++ b/test/Htmxor.AspNetCore10.Tests/Issue190ExceptionHandlerParityTests.cs
@@ -1,0 +1,87 @@
+using System.Net;
+using Htmxor.Endpoints;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Components.Endpoints;
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Htmxor.AspNetCore10;
+
+public sealed class Issue190ExceptionHandlerParityTests
+{
+	[Fact]
+	public async Task Candidate_selected_component_precommit_exception_has_stock_error_handler_parity()
+	{
+		await using var stock = await Issue190ExceptionHandlerHost.CreateAsync(useCandidate: false);
+		await using var candidate = await Issue190ExceptionHandlerHost.CreateAsync(useCandidate: true);
+
+		using var stockResponse = await stock.Client.GetAsync(Issue190ExceptionHandlerHost.OriginPath);
+		using var candidateResponse = await candidate.Client.GetAsync(Issue190ExceptionHandlerHost.OriginPath);
+		var stockSnapshot = await Issue187ResponseSnapshot.CreateAsync(stockResponse);
+		var candidateSnapshot = await Issue187ResponseSnapshot.CreateAsync(candidateResponse);
+
+		Assert.Equal(HttpStatusCode.InternalServerError, stockSnapshot.StatusCode);
+		Assert.Equal(
+			$"exception-handler:{Issue190ExceptionHandlerHost.OriginPath}:InvalidOperationException",
+			stockSnapshot.Body);
+		Assert.Equal("pre-commit", stockSnapshot.Headers["X-Issue-190-Exception-Handler"]);
+		Assert.Equal(["origin", $"handler:{Issue190ExceptionHandlerHost.OriginPath}:InvalidOperationException"], stock.Lifecycle.Events);
+		Assert.Equal(stockSnapshot.StatusCode, candidateSnapshot.StatusCode);
+		Assert.Equal(stockSnapshot.Headers, candidateSnapshot.Headers);
+		Assert.Equal(stockSnapshot.Body, candidateSnapshot.Body);
+		Assert.Equal(stock.Lifecycle.Events, candidate.Lifecycle.Events);
+	}
+}
+
+internal sealed class Issue190ExceptionHandlerHost(Issue187ParityHost host, Issue190ExceptionHandlerJournal lifecycle) : IAsyncDisposable
+{
+	public const string OriginPath = "/issue-190/exception-origin";
+
+	public HttpClient Client => host.Client;
+
+	public Issue190ExceptionHandlerJournal Lifecycle { get; } = lifecycle;
+
+	public static async Task<Issue190ExceptionHandlerHost> CreateAsync(bool useCandidate)
+	{
+		var options = new Issue187ParityHostOptions
+		{
+			EnvironmentName = Environments.Production,
+			ConfigureServices = services => services.AddSingleton<Issue190ExceptionHandlerJournal>(),
+			BeforeSession = app =>
+			{
+				app.UseExceptionHandler(errorApp => errorApp.Run(HandleExceptionAsync));
+			},
+		};
+		var host = await Issue187ParityHost.CreateAsync(
+			useHtmxor: useCandidate,
+			configureHtmxorServices: useCandidate ? HtmxorEndpointCandidateServices.Add : null,
+			options: options);
+		return new(host, host.App.Services.GetRequiredService<Issue190ExceptionHandlerJournal>());
+	}
+
+	public ValueTask DisposeAsync() => host.DisposeAsync();
+
+	private static async Task HandleExceptionAsync(HttpContext context)
+	{
+		var feature = context.Features.Get<IExceptionHandlerPathFeature>()
+			?? throw new InvalidOperationException("The exception handler feature was not available.");
+		var errorType = feature.Error.GetType().Name;
+		context.RequestServices.GetRequiredService<Issue190ExceptionHandlerJournal>()
+			.Record($"handler:{feature.Path}:{errorType}");
+		context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+		context.Response.ContentType = "text/plain";
+		context.Response.Headers["X-Issue-190-Exception-Handler"] = "pre-commit";
+		await context.Response.WriteAsync($"exception-handler:{feature.Path}:{errorType}");
+	}
+}
+
+internal sealed class Issue190ExceptionHandlerJournal
+{
+	private readonly List<string> events = [];
+
+	public IReadOnlyList<string> Events => events;
+
+	public void Record(string value) => events.Add(value);
+}

--- a/test/Htmxor.AspNetCore10.Tests/Issue190ExceptionOriginPage.razor
+++ b/test/Htmxor.AspNetCore10.Tests/Issue190ExceptionOriginPage.razor
@@ -1,0 +1,12 @@
+@page "/issue-190/exception-origin"
+@inject Issue190ExceptionHandlerJournal Journal
+
+<main data-issue-190-exception-origin>unreachable</main>
+
+@code {
+    protected override void OnInitialized()
+    {
+        Journal.Record("origin");
+        throw new InvalidOperationException("issue-190 pre-commit component exception");
+    }
+}

--- a/test/Htmxor.AspNetCore10.Tests/Issue190ExternalNavigationPage.razor
+++ b/test/Htmxor.AspNetCore10.Tests/Issue190ExternalNavigationPage.razor
@@ -1,0 +1,15 @@
+@page "/issue-190/navigate-external"
+@inject NavigationManager Navigation
+@inject Issue190LifecycleJournal Lifecycle
+
+<main data-issue-190-external-output>unreachable</main>
+
+@code {
+    protected override void OnInitialized()
+    {
+        Lifecycle.Record("external-initialized");
+        Navigation.NavigateTo(Issue190ExternalNavigationContract.Destination);
+    }
+
+    protected override void OnParametersSet() => Lifecycle.Record("external-parameters-set");
+}

--- a/test/Htmxor.AspNetCore10.Tests/Issue190NavigationPage.razor
+++ b/test/Htmxor.AspNetCore10.Tests/Issue190NavigationPage.razor
@@ -1,0 +1,15 @@
+@page "/issue-190/navigate"
+@inject NavigationManager Navigation
+@inject Issue190LifecycleJournal Lifecycle
+
+<main data-issue-190-output>unreachable</main>
+
+@code {
+    protected override void OnInitialized()
+    {
+        Lifecycle.Record("initialized");
+        Navigation.NavigateTo("/issue-190/destination");
+    }
+
+    protected override void OnParametersSet() => Lifecycle.Record("parameters-set");
+}

--- a/test/Htmxor.AspNetCore10.Tests/Issue190NavigationParityTests.cs
+++ b/test/Htmxor.AspNetCore10.Tests/Issue190NavigationParityTests.cs
@@ -28,6 +28,56 @@ public sealed class Issue190NavigationParityTests
 		Assert.Equal(stock.Lifecycle.Events, candidate.Lifecycle.Events);
 		Assert.DoesNotContain("data-issue-190-output", stockSnapshot.Body, StringComparison.Ordinal);
 	}
+
+	[Fact]
+	public async Task Candidate_selected_component_external_navigation_before_output_has_stock_redirect_parity()
+	{
+		await using var stock = await Issue190NavigationHost.CreateAsync(useCandidate: false);
+		await using var candidate = await Issue190NavigationHost.CreateAsync(useCandidate: true);
+
+		using var stockResponse = await SendEnhancedNavigationRequestAsync(stock.Client);
+		using var candidateResponse = await SendEnhancedNavigationRequestAsync(candidate.Client);
+		var stockSnapshot = await Issue187ResponseSnapshot.CreateAsync(stockResponse);
+		var candidateSnapshot = await Issue187ResponseSnapshot.CreateAsync(candidateResponse);
+
+		Assert.Equal(HttpStatusCode.Found, stockSnapshot.StatusCode);
+		Assert.Equal(stockSnapshot.StatusCode, candidateSnapshot.StatusCode);
+		Assert.Equal(stockSnapshot.Headers["blazor-enhanced-nav"], candidateSnapshot.Headers["blazor-enhanced-nav"]);
+		Assert.Equal(stockSnapshot.Body, candidateSnapshot.Body);
+		Assert.Equal(["external-initialized"], stock.Lifecycle.Events);
+		Assert.Equal(stock.Lifecycle.Events, candidate.Lifecycle.Events);
+		Assert.DoesNotContain("data-issue-190-external-output", stockSnapshot.Body, StringComparison.Ordinal);
+
+		await AssertRedirectDestinationAsync(stock.Client, stockSnapshot.Headers["Location"]);
+		await AssertRedirectDestinationAsync(candidate.Client, candidateSnapshot.Headers["Location"]);
+		Assert.Equal(stockSnapshot.Headers, candidateSnapshot.Headers);
+	}
+
+	private static async Task<HttpResponseMessage> SendEnhancedNavigationRequestAsync(HttpClient client)
+	{
+		using var request = new HttpRequestMessage(HttpMethod.Get, Issue190ExternalNavigationContract.Path);
+		request.Headers.Add("blazor-enhanced-nav", "allow");
+		return await client.SendAsync(request);
+	}
+
+	private static async Task AssertRedirectDestinationAsync(HttpClient client, string location)
+	{
+		if (location == Issue190ExternalNavigationContract.Destination)
+		{
+			return;
+		}
+
+		Assert.StartsWith("_framework/opaque-redirect?url=", location, StringComparison.Ordinal);
+		using var redirectResponse = await client.GetAsync(new Uri(client.BaseAddress!, location));
+		Assert.Equal(HttpStatusCode.Found, redirectResponse.StatusCode);
+		Assert.Equal(Issue190ExternalNavigationContract.Destination, redirectResponse.Headers.Location?.OriginalString);
+	}
+}
+
+internal static class Issue190ExternalNavigationContract
+{
+	public const string Destination = "https://example.invalid/issue-190/external-destination?source=navigation";
+	public const string Path = "/issue-190/navigate-external";
 }
 
 internal sealed class Issue190NavigationHost(Issue187ParityHost host, Issue190LifecycleJournal lifecycle) : IAsyncDisposable

--- a/test/Htmxor.AspNetCore10.Tests/Issue190NavigationParityTests.cs
+++ b/test/Htmxor.AspNetCore10.Tests/Issue190NavigationParityTests.cs
@@ -1,0 +1,79 @@
+using System.Net;
+using Htmxor.Endpoints;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Components.Endpoints;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Htmxor.AspNetCore10;
+
+public sealed class Issue190NavigationParityTests
+{
+	[Fact]
+	public async Task Candidate_selected_component_navigation_before_output_has_stock_redirect_parity()
+	{
+		await using var stock = await Issue190NavigationHost.CreateAsync(useCandidate: false);
+		await using var candidate = await Issue190NavigationHost.CreateAsync(useCandidate: true);
+
+		using var stockResponse = await stock.Client.GetAsync(Issue190NavigationHost.Path);
+		using var candidateResponse = await candidate.Client.GetAsync(Issue190NavigationHost.Path);
+		var stockSnapshot = await Issue187ResponseSnapshot.CreateAsync(stockResponse);
+		var candidateSnapshot = await Issue187ResponseSnapshot.CreateAsync(candidateResponse);
+
+		Assert.Equal(HttpStatusCode.Found, stockSnapshot.StatusCode);
+		Assert.Equal(stockSnapshot.StatusCode, candidateSnapshot.StatusCode);
+		Assert.Equal(stockSnapshot.Headers, candidateSnapshot.Headers);
+		Assert.Equal(stockSnapshot.Body, candidateSnapshot.Body);
+		Assert.Equal(["initialized"], stock.Lifecycle.Events);
+		Assert.Equal(stock.Lifecycle.Events, candidate.Lifecycle.Events);
+		Assert.DoesNotContain("data-issue-190-output", stockSnapshot.Body, StringComparison.Ordinal);
+	}
+}
+
+internal sealed class Issue190NavigationHost(Issue187ParityHost host, Issue190LifecycleJournal lifecycle) : IAsyncDisposable
+{
+	public const string Path = "/issue-190/navigate";
+
+	public HttpClient Client => host.Client;
+
+	public Issue190LifecycleJournal Lifecycle { get; } = lifecycle;
+
+	public static async Task<Issue190NavigationHost> CreateAsync(bool useCandidate)
+	{
+		var options = new Issue187ParityHostOptions
+		{
+			ConfigureServices = services => services.AddSingleton<Issue190LifecycleJournal>(),
+			BeforeAntiforgery = app => app.Use(CaptureEndpointFailureAsync),
+		};
+		var host = await Issue187ParityHost.CreateAsync(
+			useHtmxor: useCandidate,
+			configureHtmxorServices: useCandidate ? HtmxorEndpointCandidateServices.Add : null,
+			options: options);
+		return new(host, host.App.Services.GetRequiredService<Issue190LifecycleJournal>());
+	}
+
+	public ValueTask DisposeAsync() => host.DisposeAsync();
+
+	private static async Task CaptureEndpointFailureAsync(HttpContext context, RequestDelegate next)
+	{
+		try
+		{
+			await next(context);
+		}
+		catch (Exception exception) when (!context.Response.HasStarted)
+		{
+			context.Response.Clear();
+			context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+			await context.Response.WriteAsync(exception.GetType().FullName!);
+		}
+	}
+}
+
+internal sealed class Issue190LifecycleJournal
+{
+	private readonly List<string> events = [];
+
+	public IReadOnlyList<string> Events => events;
+
+	public void Record(string value) => events.Add(value);
+}

--- a/test/Htmxor.AspNetCore10.Tests/Issue190NotFoundApp.razor
+++ b/test/Htmxor.AspNetCore10.Tests/Issue190NotFoundApp.razor
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<body>
+    <Router AppAssembly="typeof(Issue190NotFoundApp).Assembly">
+        <Found Context="routeData">
+            <RouteView RouteData="routeData" />
+        </Found>
+        <NotFound>
+            <Issue190RouterNotFound />
+        </NotFound>
+    </Router>
+</body>
+</html>

--- a/test/Htmxor.AspNetCore10.Tests/Issue190NotFoundParityTests.cs
+++ b/test/Htmxor.AspNetCore10.Tests/Issue190NotFoundParityTests.cs
@@ -58,11 +58,6 @@ internal sealed class Issue190NotFoundHost(Issue187ParityHost host, Issue190NotF
 	private static async Task ObserveResponseAsync(HttpContext context, RequestDelegate next)
 	{
 		var journal = context.RequestServices.GetRequiredService<Issue190NotFoundJournal>();
-		context.Response.OnStarting(() =>
-		{
-			journal.Record($"response:starting:{context.Response.StatusCode}:{context.Response.ContentType}");
-			return Task.CompletedTask;
-		});
 		await next(context);
 		journal.Record($"response:completed:{context.Response.HasStarted}");
 	}

--- a/test/Htmxor.AspNetCore10.Tests/Issue190NotFoundParityTests.cs
+++ b/test/Htmxor.AspNetCore10.Tests/Issue190NotFoundParityTests.cs
@@ -1,0 +1,78 @@
+using System.Net;
+using Htmxor.Endpoints;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Htmxor.AspNetCore10;
+
+public sealed class Issue190NotFoundParityTests
+{
+	[Fact]
+	public async Task Candidate_selected_component_router_not_found_has_stock_http_flush_and_lifecycle_parity()
+	{
+		await using var stock = await Issue190NotFoundHost.CreateAsync(useCandidate: false);
+		await using var candidate = await Issue190NotFoundHost.CreateAsync(useCandidate: true);
+
+		using var stockResponse = await stock.Client.GetAsync(Issue190NotFoundHost.Path);
+		using var candidateResponse = await candidate.Client.GetAsync(Issue190NotFoundHost.Path);
+		var stockSnapshot = await Issue187ResponseSnapshot.CreateAsync(stockResponse);
+		var candidateSnapshot = await Issue187ResponseSnapshot.CreateAsync(candidateResponse);
+
+		Assert.Equal(HttpStatusCode.NotFound, stockSnapshot.StatusCode);
+		Assert.DoesNotContain(stockSnapshot.Headers, header =>
+			header.Key.Equals("Content-Type", StringComparison.OrdinalIgnoreCase));
+		Assert.Empty(stockSnapshot.Body);
+		Assert.Equal(stockSnapshot.StatusCode, candidateSnapshot.StatusCode);
+		Assert.Equal(stockSnapshot.Headers, candidateSnapshot.Headers);
+		Assert.Equal(stockSnapshot.Body, candidateSnapshot.Body);
+		Assert.Equal(["origin:initialized", "response:completed:False"], stock.Journal.Events);
+		Assert.Equal(stock.Journal.Events, candidate.Journal.Events);
+	}
+}
+
+internal sealed class Issue190NotFoundHost(Issue187ParityHost host, Issue190NotFoundJournal journal) : IAsyncDisposable
+{
+	public const string Path = "/issue-190/router-not-found-origin";
+
+	public HttpClient Client => host.Client;
+
+	public Issue190NotFoundJournal Journal { get; } = journal;
+
+	public static async Task<Issue190NotFoundHost> CreateAsync(bool useCandidate)
+	{
+		var options = new Issue187ParityHostOptions
+		{
+			ConfigureServices = services => services.AddSingleton<Issue190NotFoundJournal>(),
+			AfterAntiforgery = app => app.Use(ObserveResponseAsync),
+		};
+		var host = await Issue187ParityHost.CreateAsync<Issue190NotFoundApp>(
+			useHtmxor: useCandidate,
+			configureHtmxorServices: useCandidate ? HtmxorEndpointCandidateServices.Add : null,
+			options: options);
+		return new(host, host.App.Services.GetRequiredService<Issue190NotFoundJournal>());
+	}
+
+	public ValueTask DisposeAsync() => host.DisposeAsync();
+
+	private static async Task ObserveResponseAsync(HttpContext context, RequestDelegate next)
+	{
+		var journal = context.RequestServices.GetRequiredService<Issue190NotFoundJournal>();
+		context.Response.OnStarting(() =>
+		{
+			journal.Record($"response:starting:{context.Response.StatusCode}:{context.Response.ContentType}");
+			return Task.CompletedTask;
+		});
+		await next(context);
+		journal.Record($"response:completed:{context.Response.HasStarted}");
+	}
+}
+
+internal sealed class Issue190NotFoundJournal
+{
+	private readonly List<string> events = [];
+
+	public IReadOnlyList<string> Events => events;
+
+	public void Record(string value) => events.Add(value);
+}

--- a/test/Htmxor.AspNetCore10.Tests/Issue190RouterNotFound.razor
+++ b/test/Htmxor.AspNetCore10.Tests/Issue190RouterNotFound.razor
@@ -1,0 +1,10 @@
+@inject Issue190NotFoundJournal Journal
+
+<main data-issue-190-router-not-found>router-not-found</main>
+
+@code {
+    protected override void OnInitialized()
+    {
+        Journal.Record("component:initialized");
+    }
+}

--- a/test/Htmxor.AspNetCore10.Tests/Issue190RouterOrigin.razor
+++ b/test/Htmxor.AspNetCore10.Tests/Issue190RouterOrigin.razor
@@ -1,0 +1,13 @@
+@page "/issue-190/router-not-found-origin"
+@inject Issue190NotFoundJournal Journal
+@inject NavigationManager Navigation
+
+<main data-issue-190-router-origin>unreachable</main>
+
+@code {
+    protected override void OnInitialized()
+    {
+        Journal.Record("origin:initialized");
+        Navigation.NotFound();
+    }
+}

--- a/test/Htmxor.AspNetCore10.Tests/Issue190StatusOriginPage.razor
+++ b/test/Htmxor.AspNetCore10.Tests/Issue190StatusOriginPage.razor
@@ -1,0 +1,3 @@
+@page "/issue-190/status-origin"
+
+<main data-issue-190-status-origin>unreachable</main>

--- a/test/Htmxor.AspNetCore10.Tests/Issue190StatusPage.razor
+++ b/test/Htmxor.AspNetCore10.Tests/Issue190StatusPage.razor
@@ -1,0 +1,25 @@
+@page "/issue-190/status"
+@using Microsoft.AspNetCore.Diagnostics
+@inject Issue190StatusReexecutionJournal Journal
+
+<main data-issue-190-status-page
+      data-original-path="@OriginalPath"
+      data-request-path="@HttpContext.Request.Path"
+      data-original-status="@OriginalStatus">status-output</main>
+
+@code {
+    [CascadingParameter]
+    private HttpContext HttpContext { get; set; } = default!;
+
+    private string OriginalPath { get; set; } = default!;
+
+    private int OriginalStatus { get; set; }
+
+    protected override void OnInitialized()
+    {
+        var feature = HttpContext.Features.Get<IStatusCodeReExecuteFeature>();
+        OriginalPath = feature?.OriginalPath ?? "missing";
+        OriginalStatus = HttpContext.Response.StatusCode;
+        Journal.Record($"status:{OriginalPath}:{HttpContext.Request.Path}:{OriginalStatus}");
+    }
+}

--- a/test/Htmxor.AspNetCore10.Tests/Issue190StatusReexecutionParityTests.cs
+++ b/test/Htmxor.AspNetCore10.Tests/Issue190StatusReexecutionParityTests.cs
@@ -1,0 +1,85 @@
+using System.Net;
+using Htmxor.Endpoints;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Htmxor.AspNetCore10;
+
+public sealed class Issue190StatusReexecutionParityTests
+{
+	[Fact]
+	public async Task Candidate_selected_component_status_code_reexecution_has_stock_http_and_lifecycle_parity()
+	{
+		await using var stock = await Issue190StatusReexecutionHost.CreateAsync(useCandidate: false);
+		await using var candidate = await Issue190StatusReexecutionHost.CreateAsync(useCandidate: true);
+
+		using var stockResponse = await stock.Client.GetAsync(Issue190StatusReexecutionHost.OriginPath);
+		using var candidateResponse = await candidate.Client.GetAsync(Issue190StatusReexecutionHost.OriginPath);
+		var stockSnapshot = await Issue187ResponseSnapshot.CreateAsync(stockResponse);
+		var candidateSnapshot = await Issue187ResponseSnapshot.CreateAsync(candidateResponse);
+
+		Assert.Equal(HttpStatusCode.NotFound, stockSnapshot.StatusCode);
+		Assert.Equal(stockSnapshot.StatusCode, candidateSnapshot.StatusCode);
+		Assert.Equal(stockSnapshot.Body, candidateSnapshot.Body);
+		Assert.Contains("data-issue-190-status-page", stockSnapshot.Body, StringComparison.Ordinal);
+		Assert.Contains($"data-original-path=\"{Issue190StatusReexecutionHost.OriginPath}\"", stockSnapshot.Body, StringComparison.Ordinal);
+		Assert.Contains($"data-request-path=\"{Issue190StatusReexecutionHost.StatusPath}\"", stockSnapshot.Body, StringComparison.Ordinal);
+		Assert.Contains("data-original-status=\"404\"", stockSnapshot.Body, StringComparison.Ordinal);
+		Assert.DoesNotContain("data-issue-190-status-origin", stockSnapshot.Body, StringComparison.Ordinal);
+		Assert.Equal([$"status:{Issue190StatusReexecutionHost.OriginPath}:{Issue190StatusReexecutionHost.StatusPath}:404"], stock.Lifecycle.Events);
+		Assert.Equal(stock.Lifecycle.Events, candidate.Lifecycle.Events);
+		Assert.Equal(stockSnapshot.Headers, candidateSnapshot.Headers);
+	}
+}
+
+internal sealed class Issue190StatusReexecutionHost(Issue187ParityHost host, Issue190StatusReexecutionJournal lifecycle) : IAsyncDisposable
+{
+	public const string OriginPath = "/issue-190/status-origin";
+	public const string StatusPath = "/issue-190/status";
+
+	public HttpClient Client => host.Client;
+
+	public Issue190StatusReexecutionJournal Lifecycle { get; } = lifecycle;
+
+	public static async Task<Issue190StatusReexecutionHost> CreateAsync(bool useCandidate)
+	{
+		var options = new Issue187ParityHostOptions
+		{
+			ConfigureServices = services => services.AddSingleton<Issue190StatusReexecutionJournal>(),
+			BeforeSession = app =>
+			{
+				app.UseStatusCodePagesWithReExecute(StatusPath);
+				app.Use(StatusOriginAsync);
+				app.UseRouting();
+			},
+		};
+		var host = await Issue187ParityHost.CreateAsync(
+			useHtmxor: useCandidate,
+			configureHtmxorServices: useCandidate ? HtmxorEndpointCandidateServices.Add : null,
+			options: options);
+		return new(host, host.App.Services.GetRequiredService<Issue190StatusReexecutionJournal>());
+	}
+
+	public ValueTask DisposeAsync() => host.DisposeAsync();
+
+	private static Task StatusOriginAsync(HttpContext context, RequestDelegate next)
+	{
+		if (context.Request.Path == OriginPath)
+		{
+			context.Response.StatusCode = StatusCodes.Status404NotFound;
+			return Task.CompletedTask;
+		}
+
+		return next(context);
+	}
+}
+
+internal sealed class Issue190StatusReexecutionJournal
+{
+	private readonly List<string> events = [];
+
+	public IReadOnlyList<string> Events => events;
+
+	public void Record(string value) => events.Add(value);
+}


### PR DESCRIPTION
Closes #190\n\nThe inactive candidate now matches stock pre-commit navigation redirects, component not-found handling, status-code reexecution headers, and exception-handler behavior.\n\nValidation: fast 933/933; full 941/941 with matching coverage copies; focused Issue190 5/5; separate Standards and Spec reviews found no issues.