### PR TITLE
test(fragments): preserve native delivery under named selection

### DIFF
--- a/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue174BrowserTests.cs.template
+++ b/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue174BrowserTests.cs.template
@@ -1,0 +1,71 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace Htmxor.Htmx4Browser;
+
+public sealed partial class Issue56BrowserTests
+{
+	[Theory]
+	[InlineData("alpha")]
+	[InlineData("beta")]
+	public async Task Named_fragment_preserves_native_deliveries_independently_of_client_identities(string delivery)
+	{
+		await using var app = CreateApplication(new Issue56RequestProbe());
+		await app.StartAsync();
+		using var playwright = await Playwright.CreateAsync();
+		await using var browser = await playwright.Chromium.LaunchAsync(new() { Headless = true });
+		output.WriteLine($"Chromium {browser.Version}; .NET {Environment.Version}; delivery={delivery}");
+		await using var context = await browser.NewContextAsync(new() { BaseURL = Assert.Single(app.Urls) });
+		var page = await context.NewPageAsync();
+		await page.GotoAsync($"/issue-174/native-delivery?delivery={delivery}");
+		await page.WaitForFunctionAsync("() => window.htmx?.version === '4.0.0'");
+		await page.EvaluateAsync("""
+			delivery => {
+				window.issue174Deliveries = [];
+				const targets = [`main-${delivery}`, `oob-${delivery}`, `partial-${delivery}`];
+				document.addEventListener('htmx:before:settle', event => {
+					if (targets.includes(event.target.id)) {
+						window.issue174Deliveries.push(event.target.id);
+					}
+				});
+			}
+			""", delivery);
+
+		var responseTask = page.WaitForResponseAsync(response =>
+			new Uri(response.Url).AbsolutePath == "/issue-174/native-delivery");
+		await page.Locator($"#source-{delivery}").ClickAsync();
+		var response = await responseTask;
+		var headers = await response.Request.AllHeadersAsync();
+		output.WriteLine($"Status={response.Status}; request headers={JsonSerializer.Serialize(headers)}");
+		Assert.Equal(
+			new[] { "200", "true", "partial", $"button#source-{delivery}", $"main#main-{delivery}" },
+			new[] { response.Status.ToString(), headers["hx-request"], headers["hx-request-type"], headers["hx-source"], headers["hx-target"] });
+		var body = await response.BodyAsync();
+		output.WriteLine($"Response UTF-8: {Encoding.UTF8.GetString(body)}");
+		Assert.Equal(Encoding.UTF8.GetBytes(
+			$"<div id=\"envelope-{delivery}\"><aside id=\"oob-{delivery}\" hx-swap-oob=\"true\" data-delivery=\"native-oob\">OOB updated</aside>" +
+			$"<hx-partial hx-target=\"#partial-{delivery}\" hx-swap=\"innerHTML\" data-delivery=\"raw-partial\"><strong>Partial updated</strong></hx-partial>" +
+			"<section data-delivery=\"main\">Main updated</section></div>"), body);
+
+		await page.WaitForFunctionAsync("() => window.issue174Deliveries.length >= 3");
+		var events = await page.EvaluateAsync<string[]>("() => window.issue174Deliveries");
+		output.WriteLine($"Delivery events: {JsonSerializer.Serialize(events)}");
+		Assert.Equal($"main-{delivery}", events[0]);
+		Assert.Equal(new[] { $"main-{delivery}", $"oob-{delivery}", $"partial-{delivery}" }, events.Order());
+		var dom = new[]
+		{
+			await page.Locator($"#main-{delivery}").InnerHTMLAsync(),
+			await page.Locator($"#oob-{delivery}").TextContentAsync(),
+			await page.Locator($"#partial-{delivery}").InnerHTMLAsync(),
+		};
+		output.WriteLine($"Final DOM: {JsonSerializer.Serialize(dom)}");
+		Assert.Equal(new[]
+		{
+			$"<div id=\"envelope-{delivery}\"><section data-delivery=\"main\">Main updated</section></div>",
+			"OOB updated",
+			"<strong>Partial updated</strong>",
+		}, dom);
+	}
+}

