### PR TITLE
test(cache): vary named fragment representations

### DIFF
--- a/docs/htmxor-v1-feature-guide.md
+++ b/docs/htmxor-v1-feature-guide.md
@@ -302,13 +302,11 @@ fragments. The component and required ancestors may run, but excluded child
 branches below a known selection boundary must not render or execute their own
 lifecycle work.
 
-The current API uses `Id`, request target matching, `Match`, and
-`RenderDuringStandardRequest` for selection. That makes a DOM delivery detail
-double as a server execution key and makes multi-fragment responses difficult to
-read. The DX review proposes a stable fragment name that is independent of the
-wrapper `Id`, plus one explicit response-level way to select multiple names.
-The exact names remain to be decided; examples must not present a proposed
-`Name` or `RenderFragments` member as shipped API.
+Select a stable name with `Htmx.Response.SelectFragment(...)` or
+`SelectFragments(...)`. The name is independent of the wrapper `Id` and browser
+delivery details. `Match` and `RenderDuringStandardRequest` remain legacy
+conditional-renderer options; do not use request target matching as the server
+selection key.
 
 Keep server execution separate from browser delivery:
 
@@ -323,6 +321,30 @@ Keep server execution separate from browser delivery:
 Do not route capabilities by `HX-Target` or `HX-Source`. Those headers are
 useful representation hints but are optional, forgeable, and unable to encode
 all extended-selector cases.
+
+### Cache a selected representation safely
+
+Output caching is application policy. Cache only safe requests, and make the
+cache key include every input that can change the component output. For example,
+this component chooses a named fragment from the `representation` query value:
+
+```razor
+@attribute [OutputCache(
+    VaryByHeaderNames = ["HX-Request", "HX-Request-Type"],
+    VaryByQueryKeys = ["representation"])]
+```
+
+`HX-Request` separates normal routing from a direct htmx response. Add every
+other request-mode input that the component uses, such as `HX-Request-Type`,
+boost, or history state, and each route value, query value, or request header
+that selects an output. Include culture, tenant, authentication and
+authorization-dependent identity, and any other application state in the cache
+policy whenever it affects the representation. If a safe per-representation key
+cannot be defined, do not place that response in a shared output cache.
+
+HTMX headers describe an untrusted request representation; they do not authorize
+the request. The application retains responsibility for authorization and for
+choosing a cache policy that matches its own selection logic.
 
 ### Multiple targets
 

--- a/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue50CachePage.razor.template
+++ b/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue50CachePage.razor.template
@@ -1,14 +1,46 @@
 @page "/issue-50/cache"
-@attribute [OutputCache(VaryByHeaderNames = ["HX-Request"])]
+@attribute [OutputCache(VaryByHeaderNames = ["HX-Request", "HX-Request-Type"], VaryByQueryKeys = ["representation"])]
+@using Htmxor.Http
 @using Microsoft.AspNetCore.OutputCaching
+@inject HtmxContext Htmx
 @inject Issue50CacheProbe Probe
 
-<main data-issue-50-cache data-render-count="@renderCount">
+<main data-issue-50-cache data-representation="@Representation" data-render-count="@renderCount">
 	<h1>Output cache representation</h1>
+	<HtmxFragment Name="alpha">
+		<section data-issue-50-fragment="alpha" data-representation="@Representation">Alpha fragment</section>
+	</HtmxFragment>
+	<HtmxFragment Name="beta">
+		<section data-issue-50-fragment="beta" data-representation="@Representation">Beta fragment</section>
+	</HtmxFragment>
 </main>
 
 @code {
 	private int renderCount;
 
+	[SupplyParameterFromQuery(Name = "representation")]
+	private string Representation { get; set; } = "whole";
+
 	protected override void OnInitialized() => renderCount = Probe.RecordRender();
+
+	protected override void OnParametersSet()
+	{
+		if (Htmx.Request.RoutingMode is not RoutingMode.Direct)
+		{
+			return;
+		}
+
+		if (string.Equals(Representation, "alpha", StringComparison.Ordinal))
+		{
+			Htmx.Response.SelectFragment("alpha");
+		}
+		else if (string.Equals(Representation, "beta", StringComparison.Ordinal))
+		{
+			Htmx.Response.SelectFragment("beta");
+		}
+		else
+		{
+			Htmx.Response.SelectWholeComponent();
+		}
+	}
 }

