### PR TITLE
feat(fragments): validate nested and invalid selections

### DIFF
--- a/docs/engineering/fragment-selection.md
+++ b/docs/engineering/fragment-selection.md
@@ -3,6 +3,8 @@
 Issue [#168](https://github.com/egil/Htmxor/issues/168) implements the valid flat
 selection portion of the approved
 [#167 contract](https://github.com/egil/Htmxor/issues/167#issuecomment-5531911245).
+Issue [#169](https://github.com/egil/Htmxor/issues/169) completes its nested and
+invalid-selection rules.
 
 When application code selects whole, one stable fragment name, or an ordered
 valid flat set during a direct request, Htmxor completes normal rendering and
@@ -28,6 +30,23 @@ an empty list means whole-component selection. The response copies the caller's
 array. Selection operations can run in normal lifecycle code on either request
 path. Normal requests always emit the complete page; direct requests default to
 the whole routed component, without the page shell.
+
+Names start with an ASCII letter, continue with ASCII letters, digits, hyphens,
+or underscores, and contain at most 64 characters. No trimming or case
+normalization occurs. A null declaration is unnamed; an empty or malformed
+declaration is invalid. Before writing a direct response, Htmxor validates every
+rendered named declaration, including declarations outside the selection and
+declarations in whole-component output. Invalid names and duplicate declarations
+raise a diagnostic `InvalidOperationException` before response HTML is written.
+The application's normal error handling remains responsible for the HTTP error
+response.
+
+Every selected name must exist exactly once and may appear only once in the
+selection. Selecting a nested child emits that child's optional wrapper and
+subtree, excluding its ancestors' wrappers and siblings. Selecting a parent
+emits its whole rendered subtree. A selection containing both an ancestor and
+its descendant fails before output, in either caller order. The renderer uses
+Blazor's completed component-state parent links to detect that overlap.
 
 The active endpoint renderer records real `HtmxFragment` component states while
 Blazor constructs the tree. It reads their final names and resolves all selected
@@ -75,9 +94,25 @@ descendant work. The existing published-package Chromium suite passed all 39
 cases after this fixture-only migration. Its preceding four failures are retained
 in `artifacts/issue168/full-before-fixture-migration.log` and the matching TRX.
 
-Nested selection, complete invalid-name validation and diagnostics, overlapping
-sets, concurrent requests, cancellation, browser delivery, caching, and
-skipped-work optimization retain their separately owned acceptance contracts.
+The #169 focused renderer matrix records meaningful red at test checkpoint
+`d5f263f6f60bff5a81298e428333a6fb123f940e`, against unchanged production at
+`b2bb028f6d5b5e611fdbf27d83decd4ba96150b3`: 37 executed, 12 baseline passes,
+and 25 failures. The packed HTTP consumer executed 18 cases, with 12 baseline
+passes and six failures. In both nested-overlap orders, the old writer emitted
+the child twice. Malformed declarations, unselected duplicate declarations,
+and repeated selections supplied the other missing-behavior evidence. Existing
+valid nested output was retained as baseline coverage.
+
+The packed timing probe places a 32 KiB fragment before invalid selections,
+exceeding the response writer's 16 KiB buffer. Test middleware observes the real
+response-start state and emits a sentinel only when no response has started.
+This probe enables TestServer synchronous I/O because the existing writer
+flushes large output synchronously; it does not establish default-host
+large-output compatibility. Initial synchronous-I/O and 128 KiB pipe-backpressure
+failures are recorded separately from meaningful red.
+
+Concurrent requests, cancellation, browser delivery, caching, and skipped-work
+optimization retain their separately owned acceptance contracts.
 The migrated conformance fixtures do not establish those complete contracts.
 No non-Linux, other-framework, other-browser, or release-candidate package claim
 is made. Full-scope mutation is not part of this ordinary issue check.

--- a/src/Htmxor/Components/HtmxFragment.cs
+++ b/src/Htmxor/Components/HtmxFragment.cs
@@ -18,6 +18,12 @@ public class HtmxFragment : ConditionalComponentBase
 	/// <summary>
 	/// Gets or sets the stable, case-sensitive server selection name. This does not emit markup or request a wrapper.
 	/// </summary>
+	/// <remarks>
+	/// A name starts with an ASCII letter, followed by ASCII letters, digits, hyphens, or underscores,
+	/// and has at most 64 characters. A null name leaves the fragment unnamed. Invalid or duplicate
+	/// declarations fail before direct-response output. Selecting a named fragment includes its own
+	/// optional wrapper and rendered subtree, without its ancestors' output.
+	/// </remarks>
 	[Parameter]
 	public string? Name { get; set; }
 

--- a/src/Htmxor/Endpoints/HtmxorEndpointCandidateRenderer.FragmentSelection.cs
+++ b/src/Htmxor/Endpoints/HtmxorEndpointCandidateRenderer.FragmentSelection.cs
@@ -32,19 +32,90 @@ internal partial class HtmxorEndpointCandidateRenderer
 	internal void WriteResponseHtml(HtmlRootComponent content, HtmxContext context, TextWriter output)
 	{
 		Dispatcher.AssertAccess();
-		var names = context.Response.SelectedFragmentNames;
-		if (context.Request.RoutingMode is not RoutingMode.Direct || names.Count == 0)
+		if (context.Request.RoutingMode is not RoutingMode.Direct)
 		{
 			content.WriteHtmlTo(output);
 			return;
 		}
 
-		// Resolve every boundary before writing so a missing name cannot leave a partial response.
-		var componentIds = names.Select(name => renderedFragments.Single(fragment =>
-			string.Equals(fragment.Value.Name, name, StringComparison.Ordinal)).Key).ToArray();
+		// Validate the complete name scope and selection before the writer can commit any HTML.
+		var componentIds = ResolveSelectedFragments(context.Response.SelectedFragmentNames);
+		if (componentIds.Length == 0)
+		{
+			content.WriteHtmlTo(output);
+			return;
+		}
+
 		foreach (var componentId in componentIds)
 		{
 			WriteCompletedComponentHtml(componentId, output);
+		}
+	}
+
+	private int[] ResolveSelectedFragments(IReadOnlyList<string> names)
+	{
+		var declarations = GetNamedFragmentComponents();
+		var selectedNames = new HashSet<string>(StringComparer.Ordinal);
+		var componentIds = new int[names.Count];
+		for (var index = 0; index < names.Count; index++)
+		{
+			var name = names[index];
+			ValidateFragmentName(name);
+			if (!selectedNames.Add(name))
+			{
+				throw new InvalidOperationException($"Fragment '{name}' was selected more than once.");
+			}
+			if (!declarations.TryGetValue(name, out componentIds[index]))
+			{
+				throw new InvalidOperationException($"No fragment named '{name}' was rendered.");
+			}
+		}
+		ValidateNonOverlappingFragments(componentIds);
+		return componentIds;
+	}
+
+	private Dictionary<string, int> GetNamedFragmentComponents()
+	{
+		var declarations = new Dictionary<string, int>(StringComparer.Ordinal);
+		foreach (var (componentId, fragment) in renderedFragments)
+		{
+			if (fragment.Name is not { } name)
+			{
+				continue;
+			}
+			ValidateFragmentName(name);
+			if (!declarations.TryAdd(name, componentId))
+			{
+				throw new InvalidOperationException($"More than one fragment named '{name}' was rendered.");
+			}
+		}
+		return declarations;
+	}
+
+	private static void ValidateFragmentName(string? name)
+	{
+		if (name is not { Length: > 0 and <= 64 } ||
+			!char.IsAsciiLetter(name[0]) ||
+			name.Any(character => !char.IsAsciiLetterOrDigit(character) && character is not '-' and not '_'))
+		{
+			throw new InvalidOperationException($"Invalid fragment name '{name}'. Names must start with an ASCII letter, contain only ASCII letters, digits, '-' or '_', and have at most 64 characters.");
+		}
+	}
+
+	private void ValidateNonOverlappingFragments(int[] componentIds)
+	{
+		var selectedIds = componentIds.ToHashSet();
+		foreach (var componentId in componentIds)
+		{
+			for (var ancestor = GetComponentState(componentId).ParentComponentState;
+				ancestor is not null;
+				ancestor = ancestor.ParentComponentState)
+			{
+				if (selectedIds.Contains(ancestor.ComponentId))
+				{
+					throw new InvalidOperationException("Selected fragments cannot include both an ancestor and its descendant.");
+				}
+			}
 		}
 	}
 }

--- a/src/Htmxor/Http/HtmxResponse.FragmentSelection.cs
+++ b/src/Htmxor/Http/HtmxResponse.FragmentSelection.cs
@@ -28,6 +28,11 @@ public sealed partial class HtmxResponse
 	/// Selects stable server fragment names in caller order, replacing any previous selection.
 	/// The caller's array is copied so later mutations cannot change this request's selection.
 	/// </summary>
+	/// <remarks>
+	/// Names follow the identifier rules of <see cref="Htmxor.Components.HtmxFragment.Name"/>.
+	/// Invalid, repeated, unknown, or overlapping ancestor/descendant selections are rejected against
+	/// the completed direct-request render before response HTML is written.
+	/// </remarks>
 	public HtmxResponse SelectFragments(params string[] names)
 	{
 		ArgumentNullException.ThrowIfNull(names);

--- a/test/Htmxor.Quality.Tests/PackageConsumer/Issue169App.razor.scenario
+++ b/test/Htmxor.Quality.Tests/PackageConsumer/Issue169App.razor.scenario
@@ -1,0 +1,3 @@
+@namespace Htmxor.PackageConsumer
+@using Microsoft.AspNetCore.Components.Routing
+<!DOCTYPE html><html lang="en"><body><Router AppAssembly="typeof(Issue169App).Assembly"><Found Context="routeData"><RouteView RouteData="routeData" /></Found></Router></body></html>

--- a/test/Htmxor.Quality.Tests/PackageConsumer/Issue169Child.razor.scenario
+++ b/test/Htmxor.Quality.Tests/PackageConsumer/Issue169Child.razor.scenario
@@ -1,0 +1,7 @@
+@namespace Htmxor.PackageConsumer
+@using Htmxor.Components
+@inject Issue169RenderObservation Observation
+<HtmxFragment Name="Child"><hx-partial target="#elsewhere"><b hx-swap-oob="true">child</b></hx-partial></HtmxFragment>
+@code {
+    protected override void OnInitialized() => Observation.ChildInitialized = true;
+}

--- a/test/Htmxor.Quality.Tests/PackageConsumer/Issue169Page.razor.scenario
+++ b/test/Htmxor.Quality.Tests/PackageConsumer/Issue169Page.razor.scenario
@@ -1,0 +1,18 @@
+@page "/nested-selection"
+@namespace Htmxor.PackageConsumer
+@using Htmxor
+@using Htmxor.Components
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Http
+<main><HtmxFragment Name="Large">@(new string('x', 32768))</HtmxFragment><HtmxFragment Name="Parent" Element="section" Id="parent"><i>before</i><Issue169Child /><i>after</i></HtmxFragment><HtmxFragment Name="Sibling"><aside>sibling</aside></HtmxFragment><HtmxFragment Name="@Declaration"><u>unnamed</u></HtmxFragment></main>
+@code {
+    [CascadingParameter] private HttpContext HttpContext { get; set; } = default!;
+    [SupplyParameterFromQuery] public string? Selection { get; set; }
+    [SupplyParameterFromQuery] public string? Declaration { get; set; }
+
+    protected override void OnParametersSet()
+    {
+        if (Selection is not null)
+            HttpContext.GetHtmxContext().Response.SelectFragments(Selection.Split(','));
+    }
+}

--- a/test/Htmxor.Quality.Tests/PackageConsumer/Issue169SelectionTests.cs.scenario
+++ b/test/Htmxor.Quality.Tests/PackageConsumer/Issue169SelectionTests.cs.scenario
@@ -1,0 +1,131 @@
+using System.Net;
+using Htmxor;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Htmxor.PackageConsumer;
+
+public sealed class Issue169SelectionTests : IAsyncLifetime
+{
+    private const string Child = "<hx-partial target=\"#elsewhere\"><b hx-swap-oob=\"true\">child</b></hx-partial>";
+    private const string Parent = "<section id=\"parent\"><i>before</i>" + Child + "<i>after</i></section>";
+    private const string Sibling = "<aside>sibling</aside>";
+    private readonly Issue169RenderObservation observation = new();
+    private WebApplication app = default!;
+    private HttpClient client = default!;
+    private Exception? failure;
+    private bool responseStarted;
+
+    public async Task InitializeAsync()
+    {
+        var builder = WebApplication.CreateBuilder();
+        // Large writes must cross the response buffer to expose premature output.
+        // The current endpoint writer flushes synchronously; default-host compatibility is separate.
+        builder.WebHost.UseTestServer(options => options.AllowSynchronousIO = true);
+        builder.Services.AddSingleton(observation);
+        builder.Services.AddRazorComponents().AddHtmxor();
+        app = builder.Build();
+        app.Use(async (context, next) =>
+        {
+            try { await next(context); }
+            catch (Exception exception)
+            {
+                failure = exception;
+                responseStarted = context.Response.HasStarted;
+                if (responseStarted) throw;
+                context.Response.Clear();
+                context.Response.StatusCode = 500;
+                await context.Response.WriteAsync("test-host-handled-selection-error");
+            }
+        });
+        app.UseAntiforgery();
+        app.MapRazorComponents<Issue169App>().AddHtmxorEndpoints();
+        await app.StartAsync();
+        client = app.GetTestClient();
+    }
+
+    [Theory]
+    [InlineData("Child", Child)]
+    [InlineData("Parent", Parent)]
+    [InlineData("Sibling", Sibling)]
+    [InlineData("Sibling,Child", Sibling + Child)]
+    [InlineData("Child,Sibling", Child + Sibling)]
+    public async Task Nested_output_uses_server_names_despite_client_delivery_markup(string selection, string expected)
+    {
+        using var request = DirectRequest(selection);
+        using var response = await client.SendAsync(request);
+        Assert.True(failure is null, failure?.ToString());
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(expected, await response.Content.ReadAsStringAsync());
+        Assert.True(observation.ChildInitialized);
+        Assert.Null(failure);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Whole_output_retains_unnamed_fragment_and_nested_subtree(bool direct)
+    {
+        using var request = direct ? DirectRequest(null) : new HttpRequestMessage(HttpMethod.Get, "/nested-selection");
+        using var response = await client.SendAsync(request);
+        var whole = "<main>" + new string('x', 32768) + Parent + Sibling + "<u>unnamed</u></main>";
+        var expected = direct ? whole : "<!DOCTYPE html><html lang=\"en\"><body>" + whole + "</body></html>";
+        Assert.True(failure is null, failure?.ToString());
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(expected, await response.Content.ReadAsStringAsync());
+        Assert.True(observation.ChildInitialized);
+    }
+
+    [Theory]
+    [InlineData("Large,Parent,Child", null)]
+    [InlineData("Large,Child,Parent", null)]
+    [InlineData("Large,Child,Child", null)]
+    [InlineData("Large,Missing", null)]
+    [InlineData("Large,child", null)]
+    [InlineData("Large,1Invalid", "1Invalid")]
+    [InlineData("Large, ", null)]
+    [InlineData("Large,", null)]
+    [InlineData("Large,Child", "Child")]
+    [InlineData(null, "Child")]
+    [InlineData(null, "1Invalid")]
+    public async Task Invalid_selection_is_reported_before_any_response_output(string? selection, string? declaration)
+    {
+        using var request = DirectRequest(selection, declaration);
+        using var response = await client.SendAsync(request);
+        Assert.NotNull(failure);
+        Assert.True(failure is InvalidOperationException or ArgumentException, failure.ToString());
+        Assert.False(string.IsNullOrWhiteSpace(failure.Message));
+        Assert.False(responseStarted);
+        Assert.Equal("test-host-handled-selection-error", await response.Content.ReadAsStringAsync());
+    }
+
+    private static HttpRequestMessage DirectRequest(string? selection, string? declaration = null)
+    {
+        var query = new List<string>();
+        if (selection is not null) query.Add("selection=" + Uri.EscapeDataString(selection));
+        if (declaration is not null) query.Add("declaration=" + Uri.EscapeDataString(declaration));
+        var request = new HttpRequestMessage(HttpMethod.Get, "/nested-selection?" + string.Join("&", query));
+        request.Headers.Add("HX-Request", "true");
+        request.Headers.Add("HX-Request-Type", "partial");
+        request.Headers.Add("HX-Target", "section#parent");
+        request.Headers.Add("HX-Source", "button#Sibling");
+        request.Headers.Add("HX-Select", "#parent");
+        request.Headers.Add("HX-Select-OOB", "#parent");
+        return request;
+    }
+
+    public async Task DisposeAsync()
+    {
+        client.Dispose();
+        await app.DisposeAsync();
+    }
+}
+
+public sealed class Issue169RenderObservation
+{
+    public bool ChildInitialized { get; set; }
+}

--- a/test/Htmxor.Quality.Tests/PackedNestedSelectionConsumerTests.cs
+++ b/test/Htmxor.Quality.Tests/PackedNestedSelectionConsumerTests.cs
@@ -1,0 +1,24 @@
+using Htmxor.Quality;
+
+namespace Htmxor.Quality.Tests;
+
+[Collection(PackageConsumerCollection.Name)]
+public sealed class PackedNestedSelectionConsumerTests
+{
+	[Fact]
+	public async Task Package_only_application_resolves_nested_and_invalid_selections_before_output()
+	{
+		using var workspace = new PackageConsumerWorkspace(RepositoryLocator.Find());
+		workspace.UseIssue169SelectionScenario();
+
+		var result = await workspace.RunAsync();
+		var testRun = TrxTestRun.Read(workspace.TrxPath);
+
+		Assert.True(result.ExitCode == 0,
+			result.StandardOutput + Environment.NewLine + result.StandardError +
+			Environment.NewLine + $"TRX: {testRun}");
+		Assert.Equal(new TrxTestRun(18, 18, 18, 0, 0, 0, 0), testRun);
+		PackageConsumerEvidence.AssertPackage(workspace.PackagePath);
+		PackageConsumerEvidence.AssertConsumerPackageBoundary(workspace.ConsumerDirectory, workspace.PackageVersion);
+	}
+}

--- a/test/Htmxor.Quality.Tests/PackedPackageConsumerTests.cs
+++ b/test/Htmxor.Quality.Tests/PackedPackageConsumerTests.cs
@@ -241,7 +241,11 @@ internal sealed class PackageConsumerWorkspace : IDisposable
 		return await BuildAsync();
 	}
 
-	public void UseIssue168SelectionScenario()
+	public void UseIssue168SelectionScenario() => UseSelectionScenario("Issue168");
+
+	public void UseIssue169SelectionScenario() => UseSelectionScenario("Issue169");
+
+	private void UseSelectionScenario(string issue)
 	{
 		foreach (var path in Directory.EnumerateFiles(consumerDirectory).Where(path =>
 			path.EndsWith(".cs", StringComparison.Ordinal) || path.EndsWith(".razor", StringComparison.Ordinal)))
@@ -250,7 +254,7 @@ internal sealed class PackageConsumerWorkspace : IDisposable
 		}
 
 		var assets = Path.Combine(repositoryRoot, "test", "Htmxor.Quality.Tests", "PackageConsumer");
-		foreach (var path in Directory.EnumerateFiles(assets, "Issue168*.scenario"))
+		foreach (var path in Directory.EnumerateFiles(assets, issue + "*.scenario"))
 		{
 			File.Copy(path, Path.Combine(consumerDirectory, Path.GetFileNameWithoutExtension(path)));
 		}

--- a/test/Htmxor.Tests/Rendering/NestedFragmentSelectionTests.cs
+++ b/test/Htmxor.Tests/Rendering/NestedFragmentSelectionTests.cs
@@ -1,0 +1,165 @@
+using Htmxor.Components;
+using Htmxor.Endpoints;
+using Htmxor.Http;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Htmxor.Rendering;
+
+public sealed class NestedFragmentSelectionTests
+{
+	private const string Child = "<b>child</b>";
+	private const string Parent = "<section id=\"parent\"><i>before</i>" + Child + "<i>after</i></section>";
+	private const string Whole = "<main>" + Parent + "<aside>sibling</aside><u>unnamed</u></main>";
+
+	[Theory]
+	[InlineData("Child", Child)]
+	[InlineData("Parent", Parent)]
+	[InlineData("Sibling,Child", "<aside>sibling</aside>" + Child)]
+	[InlineData("Child,Sibling", Child + "<aside>sibling</aside>")]
+	[InlineData("", Whole)]
+	public Task Nested_selection_serializes_only_selected_boundaries_after_normal_render(string names, string expected) =>
+		WithRenderer(async (renderer, context) =>
+		{
+			var rendered = await renderer.RenderEndpointComponentAsync(typeof(NestedRoot), ParameterView.Empty);
+			rendered.ToHtmlString().Should().Be(Whole);
+			if (names.Length > 0) context.Response.SelectFragments(names.Split(','));
+			using var writer = new StringWriter();
+			renderer.WriteResponseHtml(rendered, context, writer);
+			writer.ToString().Should().Be(expected);
+		});
+
+	[Theory]
+	[InlineData("Parent", "Child")]
+	[InlineData("Child", "Parent")]
+	[InlineData("Child", "Child")]
+	[InlineData("Child", "Missing")]
+	[InlineData("Child", "child")]
+	public Task Invalid_sets_fail_before_writing_any_selected_html(string first, string second) =>
+		WithRenderer(async (renderer, context) =>
+		{
+			var rendered = await renderer.RenderEndpointComponentAsync(typeof(NestedRoot), ParameterView.Empty);
+			rendered.ToHtmlString().Should().Be(Whole);
+			using var writer = new StringWriter();
+			Action write = () =>
+			{
+				context.Response.SelectFragments(first, second);
+				renderer.WriteResponseHtml(rendered, context, writer);
+			};
+			var failure = Record.Exception(write);
+			failure.Should().NotBeNull("invalid selection must fail before output, but received {0}", writer.ToString());
+			failure!.Message.Should().NotBeNullOrWhiteSpace();
+			writer.ToString().Should().BeEmpty();
+		});
+
+	public static TheoryData<string> InvalidNames => new()
+	{
+		"", " ", "1First", "_First", "-First", "First.Second", "First Second", "Ångstrom", "Aé", new string('A', 65),
+	};
+
+	[Theory]
+	[MemberData(nameof(InvalidNames))]
+	public Task Malformed_selected_names_fail_even_when_a_declaration_matches(string name) =>
+		AssertRejectedName(name, true);
+
+	[Theory]
+	[MemberData(nameof(InvalidNames))]
+	public Task Malformed_declarations_fail_before_whole_output(string name) =>
+		AssertRejectedName(name, false);
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("Child")]
+	[InlineData("Sibling")]
+	public Task Duplicate_declarations_fail_even_when_not_selected(string? selection) =>
+		AssertRejectedName("Child", selection is not null, selection);
+
+	[Theory]
+	[InlineData("child")]
+	[InlineData("A")]
+	[InlineData("zZ09-_")]
+	[InlineData("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")]
+	public Task Valid_identifier_boundaries_remain_selectable(string name) =>
+		WithRenderer(async (renderer, context) =>
+		{
+			var rendered = await renderer.RenderEndpointComponentAsync(typeof(NestedRoot), ExtraName(name));
+			context.Response.SelectFragment(name);
+			using var writer = new StringWriter();
+			renderer.WriteResponseHtml(rendered, context, writer);
+			writer.ToString().Should().Be("<u>unnamed</u>");
+		});
+
+	private static Task AssertRejectedName(string name, bool select, string? selection = null) =>
+		WithRenderer(async (renderer, context) =>
+		{
+			using var writer = new StringWriter();
+			Func<Task> write = async () =>
+			{
+				if (select) context.Response.SelectFragment(selection ?? name);
+				var rendered = await renderer.RenderEndpointComponentAsync(typeof(NestedRoot), ExtraName(name));
+				renderer.WriteResponseHtml(rendered, context, writer);
+			};
+			(await write.Should().ThrowAsync<Exception>()).Which.Message.Should().NotBeNullOrWhiteSpace();
+			writer.ToString().Should().BeEmpty();
+		});
+
+	private static ParameterView ExtraName(string name) => ParameterView.FromDictionary(
+		new Dictionary<string, object?> { [nameof(NestedRoot.ExtraName)] = name });
+
+	private static async Task WithRenderer(Func<HtmxorEndpointCandidateRenderer, HtmxContext, Task> test)
+	{
+		var http = new DefaultHttpContext();
+		http.Request.Headers["HX-Request"] = "true";
+		http.Request.Headers["HX-Request-Type"] = "partial";
+		var context = http.GetHtmxContext();
+		context.UsesCompletedFragmentSelection = true;
+		await using var services = new ServiceCollection().AddSingleton(context).BuildServiceProvider();
+		await using var renderer = new HtmxorEndpointCandidateRenderer(services, NullLoggerFactory.Instance);
+		await renderer.Dispatcher.InvokeAsync(() => test(renderer, context));
+	}
+
+	private sealed class NestedRoot : ComponentBase
+	{
+		[Parameter] public string? ExtraName { get; set; }
+
+		protected override void BuildRenderTree(RenderTreeBuilder builder)
+		{
+			builder.OpenElement(0, "main");
+			builder.OpenComponent<HtmxFragment>(1);
+			builder.AddComponentParameter(2, nameof(HtmxFragment.Name), "Parent");
+			builder.AddComponentParameter(3, nameof(HtmxFragment.Element), "section");
+			builder.AddComponentParameter(4, nameof(HtmxFragment.Id), "parent");
+			builder.AddComponentParameter(5, nameof(HtmxFragment.ChildContent), (RenderFragment)(content =>
+			{
+				content.AddMarkupContent(0, "<i>before</i>");
+				content.OpenComponent<NestedChild>(1);
+				content.CloseComponent();
+				content.AddMarkupContent(2, "<i>after</i>");
+			}));
+			builder.CloseComponent();
+			builder.OpenComponent<HtmxFragment>(6);
+			builder.AddComponentParameter(7, nameof(HtmxFragment.Name), "Sibling");
+			builder.AddComponentParameter(8, nameof(HtmxFragment.ChildContent), (RenderFragment)(content => content.AddMarkupContent(0, "<aside>sibling</aside>")));
+			builder.CloseComponent();
+			builder.OpenComponent<HtmxFragment>(9);
+			builder.AddComponentParameter(10, nameof(HtmxFragment.Name), ExtraName);
+			builder.AddComponentParameter(11, nameof(HtmxFragment.ChildContent), (RenderFragment)(content => content.AddMarkupContent(0, "<u>unnamed</u>")));
+			builder.CloseComponent();
+			builder.CloseElement();
+		}
+	}
+
+	private sealed class NestedChild : ComponentBase
+	{
+		protected override void BuildRenderTree(RenderTreeBuilder builder)
+		{
+			builder.OpenComponent<HtmxFragment>(0);
+			builder.AddComponentParameter(1, nameof(HtmxFragment.Name), "Child");
+			builder.AddComponentParameter(2, nameof(HtmxFragment.ChildContent), (RenderFragment)(content => content.AddMarkupContent(0, Child)));
+			builder.CloseComponent();
+		}
+	}
+}


### PR DESCRIPTION
Direct fragment responses now validate the completed rendered name scope and the entire ordered selection before writing HTML. Selecting a nested child returns only that child; selecting both a parent and its descendant fails before either is emitted. Malformed, unknown, repeated, and duplicate declared names fail deterministically, while valid siblings retain caller order and normal requests retain whole output.

Closes #169.

Verification at `0882286926b6bad6efb3af2fe13dca4f668f5506`, compared with behavior start/base `b2bb028f6d5b5e611fdbf27d83decd4ba96150b3`:

- Meaningful red on unchanged production: renderer 25 failures / 37 cases; packed HTTP consumer 6 failures / 18 cases, including duplicate nested output in both selection orders.
- `dotnet test test/Htmxor.Tests/Htmxor.Tests.csproj -c Release --filter FullyQualifiedName~FragmentSelectionTests --blame-hang --blame-hang-timeout 5min`: 43/43 passed.
- `dotnet test test/Htmxor.Quality.Tests/Htmxor.Quality.Tests.csproj -c Release --no-build --filter FullyQualifiedName~PackedNestedSelectionConsumerTests --blame-hang --blame-hang-timeout 5min`: outer 1/1 and independently packed HTTP consumer 18/18 passed.
- `dotnet run --project eng/Htmxor.Quality/Htmxor.Quality.csproj -- check --profile fast`: 1,003/1,003 passed.
- `dotnet run --project eng/Htmxor.Quality/Htmxor.Quality.csproj -- check --profile full`: 1,006/1,006 passed, including browser tests and coverage verification.
- All 24 new assertion sites were reversed to confirm behavioral sensitivity and then restored green. Full-scope mutation was not run on this ordinary PR cadence.

Executed on Ubuntu Linux x64 with SDK 10.0.400 and .NET/ASP.NET Core 10.0.11. Chromium used existing system dependencies; fresh privileged dependency provisioning was unavailable. The packed pre-output probe uses 32 KiB output and test-only synchronous I/O. This does not establish default-host large-output compatibility, new async/concurrency behavior, browser delivery order, caching, skipped-work optimization, other platforms/frameworks, or release acceptance.

Delivery checkpoint: complete-change on `egil/issue-169-nested-selection`; independent local Standards and Spec reviews both passed with zero findings at the exact head. Review and Tester receipts are retained in the issue worktree under `artifacts/reviews/issue-169/complete-change/0882286926b6bad6efb3af2fe13dca4f668f5506/`. Next: current-head GitHub CI, configured Copilot review, then guarded squash merge if the reviewed base remains current.
