### PR TITLE
test(fragments): prove named lifecycle and concurrent isolation

### DIFF
--- a/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue171BrowserTests.cs.template
+++ b/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue171BrowserTests.cs.template
@@ -1,0 +1,163 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Microsoft.Playwright;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Htmxor.Htmx4Browser;
+
+public sealed partial class Issue56BrowserTests(ITestOutputHelper output)
+{
+	[Fact]
+	public async Task Named_selections_wait_for_sibling_data_and_keep_overlapping_requests_isolated()
+	{
+		var probe = new Issue171LifecycleProbe();
+		await using var app = CreateApplication(new Issue56RequestProbe(), issue171Probe: probe);
+		await app.StartAsync();
+		using var playwright = await Playwright.CreateAsync();
+		await using var browser = await playwright.Chromium.LaunchAsync(new() { Headless = true });
+		output.WriteLine($"Chromium {browser.Version}; .NET {Environment.Version}");
+		await using var context = await browser.NewContextAsync(new() { BaseURL = Assert.Single(app.Urls) });
+		var pageA = await context.NewPageAsync();
+		var pageB = await context.NewPageAsync();
+		await Task.WhenAll(
+			PrepareIssue171PageAsync(pageA, "request-a", "summary"),
+			PrepareIssue171PageAsync(pageB, "request-b", "details"));
+		var runA = probe.For("request-a");
+		var runB = probe.For("request-b");
+		output.WriteLine($"Gates A: summary={runA.Summary.Id}, details={runA.Details.Id}; B: summary={runB.Summary.Id}, details={runB.Details.Id}");
+
+		try
+		{
+			var responseA = WaitForIssue171ResponseAsync(pageA);
+			var responseB = WaitForIssue171ResponseAsync(pageB);
+			await Task.WhenAll(pageA.Locator("#issue-171-select").ClickAsync(), pageB.Locator("#issue-171-select").ClickAsync());
+			await Task.WhenAll(runA.Summary.Rendered.Task, runA.Details.Rendered.Task,
+				runB.Summary.Rendered.Task, runB.Details.Rendered.Task).WaitAsync(TimeSpan.FromSeconds(30));
+			var requestIdA = Assert.Single(runA.Snapshot().Select(item => item.RequestId).Distinct());
+			var requestIdB = Assert.Single(runB.Snapshot().Select(item => item.RequestId).Distinct());
+			Assert.NotEqual(requestIdA, requestIdB);
+			Assert.NotEqual(runA.Id, runB.Id);
+			AssertIssue171Lifecycle(runA, requestIdA, "summary", completed: []);
+			AssertIssue171Lifecycle(runB, requestIdB, "details", completed: []);
+			await AssertIssue171PendingAsync(pageA, responseA, "request-a");
+			await AssertIssue171PendingAsync(pageB, responseB, "request-b");
+
+			runA.Summary.Release.TrySetResult();
+			runB.Details.Release.TrySetResult();
+			await Task.WhenAll(runA.Summary.CompletedRender.Task, runB.Details.CompletedRender.Task)
+				.WaitAsync(TimeSpan.FromSeconds(30));
+			AssertIssue171Lifecycle(runA, requestIdA, "summary", completed: ["summary"]);
+			AssertIssue171Lifecycle(runB, requestIdB, "details", completed: ["details"]);
+			await AssertIssue171PendingAsync(pageA, responseA, "request-a");
+			await AssertIssue171PendingAsync(pageB, responseB, "request-b");
+			var blockedB = runB.Snapshot();
+
+			runA.Details.Release.TrySetResult();
+			await AssertIssue171CompletedAsync(pageA, await responseA, "request-a", requestIdA, "summary");
+			AssertIssue171Lifecycle(runA, requestIdA, "summary", completed: ["summary", "details"]);
+			var completedA = runA.Snapshot();
+			await AssertIssue171PendingAsync(pageB, responseB, "request-b");
+			Assert.False(runB.Summary.Release.Task.IsCompleted);
+			Assert.Equal(blockedB, runB.Snapshot());
+
+			runB.Summary.Release.TrySetResult();
+			await AssertIssue171CompletedAsync(pageB, await responseB, "request-b", requestIdB, "details");
+			AssertIssue171Lifecycle(runB, requestIdB, "details", completed: ["summary", "details"]);
+			Assert.Equal(completedA, runA.Snapshot());
+			await AssertIssue171DomAsync(pageA, "request-a", requestIdA, "summary");
+		}
+		finally
+		{
+			runA.ReleaseAll();
+			runB.ReleaseAll();
+		}
+	}
+
+	private static async Task PrepareIssue171PageAsync(IPage page, string marker, string selection)
+	{
+		await page.GotoAsync($"/issue-171/lifecycle?marker={marker}&selection={selection}");
+		await page.EvaluateAsync("""
+			() => {
+				window.issue171Events = [];
+				for (const name of ['htmx:after:request', 'htmx:after:swap']) {
+					document.addEventListener(name, event => {
+						if (event.detail.ctx.sourceElement.id === 'issue-171-select') {
+							window.issue171Events.push(name);
+						}
+					});
+				}
+			}
+			""");
+	}
+
+	private static Task<IResponse> WaitForIssue171ResponseAsync(IPage page) =>
+		page.WaitForResponseAsync(response => new Uri(response.Url).AbsolutePath == "/issue-171/lifecycle");
+
+	private async Task AssertIssue171PendingAsync(IPage page, Task<IResponse> response, string marker)
+	{
+		// A bounded absence window detects premature HTTP output while real descendant work is held.
+		var window = Task.Delay(TimeSpan.FromMilliseconds(250));
+		Assert.Same(window, await Task.WhenAny(response, window));
+		var html = await page.Locator("#delivery-slot").InnerHTMLAsync();
+		var events = await page.EvaluateAsync<string[]>("() => window.issue171Events");
+		output.WriteLine($"Pending {marker}: 250ms window; response arrived={response.IsCompleted}; DOM={html}; events={JsonSerializer.Serialize(events)}");
+		Assert.Equal($"Waiting {marker}", html);
+		Assert.Empty(events);
+	}
+
+	private async Task AssertIssue171CompletedAsync(
+		IPage page, IResponse response, string marker, string requestId, string selection)
+	{
+		Assert.Equal(200, response.Status);
+		var headers = await response.Request.AllHeadersAsync();
+		Assert.Equal("div#delivery-slot", headers["hx-target"]);
+		Assert.Equal("true", headers["hx-request"]);
+		Assert.Equal("partial", headers["hx-request-type"]);
+		var body = await response.TextAsync();
+		output.WriteLine($"Response {marker}: status={response.Status}; headers={JsonSerializer.Serialize(headers)}; body={body}");
+		Assert.Equal(Issue171ExpectedHtml(marker, requestId, selection),
+			Regex.Replace(body, @">\s+<", "><").Trim());
+		await AssertIssue171DomAsync(page, marker, requestId, selection);
+	}
+
+	private async Task AssertIssue171DomAsync(IPage page, string marker, string requestId, string selection)
+	{
+		await page.Locator($"#delivery-slot [data-issue-171-completed='{marker}:{requestId}:{selection}']").WaitForAsync();
+		await page.WaitForFunctionAsync("() => window.issue171Events.length === 2");
+		var html = await page.Locator("#delivery-slot").InnerHTMLAsync();
+		var events = await page.EvaluateAsync<string[]>("() => window.issue171Events");
+		output.WriteLine($"DOM {marker}: {html}; events={JsonSerializer.Serialize(events)}");
+		Assert.Equal(Issue171ExpectedHtml(marker, requestId, selection),
+			Regex.Replace(html, @">\s+<", "><").Trim());
+		Assert.Equal(new[] { "htmx:after:request", "htmx:after:swap" }, events);
+	}
+
+	private static string Issue171ExpectedHtml(string marker, string requestId, string selection) =>
+		$"<div id=\"{selection}-envelope\"><span data-issue-171-branch=\"{selection}\" data-issue-171-completed=\"{marker}:{requestId}:{selection}\">{marker}:{requestId}:{selection}</span></div>";
+
+	private void AssertIssue171Lifecycle(Issue171RequestRun run, string requestId, string selection, string[] completed)
+	{
+		var expected = new List<Issue171Observation>
+		{
+			new(requestId, run.Id, "owner", "initialized", ""),
+			new(requestId, run.Id, "owner", "parameters-set", selection),
+			new(requestId, run.Id, "owner", "rendered", selection),
+		};
+		foreach (var branch in new[] { "summary", "details" })
+		{
+			expected.AddRange(new[] { "initialized", "parameters-set", "rendered" }
+				.Select(phase => new Issue171Observation(requestId, run.Id, $"fragment:{branch}", phase, selection)));
+			expected.AddRange(new[] { "initialization-entered", "data-entered", "rendered" }
+				.Select(phase => new Issue171Observation(requestId, run.Id, $"descendant:{branch}", phase, selection)));
+		}
+		foreach (var branch in completed)
+		{
+			expected.AddRange(new[] { "data-completed", "initialization-completed", "parameters-set", "rendered" }
+				.Select(phase => new Issue171Observation(requestId, run.Id, $"descendant:{branch}", phase, selection)));
+		}
+		output.WriteLine($"Lifecycle {selection}, completed={string.Join(",", completed)}: {JsonSerializer.Serialize(run.Snapshot())}");
+		Assert.Equal(expected.OrderBy(item => item.Component).ThenBy(item => item.Phase),
+			run.Snapshot().OrderBy(item => item.Component).ThenBy(item => item.Phase));
+	}
+}

