### PR TITLE
feat(fragments): remove legacy request selection

### DIFF
--- a/docs/engineering/fragment-selection.md
+++ b/docs/engineering/fragment-selection.md
@@ -56,10 +56,10 @@ response or invoke application render fragments to discover topology. Direct
 responses wait for complete rendering. Excluded branches may perform lifecycle,
 rendering, and data work; selection makes no skipped-work claim.
 
-The legacy conditional renderer retains `Match`, `RenderDuringStandardRequest`,
-and implicit ID matching pending the separately owned legacy removal work. The
-active v1 endpoint renderer ignores those legacy filters and constructs all
-fragment content before choosing response output.
+`HtmxFragment` has no request predicate or direct-request rendering flag.
+`Id`, `HX-Target`, and `HX-Source` never choose server output. Application code
+chooses a whole response or named boundaries from the component instance; the
+renderer constructs the full tree and serializes the resulting selected HTML.
 
 ## Verification scope
 
@@ -84,9 +84,9 @@ cases. Focused red is retained in `artifacts/issue168/red/issue168-red.trx`;
 packed red and green output are retained under `artifacts/issue168/package/`.
 
 The routine full profile also found four existing packaged browser fixtures
-whose `Match`, `RenderDuringStandardRequest`, implicit ID selection, and
-skipped-descendant expectations belonged to the legacy renderer. The #122,
-#137, #139, and #144 fixtures now select explicit names. Application-authored
+whose legacy predicates, implicit ID selection, and skipped-descendant
+expectations did not describe the v1 renderer. The #122, #137, #139, and #144
+fixtures now select explicit names. Application-authored
 Razor conditions retain their normal-page controls and direct-request async
 gates. Their assertions retain exact selected response content, browser
 completion ordering, and request isolation, while recording completed excluded

--- a/docs/htmxor-v1-feature-guide.md
+++ b/docs/htmxor-v1-feature-guide.md
@@ -288,7 +288,7 @@ wrapperless, or it may emit a wrapper when `Element`, `Id`, or additional HTML
 attributes are supplied:
 
 ```razor
-<HtmxFragment Id="product-list" Element="ul" class="products">
+<HtmxFragment Name="Products" Id="product-list" Element="ul" class="products">
     @foreach (var product in products)
     {
         <li>@product.Name</li>
@@ -297,15 +297,24 @@ attributes are supplied:
 ```
 
 For a normal request the fragment participates in the full component output. A
-direct request can select the whole component, one fragment, or several
-fragments. The component and required ancestors may run, but excluded child
-branches below a known selection boundary must not render or execute their own
-lifecycle work.
+direct request defaults to the whole component; component-instance code can
+select the whole component, one fragment, or several fragments in caller order:
 
-Select a stable name with `Htmx.Response.SelectFragment(...)` or
-`SelectFragments(...)`. The name is independent of the wrapper `Id` and browser
-delivery details. `Match` and `RenderDuringStandardRequest` remain legacy
-conditional-renderer options; do not use request target matching as the server
+```csharp
+Htmx.Response.SelectWholeComponent();
+Htmx.Response.SelectFragment("Products");
+Htmx.Response.SelectFragments("Products", "Totals");
+```
+
+Names are case-sensitive. Every selected name must be declared exactly once;
+duplicate, missing, malformed, or ancestor-and-descendant selections fail before
+response HTML is written. Selecting a nested name emits that boundary and its
+subtree without its ancestors. The renderer completes the component tree before
+serializing selected HTML. Lifecycle, rendering, data work, and quiescence can
+therefore occur in branches outside the selected response.
+
+The name is independent of the wrapper `Id` and browser delivery details. Do
+not use a request target, source, predicate, or request flag as the server
 selection key.
 
 Keep server execution separate from browser delivery:
@@ -1257,8 +1266,8 @@ the public API do not yet match this guide:
 
 - direct method inference and diagnostics cover only a limited set of Razor
   syntax;
-- fragment selection currently couples `Id`, request-target matching, `Match`,
-  and rendering flags rather than a clear named-selection model;
+- fragment selection uses stable component-owned names; its renderer completes
+  the tree before serializing whole or selected response HTML;
 - some infrastructure/prototype types are public because of current assembly
   boundaries rather than an intentional stable developer contract; and
 - several client compositions in this guide are not yet browser-conformance