--- a/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue56BrowserTests.cs.template
+++ b/test/Htmxor.Quality.Tests/Htmx4PackageBrowser/Issue56BrowserTests.cs.template
@@ -21,6 +21,14 @@ public sealed partial class Issue56BrowserTests
 	private const string ApplicationHtmxPath = "/htmx-4.0.0.min.js";
 	private const string Issue111Path = "/issue-111";
 	private const string Issue50Path = "/issue-50/cache";
+	private static readonly CacheRepresentation[] Issue50Representations =
+	[
+		new("normal", "normal", RequestType: null),
+		new("whole-partial", "whole", "partial"),
+		new("alpha-partial", "alpha", "partial"),
+		new("beta-partial", "beta", "partial"),
+		new("alpha-full", "alpha", "full"),
+	];
 	private const string Issue18Path = "/issue-18/headers";
 	private const string Issue116Path = "/issue-116/trigger";
 	private const string Issue118Path = "/issue-118/request-context";
@@ -123,8 +131,9 @@ public sealed partial class Issue56BrowserTests
 		await app.StartAsync();
 		using var client = new HttpClient { BaseAddress = new Uri(Assert.Single(app.Urls)) };
 
-		using var first = await SendCacheRequestAsync(client, htmx: false);
-		using var second = await SendCacheRequestAsync(client, htmx: false);
+		var normal = Issue50Representations.Single(representation => representation.Label == "normal");
+		using var first = await SendCacheRequestAsync(client, normal);
+		using var second = await SendCacheRequestAsync(client, normal);
 		Assert.Equal(HttpStatusCode.OK, first.StatusCode);
 		Assert.Equal(HttpStatusCode.OK, second.StatusCode);
 		Assert.Equal(
@@ -134,20 +143,22 @@ public sealed partial class Issue56BrowserTests
 	}
 
 	[Fact]
-	public async Task Output_cache_keeps_full_and_direct_get_representations_distinct()
+	public async Task Output_cache_keeps_normal_direct_whole_and_named_fragment_representations_distinct()
 	{
-		foreach (var htmxFirst in new[] { false, true })
+		foreach (var alphaFirst in new[] { "alpha-full", "alpha-partial" })
 		{
 			var probe = new Issue50CacheProbe();
 			await using var app = CreateApplication(new Issue56RequestProbe(), cacheProbe: probe);
 			await app.StartAsync();
 			using var client = new HttpClient { BaseAddress = new Uri(Assert.Single(app.Urls)) };
 
-			var firstBody = await AssertCachedRepresentationAsync(client, htmxFirst);
-			Assert.Equal(1, probe.RenderCount);
-			var secondBody = await AssertCachedRepresentationAsync(client, !htmxFirst);
-			Assert.Equal(2, probe.RenderCount);
-			Assert.NotEqual(firstBody, secondBody);
+			foreach (var representation in Issue50Representations
+				.OrderBy(representation => representation.Label == alphaFirst ? 0 : 1))
+			{
+				await AssertCachedRepresentationAsync(client, representation);
+			}
+
+			Assert.Equal(Issue50Representations.Length, probe.RenderCount);
 		}
 	}
 
@@ -2962,10 +2973,10 @@ public sealed partial class Issue56BrowserTests
 		return await client.SendAsync(request);
 	}
 