--- a/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue171Descendant.razor.template
+++ b/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue171Descendant.razor.template
@@ -1,0 +1,31 @@
+@inject Issue171RequestWork Work
+
+@{
+	Work.Record($"descendant:{Branch}", "rendered");
+	Gate.Rendered.TrySetResult();
+	if (Completed is not null)
+	{
+		Gate.CompletedRender.TrySetResult();
+	}
+}
+<span data-issue-171-branch="@Branch" data-issue-171-completed="@Completed">@Completed</span>
+
+@code {
+	[Parameter, EditorRequired]
+	public required string Branch { get; set; }
+
+	private string? Completed { get; set; }
+	private Issue171DataGate Gate => Branch == "summary" ? Work.Run.Summary : Work.Run.Details;
+
+	protected override async Task OnInitializedAsync()
+	{
+		Work.Record($"descendant:{Branch}", "initialization-entered");
+		Work.Record($"descendant:{Branch}", "data-entered");
+		await Gate.Release.Task;
+		Completed = $"{Work.Marker}:{Work.RequestId}:{Branch}";
+		Work.Record($"descendant:{Branch}", "data-completed");
+		Work.Record($"descendant:{Branch}", "initialization-completed");
+	}
+
+	protected override void OnParametersSet() => Work.Record($"descendant:{Branch}", "parameters-set");
+}

