### PR TITLE
feat(fragments): select flat fragments by stable server name

### DIFF
--- a/docs/engineering/fragment-selection.md
+++ b/docs/engineering/fragment-selection.md
@@ -64,8 +64,20 @@ query value and added distinct-case selection, bringing that boundary to 12
 cases. Focused red is retained in `artifacts/issue168/red/issue168-red.trx`;
 packed red and green output are retained under `artifacts/issue168/package/`.
 
+The routine full profile also found four existing packaged browser fixtures
+whose `Match`, `RenderDuringStandardRequest`, implicit ID selection, and
+skipped-descendant expectations belonged to the legacy renderer. The #122,
+#137, #139, and #144 fixtures now select explicit names. Application-authored
+Razor conditions retain their normal-page controls and direct-request async
+gates. Their assertions retain exact selected response content, browser
+completion ordering, and request isolation, while recording completed excluded
+descendant work. The existing published-package Chromium suite passed all 39
+cases after this fixture-only migration. Its preceding four failures are retained
+in `artifacts/issue168/full-before-fixture-migration.log` and the matching TRX.
+
 Nested selection, complete invalid-name validation and diagnostics, overlapping
 sets, concurrent requests, cancellation, browser delivery, caching, and
-skipped-work optimization remain separately owned. These tests make no browser,
-non-Linux, other-framework, or release-candidate package claim. Full-scope
-mutation is not part of this ordinary issue check.
+skipped-work optimization retain their separately owned acceptance contracts.
+The migrated conformance fixtures do not establish those complete contracts.
+No non-Linux, other-framework, other-browser, or release-candidate package claim
+is made. Full-scope mutation is not part of this ordinary issue check.