--- a/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue174Page.razor.template
+++ b/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue174Page.razor.template
@@ -1,0 +1,35 @@
+@page "/issue-174/native-delivery"
+@using Htmxor.Http
+@inject HtmxContext Htmx
+
+@if (Htmx.Request.RoutingMode is RoutingMode.Direct)
+{
+	<section data-unselected-shell>
+		<HtmxFragment Name="main-alpha"><p>Wrong alpha fragment</p></HtmxFragment>
+		@* Additional deliveries precede main markup to distinguish declaration order from browser delivery order. *@
+		<HtmxFragment Name="server-bundle" Id="@($"envelope-{Delivery}")"><aside id="@($"oob-{Delivery}")" hx-swap-oob="true" data-delivery="native-oob">OOB updated</aside><hx-partial hx-target="@($"#partial-{Delivery}")" hx-swap="innerHTML" data-delivery="raw-partial"><strong>Partial updated</strong></hx-partial><section data-delivery="main">Main updated</section></HtmxFragment>
+		<HtmxFragment Name="main-beta"><p>Wrong beta fragment</p></HtmxFragment>
+	</section>
+}
+else
+{
+	<button id="@($"source-{Delivery}")" type="button"
+			hx-get="@($"/issue-174/native-delivery?delivery={Delivery}")"
+			hx-target="@($"#main-{Delivery}")" hx-swap="innerHTML">Load native deliveries</button>
+	<main id="@($"main-{Delivery}")">Main original</main>
+	<aside id="@($"oob-{Delivery}")">OOB original</aside>
+	<div id="@($"partial-{Delivery}")">Partial original</div>
+}
+
+@code {
+	[SupplyParameterFromQuery]
+	private string Delivery { get; set; } = "alpha";
+
+	protected override void OnParametersSet()
+	{
+		if (Htmx.Request.RoutingMode is RoutingMode.Direct)
+		{
+			Htmx.Response.SelectFragment("server-bundle");
+		}
+	}
+}

--- a/test/Htmxor.Quality.Tests/Htmx4PackageBrowserTests.cs
+++ b/test/Htmxor.Quality.Tests/Htmx4PackageBrowserTests.cs
@@ -20,7 +20,7 @@ public sealed class Htmx4PackageBrowserTests
 			result.ExitCode == 0,
 			result.StandardOutput + Environment.NewLine + result.StandardError +
 			Environment.NewLine + $"TRX: {testRun}");
-		Assert.Equal(new TrxTestRun(40, 40, 40, 0, 0, 0, 0), testRun);
+		Assert.Equal(new TrxTestRun(42, 42, 42, 0, 0, 0, 0), testRun);
 		PackageConsumerEvidence.AssertPackage(workspace.PackagePath);
 		Htmx4PackageBrowserEvidence.AssertConsumer(workspace);
 	}


### PR DESCRIPTION
Adds package-browser characterization for a fixed server fragment name containing application-authored main content, OOB markup, and raw `<hx-partial>` envelopes. Two variants change client identities while the server name stays fixed; exact UTF-8 response bytes and native htmx events/final DOM verify unchanged markup, selection independence, and main-before-additional delivery. No production code changes.

Closes #174.

Verified candidate: `8a8355b93b9a7d3515e4bb1240aa13fa2c3d4269`; comparison base and behavior start: `9116b4065fc53415d47cadddd4bfdc228e8e93e0`.

Validation:

- Existing package-browser baseline: 40/40; final consumer suite: 42/42 (outer 1/1).
- Ten controlled assertion reversals failed as intended, plus a discovery-count inversion; all assertions restored and green.
- `dotnet run --project eng/Htmxor.Quality/Htmxor.Quality.csproj --configuration Release --no-restore -- check --profile fast`: 1,003/1,003 passed.
- Same command with `--profile full`: 1,006/1,006 passed, fresh matching coverage; both profiles built Release with zero warnings/errors.
- Exact focused command and reversal evidence are retained in the commit body and ignored local review receipts.

Boundary: separately packed package, Production-published .NET/ASP.NET Core 10.0.11 application on Linux/Kestrel, application-owned htmx 4.0.0 defaults, Chromium 151.0.7922.34. Full-scope mutation was not requested. Other runtimes, browsers, operating systems, target/swap shapes, streaming, history, extensions, caching, concurrency, performance, and fresh browser provisioning remain outside this evidence.

Independent local review: test-contract and complete-change modes both passed separate Standards and Spec reviews with zero findings at the exact candidate commit. Fresh green-finalization passed all required local gates. Review receipts are retained under the ignored exact-snapshot directories.