--- a/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue171LifecycleProbe.cs.template
+++ b/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue171LifecycleProbe.cs.template
@@ -1,0 +1,55 @@
+using System.Collections.Concurrent;
+using Htmxor.Http;
+using Microsoft.AspNetCore.Http;
+
+namespace Htmxor.Htmx4Browser;
+
+public sealed class Issue171LifecycleProbe
+{
+	private readonly ConcurrentDictionary<string, Issue171RequestRun> requests = new(StringComparer.Ordinal);
+
+	public Issue171RequestRun For(string marker) => requests.GetOrAdd(marker, static _ => new());
+}
+
+public sealed class Issue171RequestRun
+{
+	private readonly ConcurrentQueue<Issue171Observation> observations = new();
+
+	public Guid Id { get; } = Guid.NewGuid();
+	public Issue171DataGate Summary { get; } = new();
+	public Issue171DataGate Details { get; } = new();
+
+	public void Record(Issue171Observation observation) => observations.Enqueue(observation);
+	public Issue171Observation[] Snapshot() => observations.ToArray();
+	public void ReleaseAll()
+	{
+		Summary.Release.TrySetResult();
+		Details.Release.TrySetResult();
+	}
+}
+
+public sealed class Issue171DataGate
+{
+	public Guid Id { get; } = Guid.NewGuid();
+	public TaskCompletionSource Rendered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+	public TaskCompletionSource Release { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+	public TaskCompletionSource CompletedRender { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+}
+
+public sealed class Issue171RequestWork(HtmxContext htmx, IHttpContextAccessor accessor, Issue171LifecycleProbe probe)
+{
+	public string RequestId { get; } = accessor.HttpContext!.TraceIdentifier;
+	public string Marker { get; } = accessor.HttpContext!.Request.Query["marker"].ToString();
+	public bool IsDirect => htmx.Request.RoutingMode is RoutingMode.Direct;
+	public Issue171RequestRun Run => probe.For(Marker);
+
+	public void Record(string component, string phase)
+	{
+		if (IsDirect)
+		{
+			Run.Record(new(RequestId, Run.Id, component, phase, string.Join(",", htmx.Response.SelectedFragmentNames)));
+		}
+	}
+}
+
+public sealed record Issue171Observation(string RequestId, Guid RunId, string Component, string Phase, string Selection);

--- a/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue171ObservedFragment.cs.template
+++ b/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue171ObservedFragment.cs.template
@@ -1,0 +1,26 @@
+using System.Diagnostics.CodeAnalysis;
+using Htmxor.Components;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Htmxor.Htmx4Browser;
+
+public sealed class Issue171ObservedFragment : HtmxFragment
+{
+	[Inject]
+	public required Issue171RequestWork Work { get; set; }
+
+	protected override void OnInitialized() => Work.Record($"fragment:{Name}", "initialized");
+
+	protected override void OnParametersSet()
+	{
+		base.OnParametersSet();
+		Work.Record($"fragment:{Name}", "parameters-set");
+	}
+
+	protected override void BuildRenderTree([NotNull] RenderTreeBuilder builder)
+	{
+		Work.Record($"fragment:{Name}", "rendered");
+		base.BuildRenderTree(builder);
+	}
+}

--- a/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue171Page.razor.template
+++ b/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue171Page.razor.template
@@ -1,0 +1,42 @@
+@page "/issue-171/lifecycle"
+@using Htmxor.Http
+@inject HtmxContext Htmx
+@inject Issue171RequestWork Work
+
+@{
+	Work.Record("owner", "rendered");
+}
+@if (Work.IsDirect)
+{
+	<section data-issue-171-owner>
+		<Issue171ObservedFragment Name="summary" Id="summary-envelope">
+			<Issue171Descendant Branch="summary" />
+		</Issue171ObservedFragment>
+		<Issue171ObservedFragment Name="details" Id="details-envelope">
+			<Issue171Descendant Branch="details" />
+		</Issue171ObservedFragment>
+	</section>
+}
+else
+{
+	<button id="issue-171-select" type="button"
+			hx-get="@($"/issue-171/lifecycle?marker={Work.Marker}&selection={Selection}")"
+			hx-target="#delivery-slot" hx-swap="innerHTML">Select @Selection</button>
+	<div id="delivery-slot">Waiting @Work.Marker</div>
+}
+
+@code {
+	[SupplyParameterFromQuery]
+	private string Selection { get; set; } = "summary";
+
+	protected override void OnInitialized() => Work.Record("owner", "initialized");
+
+	protected override void OnParametersSet()
+	{
+		if (Work.IsDirect)
+		{
+			Htmx.Response.SelectFragment(Selection);
+		}
+		Work.Record("owner", "parameters-set");
+	}
+}

--- a/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue56BrowserTests.cs.template
+++ b/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue56BrowserTests.cs.template
@@ -14,7 +14,7 @@ using Xunit;
 
 namespace Htmxor.Htmx4Browser;
 
-public sealed class Issue56BrowserTests
+public sealed partial class Issue56BrowserTests
 {
 	private const string EntryPath = "/issue-56";
 	private const string GetOnlyPath = "/issue-56/get-only";
@@ -2755,7 +2755,8 @@ public sealed class Issue56BrowserTests
 		Issue137LifecycleProbe? issue137Probe = null,
 		Issue139AsyncLifecycleProbe? issue139Probe = null,
 		Issue144ConcurrentLifecycleProbe? issue144Probe = null,
-		bool useHtmxor = true)
+		bool useHtmxor = true,
+		Issue171LifecycleProbe? issue171Probe = null)
 	{
 		var builder = WebApplication.CreateBuilder(new WebApplicationOptions
 		{
@@ -2794,6 +2795,8 @@ public sealed class Issue56BrowserTests
 		builder.Services.AddSingleton(issue139Probe ?? new Issue139AsyncLifecycleProbe());
 		builder.Services.AddSingleton(issue144Probe ?? new Issue144ConcurrentLifecycleProbe());
 		builder.Services.AddScoped<Issue120RequestScope>();
+		builder.Services.AddSingleton(issue171Probe ?? new Issue171LifecycleProbe());
+		builder.Services.AddScoped<Issue171RequestWork>();
 
 		var app = builder.Build();
 		Assert.True(app.Environment.IsProduction());

--- a/test/Htmxor.Quality.Tests/Htmx4PackageBrowserTests.cs
+++ b/test/Htmxor.Quality.Tests/Htmx4PackageBrowserTests.cs
@@ -20,7 +20,7 @@ public sealed class Htmx4PackageBrowserTests
 			result.ExitCode == 0,
 			result.StandardOutput + Environment.NewLine + result.StandardError +
 			Environment.NewLine + $"TRX: {testRun}");
-		Assert.Equal(new TrxTestRun(39, 39, 39, 0, 0, 0, 0), testRun);
+		Assert.Equal(new TrxTestRun(40, 40, 40, 0, 0, 0, 0), testRun);
 		PackageConsumerEvidence.AssertPackage(workspace.PackagePath);
 		Htmx4PackageBrowserEvidence.AssertConsumer(workspace);
 	}


### PR DESCRIPTION
Overlapping named-fragment requests now have packed-package browser coverage for normal full-tree lifecycle and quiescence. The test releases selected data before sibling data, then completes one request while the other remains gated, verifying request-local selections and lifecycle records, exact response HTML, htmx events, and live DOM. Server names differ from both fragment wrapper IDs and browser targets. No production behavior changes.

Closes #171.

Verification at `2d91806efb21d4709e0db05df05a24355745ac5e` against base `31a536ab150bb2a02babace51a49f3c24806e977`:

- Separately packed and published .NET 10 Production application, Kestrel, application-owned htmx 4.0.0, and cached Chromium: 40/40 browser tests, outer package-boundary test 1/1.
- 18 individual assertion reversals produced intended failures and passed after restoration; the nested test-count guard was also verified.
- `dotnet run --project eng/Htmxor.Quality/Htmxor.Quality.csproj -- check --profile fast`: 1,003/1,003 passed.
- Same command with `--profile full`: 1,006/1,006 passed; two identical fresh coverage reports. Both profiles passed Release/static gates with zero failed/skipped/error/timeout tests.
- Independent test-contract and complete-change Standards and Spec reviews: clean, zero findings on each axis.

Evidence covers Linux and cached Chromium only. Fresh browser provisioning, other browsers/frameworks, additional clients, cancellation/disposal/errors, streaming, optimization, and performance are outside scope. Full-scope mutation was not run on this ordinary PR cadence.

Delivery phase: local verification and independent reviews clean at the exact candidate above; next owner: hosted CI, then ready/current-head Copilot review before authorized squash merge. No release or deployment.