--- a/docs/roadmap/v1/issue-154-package-public-surface.txt
+++ b/docs/roadmap/v1/issue-154-package-public-surface.txt
@@ -34,30 +34,23 @@ TYPE Htmxor.Components.HtmxAsyncLoad [kind=class;abstract=False;sealed=True;gene
   Property [visibility=public|public;static=False;get=public,instance;set=public,instance] System.String Element
   Property [visibility=public|public;static=False;get=public,instance;set=public,instance] System.String Id
   Property [visibility=public|public;static=False;get=public,instance;set=public,instance] Microsoft.AspNetCore.Components.RenderFragment Loading
-TYPE Htmxor.Components.HtmxFragment [kind=class;abstract=False;sealed=False;genericArity=0;base=Htmxor.Components.ConditionalComponentBase]
+TYPE Htmxor.Components.HtmxFragment [kind=class;abstract=False;sealed=False;genericArity=0;base=Microsoft.AspNetCore.Components.ComponentBase]
   Constructor [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=0] Void .ctor()
-  Method [visibility=public;static=False;abstract=False;virtual=True;final=False;genericArity=0;parameters=3] Boolean ShouldOutput(Htmxor.Http.HtmxContext, Int32, Int32)
   Method [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=0] System.Collections.Generic.IDictionary`2[System.String,System.Object] get_AdditionalAttributes()
   Method [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=0] Microsoft.AspNetCore.Components.RenderFragment get_ChildContent()
   Method [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=0] System.String get_Element()
   Method [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=0] System.String get_Id()
-  Method [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=0] System.Func`2[Htmxor.Http.HtmxRequest,System.Boolean] get_Match()
   Method [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=0] System.String get_Name()
-  Method [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=0] Boolean get_RenderDuringStandardRequest()
   Method [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=1] Void set_AdditionalAttributes(System.Collections.Generic.IDictionary`2[System.String,System.Object])
   Method [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=1] Void set_ChildContent(Microsoft.AspNetCore.Components.RenderFragment)
   Method [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=1] Void set_Element(System.String)
   Method [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=1] Void set_Id(System.String)
-  Method [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=1] Void set_Match(System.Func`2[Htmxor.Http.HtmxRequest,System.Boolean])
   Method [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=1] Void set_Name(System.String)
-  Method [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=1] Void set_RenderDuringStandardRequest(Boolean)
   Property [visibility=public|public;static=False;get=public,instance;set=public,instance] System.Collections.Generic.IDictionary`2[System.String,System.Object] AdditionalAttributes
   Property [visibility=public|public;static=False;get=public,instance;set=public,instance] Microsoft.AspNetCore.Components.RenderFragment ChildContent
   Property [visibility=public|public;static=False;get=public,instance;set=public,instance] System.String Element
   Property [visibility=public|public;static=False;get=public,instance;set=public,instance] System.String Id
-  Property [visibility=public|public;static=False;get=public,instance;set=public,instance] System.Func`2[Htmxor.Http.HtmxRequest,System.Boolean] Match
   Property [visibility=public|public;static=False;get=public,instance;set=public,instance] System.String Name
-  Property [visibility=public|public;static=False;get=public,instance;set=public,instance] Boolean RenderDuringStandardRequest
 TYPE Htmxor.Components.HtmxHeadOutlet [kind=class;abstract=False;sealed=False;genericArity=0;base=System.Object]
   Constructor [visibility=public;static=False;abstract=False;virtual=False;final=False;genericArity=0;parameters=0] Void .ctor()
   Method [visibility=public;static=False;abstract=False;virtual=True;final=True;genericArity=0;parameters=1] Void Attach(Microsoft.AspNetCore.Components.RenderHandle)

--- a/eng/Htmxor.UpstreamMonitor/upstream-watch.json
+++ b/eng/Htmxor.UpstreamMonitor/upstream-watch.json
@@ -222,6 +222,7 @@
       "relationship": "subclasses",
       "dependencies": [
         "src/Htmxor/Components/ConditionalComponentBase.cs",
+        "src/Htmxor/Components/HtmxFragment.cs",
         "src/Htmxor/Endpoints/HtmxorDirectComponentHost.cs",
         "src/Htmxor/Endpoints/HtmxorDirectRenderHost.cs"
       ]

--- a/samples/HtmxorExamples/Components/Pages/Examples/SlowInfiniteScroll/Index.razor
+++ b/samples/HtmxorExamples/Components/Pages/Examples/SlowInfiniteScroll/Index.razor
@@ -1,5 +1,5 @@
-@inherits ConditionalComponentBase
 @page "/examples/slow-infinite-scroll"
+@inject HtmxContext Htmx
 @code {
     private const int PageSize = 20;
     private IEnumerable<Contact> contacts = Enumerable.Empty<Contact>();
@@ -11,9 +11,17 @@
     {
         // Only load contact data during a direct request, since the loading
         // is slow it would prevent the page from rendering initially.
-        contacts = Context.Request.RoutingMode == RoutingMode.Direct
+        contacts = Htmx.Request.RoutingMode == RoutingMode.Direct
             ? await GetContactsAsync(Page)
             : Enumerable.Empty<Contact>();
+    }
+
+    protected override void OnParametersSet()
+    {
+        if (Htmx.Request.RoutingMode is RoutingMode.Direct)
+        {
+            Htmx.Response.SelectFragment("contacts");
+        }
     }
 
     private static async Task<IEnumerable<Contact>> GetContactsAsync(int pageNumber)
@@ -36,8 +44,9 @@
         </tr>
     </thead>
     <tbody>
-        <HtmxFragment>
-            <HtmxFragment RenderDuringStandardRequest="false">
+        <HtmxFragment Name="contacts">
+            @if (Htmx.Request.RoutingMode is RoutingMode.Direct)
+            {
                 @foreach (var contact in contacts)
                 {
                     <tr>
@@ -47,7 +56,7 @@
                         <td>@contact.Email</td>
                     </tr>
                 }
-            </HtmxFragment>
+            }
             <tr hx-get="/examples/slow-infinite-scroll?page=@(Page + 1)" hx-trigger="revealed" hx-swap="outerHTML">
                 <td colspan="4" class="text-center htmx-indicator">
                     Loading data <span class="spinner-grow spinner-grow-sm" role="status"></span>

--- a/samples/HtmxorExamples/Components/Pages/Examples/UpdatingOtherContent/TriggeringEvents.razor
+++ b/samples/HtmxorExamples/Components/Pages/Examples/UpdatingOtherContent/TriggeringEvents.razor
@@ -1,5 +1,5 @@
-@inherits ConditionalComponentBase
 @page "/examples/updating-other-content/triggering-events"
+@inject HtmxContext Htmx
 <PageTitle>Htmxor - Examples - Updating Other Content - Triggering Events</PageTitle>
 <h1>Updating Other Content - Triggering Events</h1>
 <p>This is a Htmxor version of the <a href="https://htmx.org/examples/update-other-content/#events" title="Updating Other Content article">Updating Other Content - Solution 3: Triggering Events</a> example at htmx.org.</p>
@@ -13,7 +13,7 @@
                 <th>Email</th>
             </tr>
         </thead>
-        <HtmxFragment Match=@(req => req.Target == "contacts-table")>
+        <HtmxFragment Name="contacts">
             <tbody id="contacts-table" hx-get hx-trigger="newContact from:body" hx-swap="outerHTML">
                 @foreach (var contact in Contacts.Data.Values.OrderBy(x => x.Modified).Take(20))
                 {
@@ -28,8 +28,18 @@
     </table>
     <div class="w-50 p-3 border">
         <h5>Create new contact</h5>
-        <HtmxFragment Match=@(req => req.Method == HttpMethods.Post)>
-            <ContactEditForm hx-post OnContactSave=@(() => Context.Response.Trigger("newContact")) />
+        <HtmxFragment Name="contact-form">
+            <ContactEditForm hx-post OnContactSave=@(() => Htmx.Response.Trigger("newContact")) />
         </HtmxFragment>
     </div>
 </div>
+
+@code {
+    protected override void OnParametersSet()
+    {
+        if (Htmx.Request.RoutingMode is RoutingMode.Direct)
+        {
+            Htmx.Response.SelectFragment(Htmx.Request.Method == HttpMethods.Post ? "contact-form" : "contacts");
+        }
+    }
+}

--- a/samples/HtmxorExamples/Components/Pages/Examples/UpdatingOtherContent/TriggeringEventsIndirectly.razor
+++ b/samples/HtmxorExamples/Components/Pages/Examples/UpdatingOtherContent/TriggeringEventsIndirectly.razor
@@ -1,5 +1,5 @@
-@inherits ConditionalComponentBase
 @page "/examples/updating-other-content/triggering-events-indirectly"
+@inject HtmxContext Htmx
 <PageTitle>Htmxor - Examples - Updating Other Content - Triggering Events Indirectly</PageTitle>
 <h1>Updating Other Content - Triggering Events</h1>
 <p>This is a Htmxor version of the <a href="https://htmx.org/examples/update-other-content/#events" title="Updating Other Content article">Updating Other Content - Solution 3: Triggering Events</a> example at htmx.org.</p>
@@ -13,7 +13,7 @@
                 <th>Email</th>
             </tr>
         </thead>
-        <HtmxFragment Match=@(req => req.Target == "contacts-table")>
+        <HtmxFragment Name="contacts">
             <tbody id="contacts-table" hx-get hx-trigger="newContact from:body" hx-swap="outerHTML">
                 @foreach (var contact in Contacts.Data.Values.OrderBy(x => x.Modified).Take(20))
                 {
@@ -31,3 +31,13 @@
         <ContactEditFormPage />
     </div>
 </div>
+
+@code {
+    protected override void OnParametersSet()
+    {
+        if (Htmx.Request.RoutingMode is RoutingMode.Direct)
+        {
+            Htmx.Response.SelectFragment("contacts");
+        }
+    }
+}

--- a/src/Htmxor/Components/HtmxFragment.cs
+++ b/src/Htmxor/Components/HtmxFragment.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using Htmxor.Http;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
 
@@ -8,12 +7,8 @@ namespace Htmxor.Components;
 /// <summary>
 /// Defines a server-selectable fragment with optional wrapper markup.
 /// </summary>
-/// <remarks>
-/// The v1 endpoint renderer completes the component tree before selecting response output by
-/// <see cref="Name"/>. <see cref="Match"/> and <see cref="RenderDuringStandardRequest"/>
-/// apply only to the legacy conditional renderer.
-/// </remarks>
-public class HtmxFragment : ConditionalComponentBase
+/// <remarks>The v1 endpoint renderer completes the component tree before selecting response output by <see cref="Name"/>.</remarks>
+public class HtmxFragment : ComponentBase
 {
 	/// <summary>
 	/// Gets or sets the stable, case-sensitive server selection name. This does not emit markup or request a wrapper.
@@ -56,27 +51,9 @@ public class HtmxFragment : ConditionalComponentBase
 	[Parameter]
 	public string? Id { get; set; }
 
-	/// <summary>
-	/// Gets or sets the legacy conditional renderer's child-content predicate.
-	/// </summary>
-	[Parameter]
-	public Func<HtmxRequest, bool>? Match { get; set; }
-
-	/// <summary>
-	/// Gets or sets whether the legacy conditional renderer emits this fragment during a standard request.
-	/// </summary>
-	/// <remarks>Default is <see langword="true"/>.</remarks>
-	[Parameter]
-	public bool RenderDuringStandardRequest { get; set; } = true;
-
 	/// <inheritdoc/>
 	protected override void BuildRenderTree([NotNull] RenderTreeBuilder builder)
 	{
-		if (!Context.UsesCompletedFragmentSelection && !ShouldOutput(Context, 0, 0))
-		{
-			return;
-		}
-
 		var wrapper = Element;
 		if (wrapper is null && (Id is not null || AdditionalAttributes?.Count > 0))
 		{
@@ -105,17 +82,6 @@ public class HtmxFragment : ConditionalComponentBase
 		Element = Normalize(Element);
 		Id = Normalize(Id);
 	}
-
-	/// <inheritdoc/>
-	public override bool ShouldOutput([NotNull] HtmxContext context, int directConditionalChildren, int conditionalChildren)
-		=> (RenderDuringStandardRequest && context.Request.RoutingMode is RoutingMode.Standard)
-		|| (context.Request.RoutingMode is RoutingMode.Direct &&
-			(Match?.Invoke(context.Request) ?? MatchesTarget(context.Request.Target)));
-
-	private bool MatchesTarget(string? target)
-		=> Id is null
-		|| string.Equals(Id, target, StringComparison.Ordinal)
-		|| HtmxElementIdentity.Matches(Element ?? "div", Id, target);
 
 	private static string? Normalize(string? value)
 		=> string.IsNullOrWhiteSpace(value) ? null : value.Trim();

--- a/test/Htmxor.Quality.Tests/UpstreamMonitorPolicyTests.cs
+++ b/test/Htmxor.Quality.Tests/UpstreamMonitorPolicyTests.cs
@@ -61,7 +61,7 @@ public sealed class UpstreamMonitorPolicyTests
 
 		Assert.Equal(
 			[
-				"src/Components/Components/src/ComponentBase.cs|file|subclass|subclasses|src/Htmxor/Components/ConditionalComponentBase.cs,src/Htmxor/Endpoints/HtmxorDirectComponentHost.cs,src/Htmxor/Endpoints/HtmxorDirectRenderHost.cs",
+				"src/Components/Components/src/ComponentBase.cs|file|subclass|subclasses|src/Htmxor/Components/ConditionalComponentBase.cs,src/Htmxor/Components/HtmxFragment.cs,src/Htmxor/Endpoints/HtmxorDirectComponentHost.cs,src/Htmxor/Endpoints/HtmxorDirectRenderHost.cs",
 				"src/Components/Components/src/IComponent.cs|file|interface|implements|src/Htmxor/Components/HtmxHeadOutlet.cs,src/Htmxor/Endpoints/HtmxorComponentRequestHost.cs,src/Htmxor/Endpoints/HtmxorEndpointCandidateRenderModeBoundary.cs",
 				"src/Components/Components/src/IPersistentComponentStateStore.cs|file|interface|implements|src/Htmxor/Endpoints/HtmxorEndpointCandidateStateStore.cs",
 				"src/Components/Components/src/LayoutComponentBase.cs|file|subclass|subclasses|src/Htmxor/Components/HtmxLayoutComponentBase.cs",

--- a/test/Htmxor.TestApp/Components/Pages/Examples/BulkUpdate1/BulkUpdateForm1.razor
+++ b/test/Htmxor.TestApp/Components/Pages/Examples/BulkUpdate1/BulkUpdateForm1.razor
@@ -1,6 +1,4 @@
 @page "/bulk-update-1"
-@implements IConditionalRender
-@inject HtmxContext hxContext
 @code {
     private string? toast;
 
@@ -38,13 +36,11 @@
         }
     }
 
-    public virtual bool ShouldOutput([NotNull] HtmxContext context, int directConditionalChildren, int conditionalChildren)
-        => context.Request.RoutingMode is RoutingMode.Standard;
 }
 <form id="checked-contacts"
       hx-post="/bulk-update-1"
       hx-swap="outerHTML settle:3s"
-      hx-target="#toast">
+      hx-target="#checked-contacts">
     <AntiforgeryToken />
     <table>
         <thead>
@@ -66,7 +62,5 @@
         </tbody>
     </table>
     <input type="submit" value="Bulk Update">
-    <HtmxFragment>
-        <span id="toast" aria-live="polite">@toast</span>
-    </HtmxFragment>
+    <span id="toast" aria-live="polite">@toast</span>
 </form>

--- a/test/Htmxor.TestApp/Components/Pages/Examples/EditRow1/EditRow1.razor
+++ b/test/Htmxor.TestApp/Components/Pages/Examples/EditRow1/EditRow1.razor
@@ -9,7 +9,7 @@
     [Parameter]
     public Guid Id { get; set; }
 
-    private bool IsEditing => Id != Guid.Empty && Htmx.Request.Path.ToUriComponent().EndsWith("/edit");
+    private bool IsEditing => Id != Guid.Empty && Htmx.Request.Path.ToUriComponent().EndsWith("/edit", StringComparison.OrdinalIgnoreCase);
 
     protected override void OnParametersSet()
     {

--- a/test/Htmxor.TestApp/Components/Pages/Examples/EditRow1/EditRow1.razor
+++ b/test/Htmxor.TestApp/Components/Pages/Examples/EditRow1/EditRow1.razor
@@ -1,6 +1,7 @@
 @page "/edit-row-1/edit-row"
 @page "/edit-row-1/edit-row/{id:guid}"
 @page "/edit-row-1/edit-row/{id:guid}/edit"
+@inject HtmxContext Htmx
 @code {
     [SupplyParameterFromForm]
     public Contact? Contact { get; set; }
@@ -8,10 +9,19 @@
     [Parameter]
     public Guid Id { get; set; }
 
-    private bool RenderCondition(HtmxRequest request, Guid id)
+    private bool IsEditing => Id != Guid.Empty && Htmx.Request.Path.ToUriComponent().EndsWith("/edit");
+
+    protected override void OnParametersSet()
     {
-        return Id == Guid.Empty || (id == Id && !request.Path.ToUriComponent().EndsWith("/edit"));
+        if (Htmx.Request.RoutingMode is RoutingMode.Direct && Id != Guid.Empty)
+        {
+            Htmx.Response.SelectFragment(IsEditing ? EditFragmentName(Id) : DisplayFragmentName(Id));
+        }
     }
+
+    private static string DisplayFragmentName(Guid id) => $"row-{id:N}";
+
+    private static string EditFragmentName(Guid id) => $"edit-row-{id:N}";
 }
 <AntiforgeryToken />
 <table class="table">
@@ -25,7 +35,9 @@
     <tbody hx-target="closest tr" hx-swap="outerHTML">
         @foreach (var contact in DataStore.OfType<Contact>())
         {
-            <HtmxFragment Match=@(req => RenderCondition(req, contact.Id))>
+            @if (Id == Guid.Empty || (contact.Id == Id && !IsEditing))
+            {
+            <HtmxFragment Name="@DisplayFragmentName(contact.Id)">
                 <tr>
                     <td>@contact.FirstName</td>
                     <td>@contact.Email</td>
@@ -37,7 +49,10 @@
                     </td>
                 </tr>
             </HtmxFragment>
-            <HtmxFragment Match=@(req => req.Path.ToUriComponent().EndsWith($"/{contact.Id}/edit"))>
+            }
+            @if (contact.Id == Id && IsEditing)
+            {
+            <HtmxFragment Name="@EditFragmentName(contact.Id)">
                 <tr hx-trigger='cancel' class='editing' hx-get="/edit-row-1/edit-row/@(contact.Id)">
                     <td><input name='Contact.Name' value=@contact.FirstName></td>
                     <td><input name='Contact.Email' value=@contact.Email></td>
@@ -53,6 +68,7 @@
                     </td>
                 </tr>
             </HtmxFragment>
+            }
         }
     </tbody>
 </table>

--- a/test/Htmxor.Tests/Components/HtmxFragmentTests.cs
+++ b/test/Htmxor.Tests/Components/HtmxFragmentTests.cs
@@ -42,23 +42,17 @@ public sealed class HtmxFragmentTests : BunitContext
 			""");
 	}
 
-	[Theory]
-	[InlineData("form#sidebar", true)]
-	[InlineData("FORM#sidebar", true)]
-	[InlineData("form#Sidebar", false)]
-	[InlineData("div#sidebar", false)]
-	public void Direct_request_uses_complete_target_identity_for_default_selection(
-		string target,
-		bool expectedChild)
+	[Fact]
+	public void Direct_request_does_not_let_target_choose_fragment_output()
 	{
-		AddContext(target);
+		AddContext("aside#unrelated");
 
 		var component = Render<HtmxFragment>(parameters => parameters
 			.Add(fragment => fragment.Element, "form")
 			.Add(fragment => fragment.Id, "sidebar")
 			.AddChildContent("<span data-fragment>content</span>"));
 
-		Assert.Equal(expectedChild ? 1 : 0, component.FindAll("[data-fragment]").Count);
+		component.MarkupMatches("<form id=\"sidebar\"><span data-fragment>content</span></form>");
 	}
 
 	private void AddContext(string? target = null)

--- a/test/Htmxor.Tests/DemoTestCases/BulkUpdate1Test.cs
+++ b/test/Htmxor.Tests/DemoTestCases/BulkUpdate1Test.cs
@@ -12,7 +12,7 @@ public class BulkUpdate1Test : TestAppTestBase
 	}
 
 	[Fact]
-	public async Task Hx_post_with_partial_return()
+	public async Task Hx_post_returns_the_updated_form()
 	{
 		var users = Enumerable.Range(1, 10)
 			.Select(num => DataStore.Store(new ActivatableUser
@@ -29,12 +29,13 @@ public class BulkUpdate1Test : TestAppTestBase
 			s.WithFormData(("Active", users[1].Id.ToString()), ("Active", users[3].Id.ToString()));
 			s.WithAntiforgeryTokensFrom(Host);
 			s.WithHxHeaders(
-				target: "span#toast",
+				target: "form#checked-contacts",
 				source: "form#checked-contacts",
 				currentUrl: $"{Host.Server.BaseAddress}bulk-update-1");
 
 			s.StatusCodeShouldBe(HttpStatusCode.OK);
-			s.ContentShouldBeHtml($"""
+			s.ContentShouldHaveSingleRootElement("form#checked-contacts");
+			s.ContentShouldHaveElementsEqualTo("#toast", $"""
                 <span id="toast" aria-live="polite">Activated 2 and deactivated 0 users.</span>
                 """);
 		});

--- a/test/Htmxor.Tests/TestAssets/Alba/AblaAssertionExtensions.cs
+++ b/test/Htmxor.Tests/TestAssets/Alba/AblaAssertionExtensions.cs
@@ -6,19 +6,28 @@ public static class AblaAssertionExtensions
 {
 	/// <summary>
 	/// Assert that the HTTP response body is parsable as Html and is semantically equivalent to
-	/// the <paramref name="expectedJson"/> JSON string.
+	/// the <paramref name="expected"/> HTML string.
 	/// </summary>
-	/// <param name="expectedJson">The expected JSON string</param>
+	/// <param name="expected">The expected HTML.</param>
 	public static Scenario ContentShouldBeHtml(this Scenario scenario, [StringSyntax("Html")] string expected)
 	{
 		return scenario.AssertThat(new SemanticHtmlContentBodyAssertion(null, expected));
 	}
 
 	/// <summary>
-	/// Assert that the HTTP response body that matches the <paramref name="cssSelector"/> is parsable as Html and is semantically equivalent to
-	/// the <paramref name="expectedJson"/> JSON string.
+	/// Assert that the HTTP response body has exactly one root element that matches <paramref name="cssSelector"/>.
 	/// </summary>
-	/// <param name="expectedJson">The expected JSON string</param>
+	/// <param name="cssSelector">The CSS selector for the required root element.</param>
+	public static Scenario ContentShouldHaveSingleRootElement(this Scenario scenario, string cssSelector)
+	{
+		return scenario.AssertThat(new SingleRootHtmlElementAssertion(cssSelector));
+	}
+
+	/// <summary>
+	/// Assert that response elements matching <paramref name="cssSelector"/> are semantically equivalent to <paramref name="expected"/>.
+	/// </summary>
+	/// <param name="cssSelector">The CSS selector for response elements.</param>
+	/// <param name="expected">The expected HTML.</param>
 	public static Scenario ContentShouldHaveElementsEqualTo(
 		this Scenario scenario,
 		string cssSelector,

--- a/test/Htmxor.Tests/TestAssets/Alba/SingleRootHtmlElementAssertion.cs
+++ b/test/Htmxor.Tests/TestAssets/Alba/SingleRootHtmlElementAssertion.cs
@@ -1,0 +1,17 @@
+using AngleSharp.Html.Parser;
+using Microsoft.AspNetCore.Http;
+
+namespace Htmxor.TestAssets.Alba;
+
+public sealed class SingleRootHtmlElementAssertion(string cssSelector) : IScenarioAssertion
+{
+	public void Assert(Scenario scenario, HttpContext context, ScenarioAssertionException ex)
+	{
+		using var document = new HtmlParser().ParseDocument(ex.ReadBody(context));
+		var rootElements = document.Body?.Children;
+		if (rootElements?.Length != 1 || !rootElements[0].Matches(cssSelector))
+		{
+			ex.Add($"Response body must have exactly one root element matching '{cssSelector}'.");
+		}
+	}
+}


### PR DESCRIPTION
Closes #178\n\nRemoves the legacy fragment predicate, direct-request flag, and implicit target selection. Maintained samples and documentation now use component-owned named selection; the package surface and monitor contract seal the remaining fragment API.\n\nVerification at 25af71aa7f0a4ba22e93c7ea3c25562512c3cdf7:\n- focused Bulk Update response: 1/1\n- fast: 1,000/1,000\n- full: 1,003/1,003, including browser coverage\n- Release build: 0 warnings, 0 errors\n- independent Standards and Spec reviews: 0 findings