-	private static async Task<string> AssertCachedRepresentationAsync(HttpClient client, bool htmx)
+	private static async Task AssertCachedRepresentationAsync(HttpClient client, CacheRepresentation representation)
 	{
-		using var first = await SendCacheRequestAsync(client, htmx);
-		using var second = await SendCacheRequestAsync(client, htmx);
+		using var first = await SendCacheRequestAsync(client, representation);
+		using var second = await SendCacheRequestAsync(client, representation);
 		Assert.Equal(HttpStatusCode.OK, first.StatusCode);
 		Assert.Equal(HttpStatusCode.OK, second.StatusCode);
 		Assert.False(first.Headers.Contains("Set-Cookie"));
@@ -2973,22 +2984,40 @@ public sealed partial class Issue56BrowserTests
 		var firstBody = await first.Content.ReadAsStringAsync();
 		var secondBody = await second.Content.ReadAsStringAsync();
 		Assert.Equal(firstBody, secondBody);
-		Assert.Equal(!htmx, firstBody.Contains("data-stock-shell", StringComparison.Ordinal));
-		Assert.Contains("data-issue-50-cache", firstBody, StringComparison.Ordinal);
-		return firstBody;
+		Assert.Equal(
+			representation.RequestType is not "partial",
+			firstBody.Contains("data-stock-shell", StringComparison.Ordinal));
+		Assert.Contains($"data-representation=\"{representation.Selection}\"", firstBody, StringComparison.Ordinal);
+		if (representation is { RequestType: "partial", Selection: "alpha" or "beta" })
+		{
+			Assert.Contains(
+				$"data-issue-50-fragment=\"{representation.Selection}\"",
+				firstBody,
+				StringComparison.Ordinal);
+		}
+		else
+		{
+			Assert.Contains("data-issue-50-cache", firstBody, StringComparison.Ordinal);
+		}
 	}
 
-	private static async Task<HttpResponseMessage> SendCacheRequestAsync(HttpClient client, bool htmx)
+	private static async Task<HttpResponseMessage> SendCacheRequestAsync(
+		HttpClient client,
+		CacheRepresentation representation)
 	{
-		using var request = new HttpRequestMessage(HttpMethod.Get, Issue50Path);
-		if (htmx)
+		using var request = new HttpRequestMessage(
+			HttpMethod.Get,
+			$"{Issue50Path}?representation={representation.Selection}");
+		if (representation.RequestType is not null)
 		{
 			request.Headers.Add("HX-Request", "true");
-			request.Headers.Add("HX-Request-Type", "partial");
+			request.Headers.Add("HX-Request-Type", representation.RequestType);
 		}
 
 		return await client.SendAsync(request);
 	}
+
+	private sealed record CacheRepresentation(string Label, string Selection, string? RequestType);
 
 	private static async Task<IResponse> SubmitQueryAsync(
 		IPage page,


### PR DESCRIPTION
## What changes

The package consumer now proves that OutputCache keeps normal, htmx full, direct-whole, and two query-selected named-fragment representations separate. Its policy explicitly varies `HX-Request`, `HX-Request-Type`, and the application-owned `representation` query key.

The feature guide now explains that each representation-affecting route, query, header, request-mode, identity, culture, tenant, and authorization input belongs in the application cache policy; HTMX headers remain untrusted representation data.

Closes #176

## Verification

- Meaningful Kestrel/package red controls: removing either `representation` query variation or `HX-Request-Type` variation cross-served a cached fragment/full response (41/42 inner consumer tests passed; 1 failed).
- Focused package-consumer test: 1/1 outer test passed, exercising 42 inner Production Kestrel tests through a locally packed package.
- `dotnet run --project eng/Htmxor.Quality/Htmxor.Quality.csproj -- check --profile fast`: 1,003/1,003 passed.
- `dotnet run --project eng/Htmxor.Quality/Htmxor.Quality.csproj -- check --profile full`: 1,006/1,006 passed with fresh coverage.
- Final independent Standards and Spec reviews: 0 findings each.