--- a/docs/engineering/fragment-selection.md
+++ b/docs/engineering/fragment-selection.md
@@ -1,0 +1,71 @@
+# Server fragment selection
+
+Issue [#168](https://github.com/egil/Htmxor/issues/168) implements the valid flat
+selection portion of the approved
+[#167 contract](https://github.com/egil/Htmxor/issues/167#issuecomment-5531911245).
+
+When application code selects whole, one stable fragment name, or an ordered
+valid flat set during a direct request, Htmxor completes normal rendering and
+emits exactly the component-owned HTML in caller order.
+
+`HtmxFragment.Name` identifies a server fragment. It is case-sensitive, does not
+emit an HTML attribute, and does not request a wrapper. `Element`, `Id`, and
+additional attributes independently request and describe optional wrapper
+markup. Neither wrapper identifiers nor `HX-Target` or `HX-Source` choose server
+fragments.
+
+Component-instance code uses the request's `HtmxContext.Response`:
+
+```csharp
+Htmx.Response.SelectWholeComponent();
+Htmx.Response.SelectFragment("Totals");
+Htmx.Response.SelectFragments("Totals", "Rows");
+```
+
+Each operation replaces the previous selection and returns the same response
+object. `SelectedFragmentNames` exposes a read-only snapshot in caller order;
+an empty list means whole-component selection. The response copies the caller's
+array. Selection operations can run in normal lifecycle code on either request
+path. Normal requests always emit the complete page; direct requests default to
+the whole routed component, without the page shell.
+
+The active endpoint renderer records real `HtmxFragment` component states while
+Blazor constructs the tree. It reads their final names and resolves all selected
+component IDs before writing any selected HTML. The writer delegates each
+boundary to the existing monitored renderer seam. It does not parse a completed
+response or invoke application render fragments to discover topology. Direct
+responses wait for complete rendering. Excluded branches may perform lifecycle,
+rendering, and data work; selection makes no skipped-work claim.
+
+The legacy conditional renderer retains `Match`, `RenderDuringStandardRequest`,
+and implicit ID matching pending the separately owned legacy removal work. The
+active v1 endpoint renderer ignores those legacy filters and constructs all
+fragment content before choosing response output.
+
+## Verification scope
+
+The focused component-state tests prove whole/default selection, normal-request
+output, single selection, reversed caller order, copied read-only introspection,
+and separate request state. The independently packed static-SSR HTTP consumer
+proves exact normal and direct bodies, optional wrapper forms, distinct-case
+names, header independence, and quiescent child rendering with scoped injection.
+
+Meaningful red was recorded on base
+`1abdf719afdaedc79ad604d57a45cc5a89aa2114` with the public API and tests present
+but the writer still serializing the root:
+
+| Boundary | Executed | Passed | Failed | Failure |
+| --- | ---: | ---: | ---: | --- |
+| Focused renderer | 6 | 4 | 2 | Single and ordered selections received root and sibling HTML |
+| Packed HTTP consumer | 11 | 2 | 9 | Selected responses received root HTML; legacy target matching omitted an ID wrapper |
+
+The packed green fixture also corrected its default request to omit an empty
+query value and added distinct-case selection, bringing that boundary to 12
+cases. Focused red is retained in `artifacts/issue168/red/issue168-red.trx`;
+packed red and green output are retained under `artifacts/issue168/package/`.
+
+Nested selection, complete invalid-name validation and diagnostics, overlapping
+sets, concurrent requests, cancellation, browser delivery, caching, and
+skipped-work optimization remain separately owned. These tests make no browser,
+non-Linux, other-framework, or release-candidate package claim. Full-scope
+mutation is not part of this ordinary issue check.

--- a/docs/roadmap/v1/issue-154-package-public-surface.txt
+++ b/docs/roadmap/v1/issue-154-package-public-surface.txt
@@ -42,18 +42,21 @@ TYPE Htmxor.Components.HtmxFragment [kind=class;abstract=False;sealed=False;gene
   Method [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=0] System.String get_Element()
   Method [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=0] System.String get_Id()
   Method [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=0] System.Func`2[Htmxor.Http.HtmxRequest,System.Boolean] get_Match()
+  Method [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=0] System.String get_Name()
   Method [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=0] Boolean get_RenderDuringStandardRequest()
   Method [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=1] Void set_AdditionalAttributes(System.Collections.Generic.IDictionary`2[System.String,System.Object])
   Method [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=1] Void set_ChildContent(Microsoft.AspNetCore.Components.RenderFragment)
   Method [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=1] Void set_Element(System.String)
   Method [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=1] Void set_Id(System.String)
   Method [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=1] Void set_Match(System.Func`2[Htmxor.Http.HtmxRequest,System.Boolean])
+  Method [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=1] Void set_Name(System.String)
   Method [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=1] Void set_RenderDuringStandardRequest(Boolean)
   Property [visibility=public|public;static=False;get=public,instance;set=public,instance] System.Collections.Generic.IDictionary`2[System.String,System.Object] AdditionalAttributes
   Property [visibility=public|public;static=False;get=public,instance;set=public,instance] Microsoft.AspNetCore.Components.RenderFragment ChildContent
   Property [visibility=public|public;static=False;get=public,instance;set=public,instance] System.String Element
   Property [visibility=public|public;static=False;get=public,instance;set=public,instance] System.String Id
   Property [visibility=public|public;static=False;get=public,instance;set=public,instance] System.Func`2[Htmxor.Http.HtmxRequest,System.Boolean] Match
+  Property [visibility=public|public;static=False;get=public,instance;set=public,instance] System.String Name
   Property [visibility=public|public;static=False;get=public,instance;set=public,instance] Boolean RenderDuringStandardRequest
 TYPE Htmxor.Components.HtmxHeadOutlet [kind=class;abstract=False;sealed=False;genericArity=0;base=System.Object]
   Constructor [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=0] Void .ctor()
@@ -164,10 +167,15 @@ TYPE Htmxor.Http.HtmxResponse [kind=class;abstract=False;sealed=True;genericArit
   Method [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=1] Htmxor.Http.HtmxResponse Reselect(System.String)
   Method [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=1] Htmxor.Http.HtmxResponse Reswap(System.String)
   Method [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=1] Htmxor.Http.HtmxResponse Retarget(System.String)
+  Method [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=1] Htmxor.Http.HtmxResponse SelectFragment(System.String)
+  Method [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=1] Htmxor.Http.HtmxResponse SelectFragments(System.String[])
+  Method [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=0] Htmxor.Http.HtmxResponse SelectWholeComponent()
   Method [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=2] Htmxor.Http.HtmxResponse SetExtensionHeader(System.String, System.String)
   Method [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=1] Htmxor.Http.HtmxResponse StatusCode(System.Net.HttpStatusCode)
   Method [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=1] Htmxor.Http.HtmxResponse Trigger(System.String)
   Method [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=1;parameters=3] Htmxor.Http.HtmxResponse Trigger[TEventDetail](System.String, TEventDetail, System.Text.Json.JsonSerializerOptions)
+  Method [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=0] System.Collections.Generic.IReadOnlyList`1[System.String] get_SelectedFragmentNames()
+  Property [visibility=public|none;static=False;get=public,instance;set=none] System.Collections.Generic.IReadOnlyList`1[System.String] SelectedFragmentNames
 TYPE Htmxor.Http.HtmxResponseHeaderNames [kind=class;abstract=True;sealed=True;genericArity=0;base=System.Object]
   Field [visibility=public;static=True;literal=True;readonly=False] System.String Location
   Field [visibility=public;static=True;literal=True;readonly=False] System.String PushUrl

--- a/src/Htmxor/Components/HtmxFragment.cs
+++ b/src/Htmxor/Components/HtmxFragment.cs
@@ -6,13 +6,21 @@ using Microsoft.AspNetCore.Components.Rendering;
 namespace Htmxor.Components;
 
 /// <summary>
-/// Represents a component that will only render its <see cref="ChildContent"/> if
-/// its <see cref="Match"/> predicate returns <see langword="true"/> or
-/// if the request is a standard request and <see cref="RenderDuringStandardRequest"/>
-/// is <see langword="true"/>.
+/// Defines a server-selectable fragment with optional wrapper markup.
 /// </summary>
+/// <remarks>
+/// The v1 endpoint renderer completes the component tree before selecting response output by
+/// <see cref="Name"/>. <see cref="Match"/> and <see cref="RenderDuringStandardRequest"/>
+/// apply only to the legacy conditional renderer.
+/// </remarks>
 public class HtmxFragment : ConditionalComponentBase
 {
+	/// <summary>
+	/// Gets or sets the stable, case-sensitive server selection name. This does not emit markup or request a wrapper.
+	/// </summary>
+	[Parameter]
+	public string? Name { get; set; }
+
 	/// <summary>
 	/// Gets or sets additional attributes for the optional wrapper element.
 	/// </summary>
@@ -58,7 +66,7 @@ public class HtmxFragment : ConditionalComponentBase
 	/// <inheritdoc/>
 	protected override void BuildRenderTree([NotNull] RenderTreeBuilder builder)
 	{
-		if (!ShouldOutput(Context, 0, 0))
+		if (!Context.UsesCompletedFragmentSelection && !ShouldOutput(Context, 0, 0))
 		{
 			return;
 		}

--- a/src/Htmxor/Components/HtmxFragment.cs
+++ b/src/Htmxor/Components/HtmxFragment.cs
@@ -29,7 +29,7 @@ public class HtmxFragment : ConditionalComponentBase
 	public IDictionary<string, object>? AdditionalAttributes { get; set; }
 
 	/// <summary>
-	/// Gets or sets the child content that should be rendered if the <see cref="Match"/> predicate returns <see langword="true"/>.
+	/// Gets or sets the fragment's child content.
 	/// </summary>
 	[Parameter, EditorRequired]
 	public required RenderFragment ChildContent { get; set; }
@@ -51,13 +51,13 @@ public class HtmxFragment : ConditionalComponentBase
 	public string? Id { get; set; }
 
 	/// <summary>
-	/// Gets or sets the predicate to determine if the <see cref="ChildContent"/> should be rendered.
+	/// Gets or sets the legacy conditional renderer's child-content predicate.
 	/// </summary>
 	[Parameter]
 	public Func<HtmxRequest, bool>? Match { get; set; }
 
 	/// <summary>
-	/// Gets or sets whether or not to render during a standard request.
+	/// Gets or sets whether the legacy conditional renderer emits this fragment during a standard request.
 	/// </summary>
 	/// <remarks>Default is <see langword="true"/>.</remarks>
 	[Parameter]

--- a/src/Htmxor/Endpoints/HtmxorEndpointCandidate.cs
+++ b/src/Htmxor/Endpoints/HtmxorEndpointCandidate.cs
@@ -30,6 +30,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Htmxor.DependencyInjection;
+using Htmxor.Http;
 using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
@@ -115,7 +116,8 @@ internal sealed class HtmxorEndpointCandidateInvoker(HtmxorEndpointCandidateRend
 		context.Response.ContentType = DefaultContentType;
 		var isErrorHandler = context.Features.Get<IExceptionHandlerFeature>() is not null;
 		var isReexecuted = context.Features.Get<IStatusCodeReExecuteFeature>() is not null;
-		renderer.InitializeStreamingRenderingFraming(context, isErrorHandler || isReexecuted);
+		renderer.InitializeStreamingRenderingFraming(context,
+			isErrorHandler || isReexecuted || context.GetHtmxContext().Request.RoutingMode is RoutingMode.Direct);
 		if (!isReexecuted)
 		{
 			context.Response.Headers[EnhancedNavigationHeader] = "allow";
@@ -193,7 +195,7 @@ internal sealed class HtmxorEndpointCandidateInvoker(HtmxorEndpointCandidateRend
 			defaultBufferSize,
 			ArrayPool<byte>.Shared,
 			ArrayPool<char>.Shared);
-		htmlContent.WriteHtmlTo(writer);
+		renderer.WriteResponseHtml(htmlContent, context.GetHtmxContext(), writer);
 		if (hasPendingInitialRenderWork ?? !quiesceTask.IsCompletedSuccessfully)
 		{
 			await renderer.SendStreamingUpdatesAsync(context, quiesceTask, writer);
@@ -254,6 +256,8 @@ internal partial class HtmxorEndpointCandidateRenderer : StaticHtmlRenderer
 		HttpContext context, Type pageComponent, string? handler = null, IFormCollection? form = null)
 	{
 		httpContext = context;
+		context.GetHtmxContext().UsesCompletedFragmentSelection = true;
+		renderedFragments.Clear();
 		notFoundEventArgs = null;
 		invocationSequence = -1;
 		invocationId = Guid.NewGuid();

--- a/src/Htmxor/Endpoints/HtmxorEndpointCandidateRenderer.FragmentSelection.cs
+++ b/src/Htmxor/Endpoints/HtmxorEndpointCandidateRenderer.FragmentSelection.cs
@@ -1,0 +1,50 @@
+using Htmxor.Components;
+using Htmxor.Http;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.AspNetCore.Components.RenderTree;
+using Microsoft.AspNetCore.Components.Web.HtmlRendering;
+
+namespace Htmxor.Endpoints;
+
+internal partial class HtmxorEndpointCandidateRenderer
+{
+	private readonly Dictionary<int, HtmxFragment> renderedFragments = [];
+
+	protected override ComponentState CreateComponentState(int componentId, IComponent component, ComponentState? parentComponentState)
+	{
+		var state = base.CreateComponentState(componentId, component, parentComponentState);
+		if (component is HtmxFragment fragment)
+		{
+			renderedFragments.Add(componentId, fragment);
+		}
+		return state;
+	}
+
+	private void RemoveDisposedFragments(in RenderBatch renderBatch)
+	{
+		foreach (var componentId in renderBatch.DisposedComponentIDs.Array.AsSpan(0, renderBatch.DisposedComponentIDs.Count))
+		{
+			renderedFragments.Remove(componentId);
+		}
+	}
+
+	internal void WriteResponseHtml(HtmlRootComponent content, HtmxContext context, TextWriter output)
+	{
+		Dispatcher.AssertAccess();
+		var names = context.Response.SelectedFragmentNames;
+		if (context.Request.RoutingMode is not RoutingMode.Direct || names.Count == 0)
+		{
+			content.WriteHtmlTo(output);
+			return;
+		}
+
+		// Resolve every boundary before writing so a missing name cannot leave a partial response.
+		var componentIds = names.Select(name => renderedFragments.Single(fragment =>
+			string.Equals(fragment.Value.Name, name, StringComparison.Ordinal)).Key).ToArray();
+		foreach (var componentId in componentIds)
+		{
+			WriteCompletedComponentHtml(componentId, output);
+		}
+	}
+}

--- a/src/Htmxor/Endpoints/HtmxorEndpointCandidateRenderer.Streaming.cs
+++ b/src/Htmxor/Endpoints/HtmxorEndpointCandidateRenderer.Streaming.cs
@@ -84,6 +84,7 @@ internal partial class HtmxorEndpointCandidateRenderer
 
 	protected override Task UpdateDisplayAsync(in RenderBatch renderBatch)
 	{
+		RemoveDisposedFragments(in renderBatch);
 		UpdateNamedSubmitEvents(in renderBatch);
 		for (var index = 0; !waitForQuiescence && index < renderBatch.UpdatedComponents.Count; index++)
 		{

--- a/src/Htmxor/Http/HtmxContext.cs
+++ b/src/Htmxor/Http/HtmxContext.cs
@@ -8,6 +8,8 @@ public sealed class HtmxContext
 
 	public HtmxResponse Response { get; }
 
+	internal bool UsesCompletedFragmentSelection { get; set; }
+
 	public HtmxContext(HttpContext context)
 	{
 		Request = new HtmxRequest(context);

--- a/src/Htmxor/Http/HtmxResponse.FragmentSelection.cs
+++ b/src/Htmxor/Http/HtmxResponse.FragmentSelection.cs
@@ -1,0 +1,37 @@
+namespace Htmxor.Http;
+
+public sealed partial class HtmxResponse
+{
+	private IReadOnlyList<string> selectedFragmentNames = Array.Empty<string>();
+
+	/// <summary>
+	/// Gets the application-selected server fragment names in caller order. An empty list
+	/// represents whole-component output. Normal requests always write the whole component.
+	/// </summary>
+	public IReadOnlyList<string> SelectedFragmentNames => selectedFragmentNames;
+
+	/// <summary>
+	/// Selects the whole component output, replacing any previous server fragment selection.
+	/// </summary>
+	public HtmxResponse SelectWholeComponent()
+	{
+		selectedFragmentNames = Array.Empty<string>();
+		return this;
+	}
+
+	/// <summary>
+	/// Selects one stable server fragment name, independently of browser delivery headers.
+	/// </summary>
+	public HtmxResponse SelectFragment(string name) => SelectFragments(name);
+
+	/// <summary>
+	/// Selects stable server fragment names in caller order, replacing any previous selection.
+	/// The caller's array is copied so later mutations cannot change this request's selection.
+	/// </summary>
+	public HtmxResponse SelectFragments(params string[] names)
+	{
+		ArgumentNullException.ThrowIfNull(names);
+		selectedFragmentNames = Array.AsReadOnly((string[])names.Clone());
+		return this;
+	}
+}

--- a/src/Htmxor/Http/HtmxResponse.cs
+++ b/src/Htmxor/Http/HtmxResponse.cs
@@ -23,7 +23,7 @@ namespace Htmxor.Http;
 /// a later duplicate replaces its detail without moving the event from its first position.
 /// Htmx does not process response headers on HTTP 3xx responses.
 /// </remarks>
-public sealed class HtmxResponse(HttpContext context)
+public sealed partial class HtmxResponse(HttpContext context)
 {
 	private static readonly object TriggerEventsItemsKey = new();
 	private static readonly string[] NavigationHeaderNames =

--- a/src/Htmxor/Http/HtmxResponse.cs
+++ b/src/Htmxor/Http/HtmxResponse.cs
@@ -16,7 +16,7 @@ namespace Htmxor.Http;
 /// <remarks>
 /// Navigation operations validate their arguments before checking the htmx request marker,
 /// replace any earlier core htmx navigation operation, and do not change the HTTP status code.
-/// Swap and selection operations also validate before the marker guard, preserve the exact
+/// Swap and browser-selection header operations also validate before the marker guard, preserve the exact
 /// ASCII HTTP-header-safe application-authored value, and replace only an earlier value for
 /// the same response header.
 /// Trigger operations merge exact, case-sensitive event names into one compact JSON object;

--- a/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue122FragmentPage.razor.template
+++ b/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue122FragmentPage.razor.template
@@ -1,6 +1,10 @@
 @page "/issue-122/fragments"
+@using Htmxor.Http
+@inject HtmxContext Htmx
 
-<HtmxFragment Match="@(_ => false)">
+
+@if (Htmx.Request.RoutingMode is not RoutingMode.Direct)
+{
 	<section data-issue-122-page>
 		<h1>Issue 122 fragment delivery</h1>
 		<button id="issue-122-load"
@@ -14,19 +18,31 @@
 		<div id="issue-122-first" data-state="first-original">First original</div>
 		<div id="issue-122-second" data-state="second-original">Second original</div>
 	</section>
-</HtmxFragment>
+}
 
-<HtmxFragment Match="@(_ => true)"
-		RenderDuringStandardRequest="false"
+@if (Htmx.Request.RoutingMode is RoutingMode.Direct)
+{
+	<HtmxFragment Name="first"
 		Element="hx-partial"
 		Id="issue-122-first"
 		hx-target="#issue-122-first"
 		hx-swap="innerHTML">
 	<span data-state="first-updated">First updated</span>
-</HtmxFragment>
+	</HtmxFragment>
 
-<HtmxFragment RenderDuringStandardRequest="false">
-	<hx-partial hx-target="#issue-122-second" hx-swap="outerHTML">
-		<div id="issue-122-second" data-state="second-updated">Second updated</div>
-	</hx-partial>
-</HtmxFragment>
+	<HtmxFragment Name="second">
+		<hx-partial hx-target="#issue-122-second" hx-swap="outerHTML">
+			<div id="issue-122-second" data-state="second-updated">Second updated</div>
+		</hx-partial>
+	</HtmxFragment>
+}
+
+@code {
+	protected override void OnParametersSet()
+	{
+		if (Htmx.Request.RoutingMode is RoutingMode.Direct)
+		{
+			Htmx.Response.SelectFragments("first", "second");
+		}
+	}
+}

--- a/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue137FragmentPage.razor.template
+++ b/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue137FragmentPage.razor.template
@@ -1,20 +1,24 @@
 @page "/issue-137/fragment-lifecycle"
+@using Htmxor.Http
 @inject Issue137LifecycleProbe Probe
 @inject IHttpContextAccessor HttpContextAccessor
+@inject HtmxContext Htmx
 
-<HtmxFragment Match="@(_ => false)">
+
+@if (Htmx.Request.RoutingMode is not RoutingMode.Direct)
+{
 	<button id="issue-137-select"
 			type="button"
 			hx-get="/issue-137/fragment-lifecycle"
 			hx-target="#issue-137-selected"
 			hx-swap="outerHTML">Select fragment</button>
-</HtmxFragment>
+}
 
 <Issue137LifecycleWrapper>
-	<HtmxFragment Id="issue-137-selected">
+	<HtmxFragment Name="selected" Id="issue-137-selected">
 		<Issue137ObservedDescendant Branch="selected" />
 	</HtmxFragment>
-	<HtmxFragment Id="issue-137-excluded">
+	<HtmxFragment Name="excluded" Id="issue-137-excluded">
 		<Issue137ObservedDescendant Branch="excluded" />
 	</HtmxFragment>
 </Issue137LifecycleWrapper>
@@ -22,7 +26,14 @@
 @code {
 	protected override void OnInitialized() => Record("initialized");
 
-	protected override void OnParametersSet() => Record("parameters-set");
+	protected override void OnParametersSet()
+	{
+		Record("parameters-set");
+		if (Htmx.Request.RoutingMode is RoutingMode.Direct)
+		{
+			Htmx.Response.SelectFragment("selected");
+		}
+	}
 
 	private void Record(string phase) =>
 		Probe.Record(HttpContextAccessor.HttpContext!.TraceIdentifier, "page", phase);

--- a/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue139AsyncFragmentPage.razor.template
+++ b/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue139AsyncFragmentPage.razor.template
@@ -1,6 +1,10 @@
 @page "/issue-139/async-fragment"
+@using Htmxor.Http
+@inject HtmxContext Htmx
 
-<HtmxFragment Match="@(_ => false)">
+
+@if (Htmx.Request.RoutingMode is not RoutingMode.Direct)
+{
 	<section data-issue-139-stock-control>
 		<button id="issue-139-select"
 				type="button"
@@ -10,12 +14,25 @@
 		<div id="issue-139-selected" data-issue-139-placeholder="selected">Selected placeholder</div>
 		<div id="issue-139-excluded" data-issue-139-placeholder="excluded">Excluded placeholder</div>
 	</section>
-</HtmxFragment>
+}
 
-<HtmxFragment Id="issue-139-selected" RenderDuringStandardRequest="false">
-	<Issue139AsyncDescendant Branch="selected" />
-</HtmxFragment>
+@if (Htmx.Request.RoutingMode is RoutingMode.Direct)
+{
+	<HtmxFragment Name="selected" Id="issue-139-selected">
+		<Issue139AsyncDescendant Branch="selected" />
+	</HtmxFragment>
 
-<HtmxFragment Id="issue-139-excluded" RenderDuringStandardRequest="false">
-	<Issue139AsyncDescendant Branch="excluded" />
-</HtmxFragment>
+	<HtmxFragment Name="excluded" Id="issue-139-excluded">
+		<Issue139AsyncDescendant Branch="excluded" />
+	</HtmxFragment>
+}
+
+@code {
+	protected override void OnParametersSet()
+	{
+		if (Htmx.Request.RoutingMode is RoutingMode.Direct)
+		{
+			Htmx.Response.SelectFragment("selected");
+		}
+	}
+}

--- a/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue144ConcurrentFragmentPage.razor.template
+++ b/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue144ConcurrentFragmentPage.razor.template
@@ -1,6 +1,10 @@
 @page "/issue-144/concurrent-fragment"
+@using Htmxor.Http
+@inject HtmxContext Htmx
 
-<HtmxFragment Match="@(_ => false)">
+
+@if (Htmx.Request.RoutingMode is not RoutingMode.Direct)
+{
 	<section data-issue-144-stock-control>
 		<button id="issue-144-select"
 				type="button"
@@ -10,17 +14,28 @@
 		<div id="issue-144-selected" data-issue-144-placeholder="selected">Selected placeholder @RequestMarker</div>
 		<div id="issue-144-excluded" data-issue-144-placeholder="excluded">Excluded placeholder @RequestMarker</div>
 	</section>
-</HtmxFragment>
+}
 
-<HtmxFragment Id="issue-144-selected" RenderDuringStandardRequest="false">
-	<Issue144ConcurrentDescendant Branch="selected" RequestMarker="@RequestMarker" />
-</HtmxFragment>
+@if (Htmx.Request.RoutingMode is RoutingMode.Direct)
+{
+	<HtmxFragment Name="selected" Id="issue-144-selected">
+		<Issue144ConcurrentDescendant Branch="selected" RequestMarker="@RequestMarker" />
+	</HtmxFragment>
 
-<HtmxFragment Id="issue-144-excluded" RenderDuringStandardRequest="false">
-	<Issue144ConcurrentDescendant Branch="excluded" RequestMarker="@RequestMarker" />
-</HtmxFragment>
+	<HtmxFragment Name="excluded" Id="issue-144-excluded">
+		<Issue144ConcurrentDescendant Branch="excluded" RequestMarker="@RequestMarker" />
+	</HtmxFragment>
+}
 
 @code {
 	[SupplyParameterFromQuery]
 	private string RequestMarker { get; set; } = "stock-control";
+
+	protected override void OnParametersSet()
+	{
+		if (Htmx.Request.RoutingMode is RoutingMode.Direct)
+		{
+			Htmx.Response.SelectFragment("selected");
+		}
+	}
 }

--- a/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue56BrowserTests.cs.template
+++ b/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue56BrowserTests.cs.template
@@ -1148,7 +1148,7 @@ public sealed class Issue56BrowserTests
 	}
 
 	[Fact]
-	public async Task Selected_fragment_skips_excluded_descendant_lifecycle_and_render_work()
+	public async Task Selected_fragment_excludes_sibling_markup_after_running_sibling_lifecycle()
 	{
 		var probe = new Issue137LifecycleProbe();
 		await using var app = CreateApplication(
@@ -1170,7 +1170,7 @@ public sealed class Issue56BrowserTests
 		Assert.Contains("data-issue-137-descendant=\"selected\"", normalBody, StringComparison.Ordinal);
 		Assert.Contains("data-issue-137-descendant=\"excluded\"", normalBody, StringComparison.Ordinal);
 		var normalObservations = probe.Snapshot();
-		AssertIssue137Lifecycle(normalObservations, expectedExcludedCount: 1);
+		AssertIssue137Lifecycle(normalObservations);
 		var normalRequestId = Assert.Single(
 			normalObservations.Select(observation => observation.RequestId).Distinct());
 		await page.WaitForFunctionAsync("() => window.htmx?.version === '4.0.0'");
@@ -1194,7 +1194,7 @@ public sealed class Issue56BrowserTests
 		Assert.DoesNotContain("<button", directBody, StringComparison.OrdinalIgnoreCase);
 
 		var directObservations = probe.Snapshot().Skip(beforeDirectRequest.Count).ToArray();
-		AssertIssue137Lifecycle(directObservations, expectedExcludedCount: 0);
+		AssertIssue137Lifecycle(directObservations);
 		var directRequestId = Assert.Single(
 			directObservations.Select(observation => observation.RequestId).Distinct());
 		Assert.NotEqual(normalRequestId, directRequestId);
@@ -1382,9 +1382,6 @@ public sealed class Issue56BrowserTests
 			Assert.Equal("Selected placeholder", await page.Locator("#issue-139-selected").TextContentAsync());
 			Assert.Equal(0, await page.EvaluateAsync<int>("() => window.issue139ResponseEvents"));
 			Assert.Equal(0, await page.EvaluateAsync<int>("() => window.issue139SwapEvents"));
-			Assert.DoesNotContain(
-				probe.Snapshot(),
-				observation => string.Equals(observation.Component, "excluded", StringComparison.Ordinal));
 		}
 		finally
 		{
@@ -1431,14 +1428,14 @@ public sealed class Issue56BrowserTests
 		Assert.Equal(1, await page.Locator("#issue-139-excluded").CountAsync());
 
 		var directObservations = probe.Snapshot();
-		Assert.DoesNotContain(
-			directObservations,
-			observation => string.Equals(observation.Component, "excluded", StringComparison.Ordinal));
+		var excludedCompletion = Assert.Single(directObservations, observation =>
+			observation is { Component: "excluded", Phase: "initialization-completed" });
 		var selectedCompletion = Assert.Single(directObservations, observation =>
 			observation is { Component: "selected", Phase: "initialization-completed" });
 		var browserObservation = Assert.Single(directObservations, observation =>
 			observation is { Component: "browser", Phase: "response-observed" });
 		Assert.True(selectedCompletion.Sequence < browserObservation.Sequence);
+		Assert.True(excludedCompletion.Sequence < browserObservation.Sequence);
 	}
 
 	[Fact]
@@ -2387,11 +2384,10 @@ public sealed class Issue56BrowserTests
 		string requestIdB,
 		Guid gateIdB)
 	{
-		Assert.DoesNotContain(
-			observations,
-			observation => string.Equals(observation.Component, "excluded", StringComparison.Ordinal));
 		AssertIssue144RequestObservations(observations, markerA, requestIdA, gateIdA);
 		AssertIssue144RequestObservations(observations, markerB, requestIdB, gateIdB);
+		AssertIssue144ExcludedObservations(observations, markerA, requestIdA, gateIdA);
+		AssertIssue144ExcludedObservations(observations, markerB, requestIdB, gateIdB);
 		Assert.Equal(
 			observations.Count,
 			observations.Count(observation =>
@@ -2408,19 +2404,21 @@ public sealed class Issue56BrowserTests
 		var requestObservations = observations
 			.Where(observation => string.Equals(observation.RequestMarker, requestMarker, StringComparison.Ordinal))
 			.ToArray();
-		Assert.Single(requestObservations, observation => observation.Phase == "parameters-entered");
-		Assert.Single(requestObservations, observation => observation.Phase == "initialization-entered");
+		var selectedObservations = requestObservations
+			.Where(observation => string.Equals(observation.Component, "selected", StringComparison.Ordinal))
+			.ToArray();
+		Assert.Single(selectedObservations, observation => observation.Phase == "parameters-entered");
+		Assert.Single(selectedObservations, observation => observation.Phase == "initialization-entered");
 		Assert.DoesNotContain(
-			requestObservations,
+			selectedObservations,
 			observation => observation.Phase is
 				"initialization-completed" or "parameters-completed");
-		Assert.All(requestObservations, observation =>
+		Assert.All(selectedObservations, observation =>
 		{
 			Assert.Equal(requestId, observation.RequestId);
 			Assert.Equal(gateId, observation.GateId);
-			Assert.Equal("selected", observation.Component);
 		});
-		return requestObservations;
+		return selectedObservations;
 	}
 
 	private static Issue144ConcurrentObservation[] AssertIssue144RequestObservations(
@@ -2432,19 +2430,44 @@ public sealed class Issue56BrowserTests
 		var requestObservations = observations
 			.Where(observation => string.Equals(observation.RequestMarker, requestMarker, StringComparison.Ordinal))
 			.ToArray();
-		Assert.NotEmpty(requestObservations);
-		Assert.All(requestObservations, observation =>
+		var selectedObservations = requestObservations
+			.Where(observation => string.Equals(observation.Component, "selected", StringComparison.Ordinal))
+			.ToArray();
+		Assert.NotEmpty(selectedObservations);
+		Assert.All(selectedObservations, observation =>
 		{
 			Assert.Equal(requestId, observation.RequestId);
 			Assert.Equal(gateId, observation.GateId);
-			Assert.Equal("selected", observation.Component);
 		});
-		Assert.Single(requestObservations, observation => observation.Phase == "parameters-entered");
-		Assert.Single(requestObservations, observation => observation.Phase == "initialization-entered");
-		Assert.Single(requestObservations, observation => observation.Phase == "initialization-completed");
-		Assert.Single(requestObservations, observation => observation.Phase == "parameters-completed");
-		Assert.Contains(requestObservations, observation => observation.Phase == "rendered");
-		return requestObservations;
+		Assert.Single(selectedObservations, observation => observation.Phase == "parameters-entered");
+		Assert.Single(selectedObservations, observation => observation.Phase == "initialization-entered");
+		Assert.Single(selectedObservations, observation => observation.Phase == "initialization-completed");
+		Assert.Single(selectedObservations, observation => observation.Phase == "parameters-completed");
+		Assert.Contains(selectedObservations, observation => observation.Phase == "rendered");
+		return selectedObservations;
+	}
+
+	private static void AssertIssue144ExcludedObservations(
+		IReadOnlyList<Issue144ConcurrentObservation> observations,
+		string requestMarker,
+		string requestId,
+		Guid gateId)
+	{
+		var excludedObservations = observations
+			.Where(observation =>
+				string.Equals(observation.RequestMarker, requestMarker, StringComparison.Ordinal) &&
+				string.Equals(observation.Component, "excluded", StringComparison.Ordinal))
+			.ToArray();
+		Assert.All(excludedObservations, observation =>
+		{
+			Assert.Equal(requestId, observation.RequestId);
+			Assert.Equal(gateId, observation.GateId);
+		});
+		Assert.Single(excludedObservations, observation => observation.Phase == "parameters-entered");
+		Assert.Single(excludedObservations, observation => observation.Phase == "initialization-entered");
+		Assert.Single(excludedObservations, observation => observation.Phase == "initialization-completed");
+		Assert.Single(excludedObservations, observation => observation.Phase == "parameters-completed");
+		Assert.Contains(excludedObservations, observation => observation.Phase == "rendered");
 	}
 
 	private static HttpRequestMessage CreateForgedRequest(
@@ -2835,9 +2858,7 @@ public sealed class Issue56BrowserTests
 			new Uri(response.Url).AbsolutePath == Issue135Path &&
 			string.Equals(response.Request.Method, "PUT", StringComparison.Ordinal));
 
-	private static void AssertIssue137Lifecycle(
-		IReadOnlyList<Issue137Observation> observations,
-		int expectedExcludedCount)
+	private static void AssertIssue137Lifecycle(IReadOnlyList<Issue137Observation> observations)
 	{
 		Assert.NotEmpty(observations);
 		Assert.Single(observations.Select(observation => observation.RequestId).Distinct());
@@ -2850,7 +2871,7 @@ public sealed class Issue56BrowserTests
 		Assert.Equal(1, observations.Count(observation =>
 			observation is { Component: "wrapper", Phase: "parameters-set" }));
 		AssertDescendantLifecycle(observations, "selected", expectedCount: 1);
-		AssertDescendantLifecycle(observations, "excluded", expectedExcludedCount);
+		AssertDescendantLifecycle(observations, "excluded", expectedCount: 1);
 	}
 
 	private static void AssertDescendantLifecycle(

--- a/test/Htmxor.Quality.Tests/PackageConsumer/Issue168App.razor.scenario
+++ b/test/Htmxor.Quality.Tests/PackageConsumer/Issue168App.razor.scenario
@@ -1,0 +1,3 @@
+@namespace Htmxor.PackageConsumer
+@using Microsoft.AspNetCore.Components.Routing
+<!DOCTYPE html><html lang="en"><body><Router AppAssembly="typeof(Issue168App).Assembly"><Found Context="routeData"><RouteView RouteData="routeData" /></Found></Router></body></html>

--- a/test/Htmxor.Quality.Tests/PackageConsumer/Issue168Child.razor.scenario
+++ b/test/Htmxor.Quality.Tests/PackageConsumer/Issue168Child.razor.scenario
@@ -1,0 +1,11 @@
+@namespace Htmxor.PackageConsumer
+@inject Issue168Service Service
+<span>@value</span>
+@code {
+    private string value = "not-initialized";
+    protected override async Task OnInitializedAsync()
+    {
+        await Task.Yield();
+        value = Service.Value;
+    }
+}

--- a/test/Htmxor.Quality.Tests/PackageConsumer/Issue168Page.razor.scenario
+++ b/test/Htmxor.Quality.Tests/PackageConsumer/Issue168Page.razor.scenario
@@ -1,0 +1,23 @@
+@page "/selection"
+@namespace Htmxor.PackageConsumer
+@using Htmxor
+@using Htmxor.Components
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Http
+<main><p>before</p><HtmxFragment Name="first"><strong>first</strong><Issue168Child /></HtmxFragment><p>between</p><HtmxFragment Name="second"><em>second</em></HtmxFragment><HtmxFragment Name="element" Element="aside"><b>element</b></HtmxFragment><HtmxFragment Name="identified" Id="box"><b>identified</b></HtmxFragment><HtmxFragment Name="attributes" data-kind="extra"><b>attributes</b></HtmxFragment><HtmxFragment Name="First"><i>distinct-case</i></HtmxFragment><p>after</p></main>
+@code {
+    [CascadingParameter] private HttpContext HttpContext { get; set; } = default!;
+    [SupplyParameterFromQuery] public string? Selection { get; set; }
+
+    protected override void OnParametersSet()
+    {
+        var response = HttpContext.GetHtmxContext().Response;
+        switch (Selection)
+        {
+            case null: break;
+            case "whole": response.SelectFragment("first").SelectWholeComponent(); break;
+            case "multi": response.SelectFragments("second", "first"); break;
+            default: response.SelectFragment(Selection); break;
+        }
+    }
+}

--- a/test/Htmxor.Quality.Tests/PackageConsumer/Issue168SelectionTests.cs.scenario
+++ b/test/Htmxor.Quality.Tests/PackageConsumer/Issue168SelectionTests.cs.scenario
@@ -1,0 +1,80 @@
+using System.Net;
+using Htmxor;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Htmxor.PackageConsumer;
+
+public sealed class Issue168SelectionTests : IAsyncLifetime
+{
+    private const string First = "<strong>first</strong><span>initialized-from-di</span>";
+    private const string Second = "<em>second</em>";
+    private const string Element = "<aside><b>element</b></aside>";
+    private const string Identified = "<div id=\"box\"><b>identified</b></div>";
+    private const string Attributes = "<div data-kind=\"extra\"><b>attributes</b></div>";
+    private const string DistinctCase = "<i>distinct-case</i>";
+    private const string Whole = "<main><p>before</p>" + First + "<p>between</p>" + Second + Element + Identified + Attributes + DistinctCase + "<p>after</p></main>";
+    private WebApplication app = default!;
+    private HttpClient client = default!;
+
+    public async Task InitializeAsync()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddScoped<Issue168Service>();
+        builder.Services.AddRazorComponents().AddHtmxor();
+        app = builder.Build();
+        app.UseAntiforgery();
+        app.MapRazorComponents<Issue168App>().AddHtmxorEndpoints();
+        await app.StartAsync();
+        client = app.GetTestClient();
+    }
+
+    [Fact]
+    public async Task Normal_request_retains_shell_and_all_fragments()
+    {
+        using var response = await client.GetAsync("/selection");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("<!DOCTYPE html><html lang=\"en\"><body>" + Whole + "</body></html>",
+            await response.Content.ReadAsStringAsync());
+    }
+
+    [Theory]
+    [InlineData(null, null, null, Whole)]
+    [InlineData(null, "div#box", "button#first", Whole)]
+    [InlineData("whole", "section#other", "button#second", Whole)]
+    [InlineData("first", null, null, First)]
+    [InlineData("first", "div#box", "button#second", First)]
+    [InlineData("First", null, null, DistinctCase)]
+    [InlineData("second", "section#first", "button#first", Second)]
+    [InlineData("multi", "section#other", "button#other", Second + First)]
+    [InlineData("element", null, null, Element)]
+    [InlineData("identified", "section#other", null, Identified)]
+    [InlineData("attributes", null, null, Attributes)]
+    public async Task Direct_request_returns_exact_selected_body(string? selection, string? target, string? source, string expected)
+    {
+        var path = selection is null ? "/selection" : "/selection?selection=" + selection;
+        using var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("HX-Request", "true");
+        request.Headers.Add("HX-Request-Type", "partial");
+        if (target is not null) request.Headers.Add("HX-Target", target);
+        if (source is not null) request.Headers.Add("HX-Source", source);
+        using var response = await client.SendAsync(request);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(expected, await response.Content.ReadAsStringAsync());
+    }
+
+    public async Task DisposeAsync()
+    {
+        client.Dispose();
+        await app.DisposeAsync();
+    }
+}
+
+public sealed class Issue168Service
+{
+    public string Value => "initialized-from-di";
+}

--- a/test/Htmxor.Quality.Tests/PackedPackageConsumerTests.cs
+++ b/test/Htmxor.Quality.Tests/PackedPackageConsumerTests.cs
@@ -241,6 +241,21 @@ internal sealed class PackageConsumerWorkspace : IDisposable
 		return await BuildAsync();
 	}
 
+	public void UseIssue168SelectionScenario()
+	{
+		foreach (var path in Directory.EnumerateFiles(consumerDirectory).Where(path =>
+			path.EndsWith(".cs", StringComparison.Ordinal) || path.EndsWith(".razor", StringComparison.Ordinal)))
+		{
+			File.Delete(path);
+		}
+
+		var assets = Path.Combine(repositoryRoot, "test", "Htmxor.Quality.Tests", "PackageConsumer");
+		foreach (var path in Directory.EnumerateFiles(assets, "Issue168*.scenario"))
+		{
+			File.Copy(path, Path.Combine(consumerDirectory, Path.GetFileNameWithoutExtension(path)));
+		}
+	}
+
 	public void UseComputedPutHandler()
 	{
 		var componentPath = Path.Combine(
@@ -948,6 +963,12 @@ internal static class PackageConsumerEvidence
 
 	public static void AssertConsumer(string consumerDirectory, string packageVersion)
 	{
+		AssertConsumerPackageBoundary(consumerDirectory, packageVersion);
+		AssertSourceBoundary(consumerDirectory);
+	}
+
+	public static void AssertConsumerPackageBoundary(string consumerDirectory, string packageVersion)
+	{
 		var project = XDocument.Load(Path.Combine(consumerDirectory, "Htmxor.PackageConsumer.csproj"));
 		var targetFramework = Assert.Single(
 			project.Descendants(),
@@ -961,7 +982,6 @@ internal static class PackageConsumerEvidence
 		Assert.Equal(packageVersion, htmxor.Attribute("Version")?.Value);
 		Assert.Empty(project.Descendants().Where(element => element.Name.LocalName == "ProjectReference"));
 		Assert.Empty(project.Descendants().Where(element => element.Name.LocalName == "InternalsVisibleTo"));
-		AssertSourceBoundary(consumerDirectory);
 		AssertRuntimeDependencies(consumerDirectory);
 	}
 

--- a/test/Htmxor.Quality.Tests/PackedSelectionConsumerTests.cs
+++ b/test/Htmxor.Quality.Tests/PackedSelectionConsumerTests.cs
@@ -1,0 +1,24 @@
+using Htmxor.Quality;
+
+namespace Htmxor.Quality.Tests;
+
+[Collection(PackageConsumerCollection.Name)]
+public sealed class PackedSelectionConsumerTests
+{
+	[Fact]
+	public async Task Package_only_application_serializes_selected_fragment_bodies()
+	{
+		using var workspace = new PackageConsumerWorkspace(RepositoryLocator.Find());
+		workspace.UseIssue168SelectionScenario();
+
+		var result = await workspace.RunAsync();
+		var testRun = TrxTestRun.Read(workspace.TrxPath);
+
+		Assert.True(result.ExitCode == 0,
+			result.StandardOutput + Environment.NewLine + result.StandardError +
+			Environment.NewLine + $"TRX: {testRun}");
+		Assert.Equal(new TrxTestRun(12, 12, 12, 0, 0, 0, 0), testRun);
+		PackageConsumerEvidence.AssertPackage(workspace.PackagePath);
+		PackageConsumerEvidence.AssertConsumerPackageBoundary(workspace.ConsumerDirectory, workspace.PackageVersion);
+	}
+}

--- a/test/Htmxor.Tests/Rendering/FragmentSelectionTests.cs
+++ b/test/Htmxor.Tests/Rendering/FragmentSelectionTests.cs
@@ -1,0 +1,84 @@
+using Htmxor.Components;
+using Htmxor.Endpoints;
+using Htmxor.Http;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Htmxor.Rendering;
+
+public sealed class FragmentSelectionTests
+{
+	[Theory]
+	[InlineData(false, "single", "<main><b>first</b><i>second</i><aside>sibling</aside></main>")]
+	[InlineData(true, "default", "<main><b>first</b><i>second</i><aside>sibling</aside></main>")]
+	[InlineData(true, "whole", "<main><b>first</b><i>second</i><aside>sibling</aside></main>")]
+	[InlineData(true, "single", "<b>first</b>")]
+	[InlineData(true, "multiple", "<i>second</i><b>first</b>")]
+	public async Task Completed_render_emits_application_selection_in_caller_order(bool direct, string selection, string expected)
+	{
+		var http = new DefaultHttpContext();
+		if (direct)
+		{
+			http.Request.Headers["HX-Request"] = "true";
+			http.Request.Headers["HX-Request-Type"] = "partial";
+		}
+		var context = http.GetHtmxContext();
+		await using var services = new ServiceCollection().AddSingleton(context).BuildServiceProvider();
+		await using var renderer = new HtmxorEndpointCandidateRenderer(services, NullLoggerFactory.Instance);
+		await renderer.Dispatcher.InvokeAsync(async () =>
+		{
+			var parameters = ParameterView.FromDictionary(new Dictionary<string, object?> { [nameof(SelectionRoot.Selection)] = selection });
+			var rendered = await renderer.RenderEndpointComponentAsync(typeof(SelectionRoot), parameters);
+			using var writer = new StringWriter();
+			renderer.WriteResponseHtml(rendered, context, writer);
+			writer.ToString().Should().Be(expected);
+		});
+	}
+
+	[Fact]
+	public void Selection_is_read_only_request_local_and_replaced_by_whole_selection()
+	{
+		var response = new DefaultHttpContext().GetHtmxContext().Response;
+		string[] names = ["Second", "First"];
+		response.SelectFragments(names);
+		names[0] = "Changed";
+		response.SelectedFragmentNames.Should().Equal("Second", "First");
+		((IList<string>)response.SelectedFragmentNames).IsReadOnly.Should().BeTrue();
+		new DefaultHttpContext().GetHtmxContext().Response.SelectedFragmentNames.Should().BeEmpty();
+		response.SelectWholeComponent().SelectedFragmentNames.Should().BeEmpty();
+	}
+
+	private sealed class SelectionRoot : ComponentBase
+	{
+		[Inject] public HtmxContext Context { get; set; } = default!;
+		[Parameter] public string Selection { get; set; } = "default";
+
+		protected override void OnParametersSet()
+		{
+			switch (Selection)
+			{
+				case "single": Context.Response.SelectFragment("First"); break;
+				case "multiple": Context.Response.SelectFragments("Second", "First"); break;
+				case "whole": Context.Response.SelectFragment("First").SelectWholeComponent(); break;
+			}
+		}
+
+		protected override void BuildRenderTree(RenderTreeBuilder builder)
+		{
+			builder.OpenElement(0, "main");
+			builder.OpenComponent<HtmxFragment>(1);
+			builder.AddComponentParameter(2, nameof(HtmxFragment.Name), "First");
+			builder.AddComponentParameter(3, nameof(HtmxFragment.ChildContent), (RenderFragment)(content => content.AddMarkupContent(0, "<b>first</b>")));
+			builder.CloseComponent();
+			builder.OpenComponent<HtmxFragment>(4);
+			builder.AddComponentParameter(5, nameof(HtmxFragment.Name), "Second");
+			builder.AddComponentParameter(6, nameof(HtmxFragment.ChildContent), (RenderFragment)(content => content.AddMarkupContent(0, "<i>second</i>")));
+			builder.CloseComponent();
+			builder.AddMarkupContent(7, "<aside>sibling</aside>");
+			builder.CloseElement();
+		}
+	}
+}


### PR DESCRIPTION
Closes #168

Implements server-controlled whole, single, and ordered flat named-fragment selection through the endpoint renderer, independently of DOM and HTMX request identities.

Validation:
- `dotnet run --project eng/Htmxor.Quality/Htmxor.Quality.csproj -- check --profile fast` — 965/965 passed
- `dotnet run --project eng/Htmxor.Quality/Htmxor.Quality.csproj -- check --profile full` — 968/968 passed, including packed selection and Chromium browser coverage
- Independent Standards and Spec reviews — 0 findings each

Mutation was not run; nested and invalid selection, request isolation, browser delivery ordering, cache behavior, and skipped-work optimization remain separate slices.
