### PR TITLE
fix(security): honor application-configured CSRF protection

### DIFF
--- a/docs/engineering/candidate-form-adapter.md
+++ b/docs/engineering/candidate-form-adapter.md
@@ -12,6 +12,43 @@ endpoint invoker after the paired parity boundary passes.
 [approved adapter decision](https://github.com/egil/Htmxor/issues/189#issuecomment-5554452348)
 authorize this replaceable internal boundary. No form runtime is copied.
 
+## .NET 11 configured protection
+
+Under the [approved #207 contract](https://github.com/egil/Htmxor/issues/207),
+the .NET 11 adapter consumes the effective `IAntiforgeryValidationFeature` rather
+than adding direct token validation when the feature is absent. The installed
+`EndpointMiddleware` checks required protection middleware before invoking the
+component endpoint. Generated unsafe callbacks reject a failed verdict before
+activation; an activated callback bypasses ordinary POST named-form dispatch.
+Actionless POST retains its ordinary named-form behavior after successful
+protection. Effective metadata opt-outs are preserved instead of overwritten
+by generated endpoint defaults. The .NET 10 direct token fallback is retained.
+
+Streaming token preparation follows the .NET 11 invoker: it generates tokens
+only when `HttpContext.Items` contains
+`__AntiforgeryMiddlewareWithEndpointInvoked`. This reads the framework's
+request-local invocation marker through the public items collection; it adds
+no reflection or private member accessor. The exact marker value is mirrored
+from `MiddlewareInvokedKeys.Antiforgery` and monitored as source, alongside the
+existing invoker reimplementation watch. The shared key file is .NET 11 source;
+the new conditional use does not change .NET 10 token timing.
+
+Protection/token timing was synchronized on **2026-09-13** against ASP.NET Core
+**v11.0.0-rc.1.26425.128**, commit
+**c3325eeb6b47bc6383c127d4f4827dc9642a2b6e**. Exact sources:
+
+- [RazorComponentEndpointInvoker.cs](https://github.com/dotnet/aspnetcore/blob/c3325eeb6b47bc6383c127d4f4827dc9642a2b6e/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs): effective verdict and conditional streaming token generation.
+- [MiddlewareInvokedKeys.cs](https://github.com/dotnet/aspnetcore/blob/c3325eeb6b47bc6383c127d4f4827dc9642a2b6e/src/Shared/MiddlewareInvokedKeys.cs): mirrored antiforgery invocation key in `HtmxorEndpointCandidate.cs`.
+- [EndpointMiddleware.cs](https://github.com/dotnet/aspnetcore/blob/c3325eeb6b47bc6383c127d4f4827dc9642a2b6e/src/Http/Routing/src/EndpointMiddleware.cs): required-middleware checks.
+- [CsrfProtectionMiddleware.cs](https://github.com/dotnet/aspnetcore/blob/c3325eeb6b47bc6383c127d4f4827dc9642a2b6e/src/DefaultBuilder/src/Internal/CsrfProtectionMiddleware.cs) and [AntiforgeryMiddleware.cs](https://github.com/dotnet/aspnetcore/blob/c3325eeb6b47bc6383c127d4f4827dc9642a2b6e/src/Antiforgery/src/AntiforgeryMiddleware.cs): configured validation and precedence.
+
+The Issue210 real hosted security matrix and paired stock/Htmxor streaming
+controls own this parity boundary. Their exact commands, per-target counts and
+limitations belong to the issue's delivery receipts. Browser credential
+transport and later framework releases require their own evidence. See the
+[developer protection guide](../htmxor-v1-feature-guide.md#application-owned-request-protection)
+for the POST/PUT/PATCH-only token middleware warning and explicit DELETE setup.
+
 ## Installed-service access
 
 All private dependencies come from `Microsoft.AspNetCore.Components.Endpoints.dll`,

--- a/docs/htmxor-v1-feature-guide.md
+++ b/docs/htmxor-v1-feature-guide.md
@@ -275,13 +275,46 @@ Keep the stock Blazor form and add htmx behavior:
 The normal form submission remains meaningful without JavaScript. Named-form
 dispatch, `[SupplyParameterFromForm]`, `Input*`, validation, antiforgery,
 authentication state, and lifecycle callbacks are Blazor features and must
-behave the same on the enhanced path. All unsafe methods fail closed before
-body binding or component callbacks. Do not change state on GET.
+behave the same on the enhanced path. Requests that fail configured protection
+are rejected before body binding or component callbacks. Do not change state on GET.
 
-For a PUT, PATCH, or DELETE that is not expressed by an HTML form method, render
-stock antiforgery credentials with an `EditForm` or `<AntiforgeryToken />`; the
-adapter carries the request token. In htmx 4, DELETE request values are not sent
-in the body by default, so do not treat body transport as proof of antiforgery.
+For a PUT, PATCH, or DELETE using token protection, render stock antiforgery
+credentials with an `EditForm` or `<AntiforgeryToken />`; the adapter carries an
+available request token. In htmx 4, DELETE request values are not sent in the
+body by default. Sending a token does not establish that middleware validates it.
+
+### Application-owned request protection
+
+Configure protection through ASP.NET Core. Htmxor has no security-mode option,
+origin allow-list, or independent browser-header trust policy. It consumes the
+effective framework validation result before binding, lifecycle work, or unsafe
+component callbacks; authentication and authorization remain separate checks.
+Effective endpoint protection metadata, including explicit opt-outs, remains
+authoritative. A missing required middleware configuration is an error.
+
+On .NET 11, `WebApplication` supplies native CSRF protection unless the
+application disables it. A request allowed by that configured policy does not
+need an additional Htmxor token check. If the application adds
+`UseAntiforgery()`, its token validation replaces the earlier native verdict for
+the methods it validates. Htmxor's streaming preparation generates tokens only
+when that token middleware has run; native-only responses do not eagerly issue unused
+antiforgery cookies. Retain the standard token pipeline on .NET 10.
+
+`UseAntiforgery()` automatically validates tokens only for POST, PUT, and PATCH.
+DELETE is outside that middleware's automatic token validation. On .NET 11,
+Htmxor preserves the effective DELETE verdict: native protection still applies
+when enabled, and Htmxor adds no DELETE token fallback when native protection is
+disabled. The existing .NET 10 fallback continues to validate protected DELETE
+requests.
+
+If your application requires token validation for DELETE, configure or perform
+it explicitly before component execution, such as by resolving `IAntiforgery`
+in application middleware and calling `ValidateRequestAsync`. Token generation,
+token transport, and a `UseAntiforgery()` call alone do not prove DELETE token
+validation. Microsoft's [method-limitations guidance](https://learn.microsoft.com/en-us/aspnet/core/security/anti-request-forgery?view=aspnetcore-11.0#http-method-limitations-and-httpmethodoverridemiddleware-interaction)
+also warns that form-field HTTP method override can turn POST into a method
+the token middleware does not validate. Review middleware order and explicit
+validation when using method override.
 
 ## Select response fragments
 
@@ -660,9 +693,9 @@ server. Htmx still owns all DOM behavior.
 | --- | --- | --- |
 | `hx-get` | Issue GET | Use an `@page` or `HtmxRoute` GET. Keep GET side-effect free. |
 | `hx-post` | Issue POST | Use a stock form or `@onpost`; render antiforgery credentials. |
-| `hx-put` | Issue PUT | Declare `@onput`; unsafe and antiforgery-protected. |
-| `hx-patch` | Issue PATCH | Declare `@onpatch`; unsafe and antiforgery-protected. |
-| `hx-delete` | Issue DELETE | Declare `@ondelete`; unsafe and antiforgery-protected. DELETE values are not body data by default in htmx 4. |
+| `hx-put` | Issue PUT | Declare `@onput`; configure application-owned request protection. |
+| `hx-patch` | Issue PATCH | Declare `@onpatch`; configure application-owned request protection. |
+| `hx-delete` | Issue DELETE | Declare `@ondelete`; configure application-owned request protection and explicitly arrange token validation if required. DELETE values are not body data by default in htmx 4. |
 | `hx-query` | Issue QUERY | Requires application-authored `@onquery`. Issue #111 proves one form-encoded binding per route owner; the client never grants the method. |
 | `hx-action` | Set the request URL | Pair with `hx-method`. When present, `hx-action` takes precedence over verb-specific htmx attributes. It never grants the server route. |
 | `hx-method` | Select GET, POST, PUT, PATCH, DELETE, or QUERY | The component declaration must independently allow the method. Useful for progressive markup resembling form `action`/`method`. |
@@ -1181,8 +1214,9 @@ methods.
   values as attacker-controlled.
 - Re-evaluate authentication and authorization on every request and preserve the
   effective endpoint metadata on every generated representation.
-- Validate antiforgery before binding or callbacks for POST, PUT, PATCH, DELETE,
-  and every other unsafe method.
+- Enforce the application's configured CSRF or token validation before binding
+  or callbacks for unsafe methods. Configure explicit DELETE token validation
+  when required; see [application-owned request protection](#application-owned-request-protection).
 - Escape untrusted output. Isolate intentional raw HTML and consider
   `hx-ignore` where untrusted and trusted markup meet.
 - Keep htmx's same-origin default. If the application deliberately changes the

--- a/docs/index.md
+++ b/docs/index.md
@@ -100,11 +100,21 @@ To start fresh from a (new) Blazor Web App project, follow these steps:
    records the source archive, license, and exact asset used by current
    browser evidence.
 
-   Unsafe components render stock Blazor antiforgery credentials through an
-   `EditForm` or `<AntiforgeryToken />`. The adapter sends that request token
-   through htmx 4's request context; ASP.NET Core owns the antiforgery cookie
-   and validates the request before component callbacks run. Htmxor does not
-   require a separate antiforgery middleware or readable request-token cookie.
+   The application owns ASP.NET Core protection configuration. The example
+   keeps `UseAntiforgery()` for token protection. In that configuration, render
+   stock credentials through an `EditForm` or `<AntiforgeryToken />`; the adapter
+   sends the request token through htmx 4's request context. On .NET 11, Htmxor
+   also honors native CSRF protection configured by `WebApplication`, without
+   adding a token requirement to a successful framework verdict.
+
+   Token middleware automatically validates POST, PUT, and PATCH only. It does
+   not automatically validate DELETE tokens. Applications requiring DELETE
+   token validation must configure or perform it explicitly, for example with
+   `IAntiforgery.ValidateRequestAsync` in application middleware before component
+   execution. Htmxor preserves .NET 11's effective DELETE verdict; its existing
+   .NET 10 token fallback remains. See Microsoft's
+   [HTTP method limitations and warning](https://learn.microsoft.com/en-us/aspnet/core/security/anti-request-forgery?view=aspnetcore-11.0#http-method-limitations-and-httpmethodoverridemiddleware-interaction)
+   and the [protection configuration guide](htmxor-v1-feature-guide.md#application-owned-request-protection).
 
 4. **Update App.razor**
 

--- a/eng/Htmxor.UpstreamMonitor/upstream-watch.json
+++ b/eng/Htmxor.UpstreamMonitor/upstream-watch.json
@@ -24,6 +24,15 @@
   ],
   "watches": [
     {
+      "path": "src/Shared/MiddlewareInvokedKeys.cs",
+      "match": "file",
+      "api": "none",
+      "relationship": "mirrors",
+      "dependencies": [
+        "src/Htmxor/Endpoints/HtmxorEndpointCandidate.cs"
+      ]
+    },
+    {
       "path": "src/Components/Components/src/RenderTree/Renderer.cs",
       "match": "file",
       "api": "subclass",

--- a/src/Htmxor/Builder/HtmxorComponentEndpointRouteBuilderExtensions.cs
+++ b/src/Htmxor/Builder/HtmxorComponentEndpointRouteBuilderExtensions.cs
@@ -286,7 +286,7 @@ public static class HtmxorComponentEndpointRouteBuilderExtensions
 
 	private static void RequireAntiforgery(EndpointBuilder endpointBuilder)
 	{
-		if (endpointBuilder.Metadata.OfType<IAntiforgeryMetadata>().LastOrDefault()?.RequiresValidation != true)
+		if (!endpointBuilder.Metadata.OfType<IAntiforgeryMetadata>().Any())
 		{
 			endpointBuilder.Metadata.Add(new RequireAntiforgeryTokenAttribute());
 		}
@@ -444,34 +444,44 @@ public static class HtmxorComponentEndpointRouteBuilderExtensions
 		return true;
 	}
 
-	private static async Task<bool> ValidateAntiforgery(HttpContext context)
+	private static Task<bool> ValidateAntiforgery(HttpContext context)
 	{
 		if (context.Features.Get<IAntiforgeryValidationFeature>() is { } validationFeature)
 		{
 			if (!validationFeature.IsValid)
 			{
 				context.Response.StatusCode = StatusCodes.Status400BadRequest;
-				return false;
 			}
+			return Task.FromResult(validationFeature.IsValid);
 		}
-		else
+
+#if NET11_0_OR_GREATER
+		// EndpointMiddleware enforces configured protection; .NET 11 owns the effective verdict and method scope.
+		return Task.FromResult(true);
+#else
+		return context.GetEndpoint()?.Metadata.GetMetadata<IAntiforgeryMetadata>()?.RequiresValidation == false
+			? Task.FromResult(true)
+			: ValidateAntiforgeryToken(context);
+#endif
+	}
+
+#if !NET11_0_OR_GREATER
+	private static async Task<bool> ValidateAntiforgeryToken(HttpContext context)
+	{
+		try
 		{
-			try
-			{
-				// Use one fail-closed path because ASP.NET Core antiforgery middleware skips DELETE.
-				await context.RequestServices
-					.GetRequiredService<IAntiforgery>()
-					.ValidateRequestAsync(context);
-			}
-			catch (AntiforgeryValidationException)
-			{
-				context.Response.StatusCode = StatusCodes.Status400BadRequest;
-				return false;
-			}
+			// Retain the .NET 10 fallback for methods skipped by token middleware, including DELETE.
+			await context.RequestServices.GetRequiredService<IAntiforgery>().ValidateRequestAsync(context);
+		}
+		catch (AntiforgeryValidationException)
+		{
+			context.Response.StatusCode = StatusCodes.Status400BadRequest;
+			return false;
 		}
 
 		return true;
 	}
+#endif
 
 	private static async Task InvokeDirectEndpoint(HttpContext context, RequestDelegate stockRequestDelegate)
 	{

--- a/src/Htmxor/Endpoints/HtmxorComponentActionRequest.cs
+++ b/src/Htmxor/Endpoints/HtmxorComponentActionRequest.cs
@@ -6,6 +6,8 @@ internal sealed class HtmxorComponentActionRequest : IHtmxorGeneratedComponentAc
 {
 	private HtmxorComponentActionDescriptor? activeDescriptor;
 
+	internal bool HasActiveAction => Volatile.Read(ref activeDescriptor) is not null;
+
 	public void Activate(HtmxorComponentActionDescriptor descriptor)
 	{
 		ArgumentNullException.ThrowIfNull(descriptor);

--- a/src/Htmxor/Endpoints/HtmxorEndpointCandidate.cs
+++ b/src/Htmxor/Endpoints/HtmxorEndpointCandidate.cs
@@ -16,10 +16,13 @@
 // https://github.com/dotnet/aspnetcore/blob/v10.0.11/src/Components/Endpoints/src/DependencyInjection/WebAssemblySettingsEmitter.cs
 // https://github.com/dotnet/aspnetcore/blob/a5383385245bdacc20ec19f30e46090a8154d8da/src/Components/Endpoints/src/DependencyInjection/WebAssemblySettingsEmitter.cs
 // Form coordination added for #189; exact dependency inventory: docs/engineering/candidate-form-adapter.md.
+// .NET 11 protection/token timing follows v11.0.0-rc.1.26425.128 at
+// c3325eeb6b47bc6383c127d4f4827dc9642a2b6e, synchronized 2026-09-13; see that inventory.
 // Htmxor upstream dependency: src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs | reimplements
 // Htmxor upstream dependency: src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.cs | reimplements
 // Htmxor upstream dependency: src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.PrerenderingState.cs | reimplements
 // Htmxor upstream dependency: src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Streaming.cs | reimplements
+// Htmxor upstream dependency: src/Shared/MiddlewareInvokedKeys.cs | mirrors
 // Htmxor upstream dependency: src/Components/Endpoints/src/DependencyInjection/RazorComponentsServiceCollectionExtensions.cs | reimplements
 // Issue #184 relationships: reimplements RazorComponentEndpointInvoker, subclasses StaticHtmlRenderer,
 // implements IRazorComponentEndpointInvoker, consumes ComponentState through supported seams, and reimplements
@@ -178,9 +181,7 @@ internal sealed class HtmxorEndpointCandidateInvoker(HtmxorEndpointCandidateRend
 		}
 		if (hasPendingInitialRenderWork ?? !quiesceTask.IsCompleted)
 		{
-			context.Features.GetRequiredFeature<IHttpResponseBodyFeature>().DisableBuffering();
-			antiforgery.GetAndStoreTokens(context);
-			context.Response.Headers.ContentEncoding = "identity";
+			PrepareStreamingResponse(context, antiforgery);
 		}
 		else
 		{
@@ -218,6 +219,18 @@ internal sealed class HtmxorEndpointCandidateInvoker(HtmxorEndpointCandidateRend
 			}
 		}
 		await writer.FlushAsync();
+	}
+
+	private static void PrepareStreamingResponse(HttpContext context, IAntiforgery antiforgery)
+	{
+		context.Features.GetRequiredFeature<IHttpResponseBodyFeature>().DisableBuffering();
+#if NET11_0_OR_GREATER
+		if (context.Items.ContainsKey("__AntiforgeryMiddlewareWithEndpointInvoked"))
+#endif
+		{
+			antiforgery.GetAndStoreTokens(context);
+		}
+		context.Response.Headers.ContentEncoding = "identity";
 	}
 }
 

--- a/src/Htmxor/Endpoints/HtmxorEndpointCandidateFormRequest.cs
+++ b/src/Htmxor/Endpoints/HtmxorEndpointCandidateFormRequest.cs
@@ -3,6 +3,8 @@
 
 // Adapted from ASP.NET Core v10.0.11, commit a5383385245bdacc20ec19f30e46090a8154d8da,
 // synchronized 2026-09-05. Exact sources and license: docs/engineering/candidate-form-adapter.md.
+// .NET 11 validation follows v11.0.0-rc.1.26425.128 at
+// c3325eeb6b47bc6383c127d4f4827dc9642a2b6e, synchronized 2026-09-13; see that inventory.
 // Htmxor upstream dependency: src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs | reimplements
 // Htmxor upstream dependency: src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Streaming.cs | mirrors
 
@@ -26,7 +28,15 @@ internal readonly record struct HtmxorEndpointCandidateFormRequest(
 		HttpContext context, IAntiforgery? antiforgery)
 	{
 		// Exception middleware preserves POST; its error page must not bind or submit the failed form.
-		if (!HttpMethods.IsPost(context.Request.Method) || context.Features.Get<IExceptionHandlerFeature>() is not null)
+		if (!HttpMethods.IsPost(context.Request.Method) ||
+			context.Features.Get<IExceptionHandlerFeature>() is not null)
+		{
+			return new(true, false, null, null);
+		}
+
+		// Activated callbacks need form state when present, but must not also dispatch a named form.
+		var dispatchForm = !context.RequestServices.GetRequiredService<HtmxorComponentActionRequest>().HasActiveAction;
+		if (!dispatchForm && !context.Request.HasFormContentType)
 		{
 			return new(true, false, null, null);
 		}
@@ -37,9 +47,13 @@ internal readonly record struct HtmxorEndpointCandidateFormRequest(
 		}
 
 		// The middleware result is authoritative even when endpoint validation is disabled.
+#if NET11_0_OR_GREATER
+		var valid = context.Features.Get<IAntiforgeryValidationFeature>() is not { IsValid: false };
+#else
 		var valid = context.Features.Get<IAntiforgeryValidationFeature>() is { } validation
 			? validation.IsValid
 			: antiforgery is null || await antiforgery.IsRequestValidAsync(context);
+#endif
 		if (!valid)
 		{
 			return await RejectAsync(context, "A valid antiforgery token was not provided with the request. Add an antiforgery token, or disable antiforgery validation for this endpoint.");
@@ -48,12 +62,12 @@ internal readonly record struct HtmxorEndpointCandidateFormRequest(
 		var form = await context.Request.ReadFormAsync();
 		if (!form.TryGetValue("_handler", out var handler))
 		{
-			return new(true, true, null, form);
+			return new(true, dispatchForm, null, form);
 		}
 
 		if (handler.Count == 1)
 		{
-			return new(true, true, handler[0], form);
+			return new(true, dispatchForm, handler[0], form);
 		}
 
 		context.Response.StatusCode = StatusCodes.Status400BadRequest;

--- a/test/Htmxor.AspNetCore10.Tests/Htmxor.AspNetCore10.Tests.csproj
+++ b/test/Htmxor.AspNetCore10.Tests/Htmxor.AspNetCore10.Tests.csproj
@@ -1,7 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
 	<PropertyGroup>
-		<TargetFramework>net10.0</TargetFramework>
+		<TargetFrameworks>net10.0;net11.0</TargetFrameworks>
+		<RuntimeFrameworkVersion Condition="'$(TargetFramework)' == 'net10.0'">10.0.11</RuntimeFrameworkVersion>
+		<RuntimeFrameworkVersion Condition="'$(TargetFramework)' == 'net11.0'">11.0.0-rc.1.26425.128</RuntimeFrameworkVersion>
+		<RollForward>Disable</RollForward>
+		<AspNetCoreTestVersion Condition="'$(TargetFramework)' == 'net10.0'">10.0.11</AspNetCoreTestVersion>
+		<AspNetCoreTestVersion Condition="'$(TargetFramework)' == 'net11.0'">11.0.0-rc.1.26425.128</AspNetCoreTestVersion>
+		<EnableDefaultRazorComponentItems Condition="'$(TargetFramework)' == 'net11.0'">false</EnableDefaultRazorComponentItems>
 		<CodeMetricsProfile>tests</CodeMetricsProfile>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
@@ -10,10 +16,17 @@
 		<RootNamespace>Htmxor.AspNetCore10</RootNamespace>
 	</PropertyGroup>
 
+	<!-- Existing parity fixtures remain on .NET 10; issue #210 owns the .NET 11 security boundary. -->
+	<ItemGroup Condition="'$(TargetFramework)' == 'net11.0'">
+		<Compile Remove="Issue*.cs" />
+		<Compile Include="Issue210*.cs;Issue83AuthorizationTests.cs" />
+		<RazorComponent Include="Issue210*.razor;Issue78App.razor;Issue83ProtectedPage.razor;_Imports.razor" />
+	</ItemGroup>
+
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.11" />
-		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.11" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="$(AspNetCoreTestVersion)" />
+		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreTestVersion)" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 		<PackageReference Include="xunit" Version="2.8.0" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">

--- a/test/Htmxor.AspNetCore10.Tests/Issue210ActionPage.razor
+++ b/test/Htmxor.AspNetCore10.Tests/Issue210ActionPage.razor
@@ -1,0 +1,36 @@
+@page "/issue-210/actions"
+@using Htmxor
+@using Microsoft.AspNetCore.Components.Forms
+@inject Issue210Probe Probe
+
+<button @onpost="Post" @onput="Put" @onpatch="Patch" @ondelete="Delete">Act</button>
+<AntiforgeryToken />
+<p data-action="@action">@Value</p>
+<p data-callback-value="@callbackValue"></p>
+
+@code {
+    private string action = "none";
+    private string? value;
+    private string? callbackValue;
+
+    [SupplyParameterFromForm]
+    private string? Value
+    {
+        get => value;
+        set { this.value = value; Probe.Binding(); }
+    }
+
+    protected override void OnInitialized() => Probe.Initialize();
+
+    private void Post(HtmxEventArgs _) => Complete("POST");
+    private void Put(HtmxEventArgs _) => Complete("PUT");
+    private void Patch(HtmxEventArgs _) => Complete("PATCH");
+    private void Delete(HtmxEventArgs _) => Complete("DELETE");
+
+    private void Complete(string method)
+    {
+        action = method;
+        callbackValue = Value;
+        Probe.Callback();
+    }
+}

--- a/test/Htmxor.AspNetCore10.Tests/Issue210ActionlessPage.razor
+++ b/test/Htmxor.AspNetCore10.Tests/Issue210ActionlessPage.razor
@@ -1,0 +1,11 @@
+@attribute [Htmxor.HtmxRoute("/issue-210/actionless/{Id:int}", Methods = new[] { "POST", "PUT", "PATCH", "DELETE" })]
+@attribute [Microsoft.AspNetCore.Authorization.Authorize(Policy = "custom")]
+@inject Issue210Probe Probe
+
+<p data-actionless>Rendered</p>
+
+@code {
+    [Parameter] public int Id { get; set; }
+    protected override void OnInitialized() => Probe.Initialize();
+    protected override void OnParametersSet() => Probe.Binding();
+}

--- a/test/Htmxor.AspNetCore10.Tests/Issue210AuthorizationTests.cs
+++ b/test/Htmxor.AspNetCore10.Tests/Issue210AuthorizationTests.cs
@@ -1,0 +1,106 @@
+using System.Net;
+using Microsoft.AspNetCore.Components.Endpoints;
+using Microsoft.AspNetCore.Cors.Infrastructure;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.AspNetCore.Routing;
+
+namespace Htmxor.AspNetCore10;
+
+public sealed class Issue210AuthorizationTests
+{
+	[Theory]
+	[InlineData("actions", false, null, HttpStatusCode.Unauthorized)]
+	[InlineData("form", false, null, HttpStatusCode.Unauthorized)]
+	[InlineData("actions", true, Issue83AuthenticationHandler.ForbiddenUser, HttpStatusCode.Forbidden)]
+	[InlineData("form", true, Issue83AuthenticationHandler.ForbiddenUser, HttpStatusCode.Forbidden)]
+	public async Task Fallback_and_group_custom_requirement_reject_before_application_effects(
+		string page, bool group, string? user, HttpStatusCode expected)
+	{
+		await using var host = await Issue210SecurityHost.StartAsync(groupAuthorization: group);
+		SetUser(host.Client, user);
+		using var request = Issue210SecurityHost.Request("GET", page, direct: page == "actions");
+		request.Headers.Add("Sec-Fetch-Site", "same-origin");
+
+		using var response = await host.Client.SendAsync(request);
+
+		Assert.Equal(expected, response.StatusCode);
+		host.Probe.AssertUntouched();
+	}
+
+	[Theory]
+	[InlineData("actions", false, Issue83AuthenticationHandler.ForbiddenUser)]
+	[InlineData("form", false, Issue83AuthenticationHandler.ForbiddenUser)]
+	[InlineData("actions", true, Issue83AuthenticationHandler.AuthorizedUser)]
+	[InlineData("form", true, Issue83AuthenticationHandler.AuthorizedUser)]
+	public async Task Authorized_user_reaches_ordinary_and_generated_routes_under_effective_policy(
+		string page, bool group, string user)
+	{
+		await using var host = await Issue210SecurityHost.StartAsync(groupAuthorization: group);
+		SetUser(host.Client, user);
+		using var request = Issue210SecurityHost.Request("GET", page, direct: page == "actions");
+
+		using var response = await host.Client.SendAsync(request);
+
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		Assert.Equal(1, host.Probe.Initializations);
+	}
+
+	[Theory]
+	[InlineData("actions", "PUT")]
+	[InlineData("form", "POST")]
+	public async Task Valid_protection_does_not_bypass_group_custom_authorization(string page, string method)
+	{
+		await using var host = await Issue210SecurityHost.StartAsync(groupAuthorization: true);
+		using var request = Issue210SecurityHost.Request(method, page, form: true, direct: page == "actions");
+		await host.AddCredentialsAsync(request);
+		SetUser(host.Client, Issue83AuthenticationHandler.ForbiddenUser);
+		request.Headers.Add("Sec-Fetch-Site", "same-origin");
+
+		using var response = await host.Client.SendAsync(request);
+
+		Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+		host.Probe.AssertUntouched();
+	}
+
+	[Theory]
+	[InlineData("actions", "PUT")]
+	[InlineData("form", "POST")]
+	public async Task Authorized_user_with_valid_protection_runs_the_application_callback(string page, string method)
+	{
+		await using var host = await Issue210SecurityHost.StartAsync(groupAuthorization: true);
+		using var request = Issue210SecurityHost.Request(method, page, form: true, direct: page == "actions");
+		await host.AddCredentialsAsync(request);
+		request.Headers.Add("Sec-Fetch-Site", "same-origin");
+
+		using var response = await host.Client.SendAsync(request);
+
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		Assert.Equal(1, host.Probe.Callbacks);
+	}
+
+	[Theory]
+	[InlineData(typeof(Issue210ActionPage))]
+	[InlineData(typeof(Issue210FormPage))]
+	[InlineData(typeof(Issue210ActionlessPage))]
+	public async Task Group_host_rate_limit_and_cors_metadata_survive_on_component_routes(Type componentType)
+	{
+		await using var host = await Issue210SecurityHost.StartAsync(cors: "trusted", groupAuthorization: true);
+		var endpoints = ((IEndpointRouteBuilder)host.App).DataSources.SelectMany(source => source.Endpoints)
+			.Where(endpoint => endpoint.Metadata.GetMetadata<ComponentTypeMetadata>()?.Type == componentType);
+
+		var endpoint = Assert.Single(endpoints);
+		Assert.Equal("localhost", Assert.Single(endpoint.Metadata.GetRequiredMetadata<IHostMetadata>().Hosts));
+		Assert.Equal("bounded", endpoint.Metadata.GetRequiredMetadata<EnableRateLimitingAttribute>().PolicyName);
+		Assert.Equal("trusted", endpoint.Metadata.GetRequiredMetadata<IEnableCorsAttribute>().PolicyName);
+	}
+
+	private static void SetUser(HttpClient client, string? user)
+	{
+		client.DefaultRequestHeaders.Remove(Issue83AuthenticationHandler.UserHeaderName);
+		if (user is not null)
+		{
+			client.DefaultRequestHeaders.Add(Issue83AuthenticationHandler.UserHeaderName, user);
+		}
+	}
+}

--- a/test/Htmxor.AspNetCore10.Tests/Issue210ExemptFormPage.razor
+++ b/test/Htmxor.AspNetCore10.Tests/Issue210ExemptFormPage.razor
@@ -1,0 +1,4 @@
+@page "/issue-210/exempt-form"
+@attribute [Microsoft.AspNetCore.Antiforgery.RequireAntiforgeryToken(required: false)]
+
+<Issue210FormPage />

--- a/test/Htmxor.AspNetCore10.Tests/Issue210ExemptPage.razor
+++ b/test/Htmxor.AspNetCore10.Tests/Issue210ExemptPage.razor
@@ -1,0 +1,17 @@
+@page "/issue-210/exempt"
+@attribute [Microsoft.AspNetCore.Antiforgery.RequireAntiforgeryToken(required: false)]
+@using Htmxor
+@inject Issue210Probe Probe
+
+<button hx-delete="/issue-210/exempt" @ondelete="Delete">Delete</button>
+<p data-exempt="@completed">Exempt</p>
+
+@code {
+    private bool completed;
+    protected override void OnInitialized() => Probe.Initialize();
+    private void Delete(HtmxEventArgs _)
+    {
+        completed = true;
+        Probe.Callback();
+    }
+}

--- a/test/Htmxor.AspNetCore10.Tests/Issue210FormActionTests.cs
+++ b/test/Htmxor.AspNetCore10.Tests/Issue210FormActionTests.cs
@@ -1,0 +1,39 @@
+using System.Net;
+
+namespace Htmxor.AspNetCore10;
+
+public sealed class Issue210FormActionTests
+{
+	[Theory]
+	[InlineData(true)]
+#if NET11_0_OR_GREATER
+	[InlineData(false)]
+#endif
+	public async Task Accepted_named_form_POST_supplies_submitted_value_to_generated_callback(bool tokens)
+	{
+		await using var host = await Issue210SecurityHost.StartAsync(tokens: tokens);
+		using var request = Issue210SecurityHost.Request("POST");
+		request.Content = new FormUrlEncodedContent(new Dictionary<string, string>
+		{
+			["_handler"] = "save",
+			["Value"] = "submitted",
+		});
+		if (tokens)
+		{
+			await host.AddCredentialsAsync(request);
+			request.Headers.Add("Sec-Fetch-Site", "cross-site");
+			request.Headers.Add("Origin", "https://untrusted.example");
+		}
+		else
+		{
+			request.Headers.Add("Sec-Fetch-Site", "same-origin");
+		}
+
+		using var response = await host.Client.SendAsync(request);
+		var html = await response.Content.ReadAsStringAsync();
+
+		Assert.True(response.StatusCode == HttpStatusCode.OK, html);
+		Assert.Equal(1, host.Probe.Callbacks);
+		Assert.Contains("data-callback-value=\"submitted\"", html, StringComparison.Ordinal);
+	}
+}

--- a/test/Htmxor.AspNetCore10.Tests/Issue210FormPage.razor
+++ b/test/Htmxor.AspNetCore10.Tests/Issue210FormPage.razor
@@ -1,0 +1,30 @@
+@page "/issue-210/form"
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Web
+@inject Issue210Probe Probe
+
+<form method="post" @formname="save" @onsubmit="Save">
+    <AntiforgeryToken />
+    <input name="Value" value="@Value" />
+    <button type="submit">Save</button>
+</form>
+<p data-saved="@saved.ToString()">@Value</p>
+
+@code {
+    private bool saved;
+    private string? value;
+
+    [SupplyParameterFromForm]
+    private string? Value
+    {
+        get => value;
+        set { this.value = value; Probe.Binding(); }
+    }
+
+    protected override void OnInitialized() => Probe.Initialize();
+    private void Save()
+    {
+        saved = true;
+        Probe.Callback();
+    }
+}

--- a/test/Htmxor.AspNetCore10.Tests/Issue210NativeSecurityTests.cs
+++ b/test/Htmxor.AspNetCore10.Tests/Issue210NativeSecurityTests.cs
@@ -1,0 +1,245 @@
+#if NET11_0_OR_GREATER
+using System.Net;
+
+namespace Htmxor.AspNetCore10;
+
+public sealed class Issue210NativeSecurityTests
+{
+	[Theory]
+	[InlineData(false)]
+	[InlineData(true)]
+	public async Task Token_only_configuration_does_not_add_DELETE_token_validation(bool form)
+	{
+		await using var host = await Issue210SecurityHost.StartAsync(disableNative: true);
+		using var request = Issue210SecurityHost.Request("DELETE", form: form);
+
+		using var response = await host.Client.SendAsync(request);
+
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		Assert.Contains("data-action=\"DELETE\"", await response.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+		Assert.Equal(1, host.Probe.Callbacks);
+	}
+
+	[Theory]
+	[InlineData(false)]
+	[InlineData(true)]
+	public async Task Token_middleware_preserves_native_DELETE_allowance_without_a_token(bool form)
+	{
+		await using var host = await Issue210SecurityHost.StartAsync();
+		using var request = Issue210SecurityHost.Request("DELETE", form: form);
+		request.Headers.Add("Sec-Fetch-Site", "same-origin");
+
+		using var response = await host.Client.SendAsync(request);
+
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		Assert.Contains("data-action=\"DELETE\"", await response.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+		Assert.Equal(1, host.Probe.Callbacks);
+	}
+
+	[Theory]
+	[InlineData(false)]
+	[InlineData(true)]
+	public async Task Token_middleware_preserves_native_DELETE_denial_despite_a_valid_token(bool form)
+	{
+		await using var host = await Issue210SecurityHost.StartAsync();
+		using var request = Issue210SecurityHost.Request("DELETE", form: form);
+		await host.AddCredentialsAsync(request);
+		request.Headers.Add("Sec-Fetch-Site", "cross-site");
+		request.Headers.Add("Origin", "https://untrusted.example");
+
+		using var response = await host.Client.SendAsync(request);
+
+		Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+		host.Probe.AssertUntouched();
+	}
+
+	[Fact]
+	public async Task Token_middleware_preserves_native_headerless_DELETE_allowance_on_actionless_routes()
+	{
+		await using var host = await Issue210SecurityHost.StartAsync();
+		using var request = Issue210SecurityHost.Request("DELETE", "actionless", form: true);
+
+		using var response = await host.Client.SendAsync(request);
+
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		Assert.Contains("data-actionless", await response.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+		Assert.Equal(1, host.Probe.Initializations);
+		Assert.Equal(0, host.Probe.Callbacks);
+	}
+
+	[Theory]
+	[MemberData(nameof(Issue210TokenSecurityTests.UnsafeRequests), MemberType = typeof(Issue210TokenSecurityTests))]
+	public async Task Native_same_origin_runs_generated_callbacks_without_tokens(string method, bool form)
+	{
+		await using var host = await Issue210SecurityHost.StartAsync(tokens: false);
+		using var request = Issue210SecurityHost.Request(method, form: form);
+		request.Headers.Add("Sec-Fetch-Site", "same-origin");
+		using var response = await host.Client.SendAsync(request);
+		var html = await response.Content.ReadAsStringAsync();
+		Assert.True(response.StatusCode == HttpStatusCode.OK, html);
+		Assert.Contains($"data-action=\"{method}\"", html, StringComparison.Ordinal);
+		Assert.Equal(1, host.Probe.Callbacks);
+	}
+
+	[Theory]
+	[MemberData(nameof(Issue210TokenSecurityTests.UnsafeRequests), MemberType = typeof(Issue210TokenSecurityTests))]
+	public async Task Native_cross_site_rejects_generated_callbacks_before_application_effects(string method, bool form)
+	{
+		await using var host = await Issue210SecurityHost.StartAsync(tokens: false);
+		using var request = Issue210SecurityHost.Request(method, form: form);
+		request.Headers.Add("Sec-Fetch-Site", "cross-site");
+		using var response = await host.Client.SendAsync(request);
+		Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+		host.Probe.AssertUntouched();
+	}
+
+	[Theory]
+	[InlineData("none", null, null)]
+	[InlineData("cross-site", "https://trusted.example", "trusted")]
+	[InlineData("same-site", "https://trusted.example", "trusted")]
+	[InlineData(null, "http://localhost", null)]
+	[InlineData(null, null, null)]
+	public async Task Native_allowed_headers_and_group_cors_policy_reach_generated_callback(
+		string? fetchSite, string? origin, string? cors)
+	{
+		await using var host = await Issue210SecurityHost.StartAsync(tokens: false, cors: cors);
+		using var request = Issue210SecurityHost.Request("DELETE");
+		AddOriginHeaders(request, fetchSite, origin);
+
+		using var response = await host.Client.SendAsync(request);
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		Assert.Equal(1, host.Probe.Callbacks);
+	}
+
+	[Theory]
+	[InlineData("same-site", null, null)]
+	[InlineData("unexpected", null, null)]
+	[InlineData("cross-site", "https://trusted.example", "wildcard")]
+	[InlineData(null, "https://untrusted.example", null)]
+	[InlineData(null, "null", null)]
+	public async Task Native_denied_headers_and_wildcard_cors_reject_before_application_effects(
+		string? fetchSite, string? origin, string? cors)
+	{
+		await using var host = await Issue210SecurityHost.StartAsync(tokens: false, cors: cors);
+		using var request = Issue210SecurityHost.Request("DELETE");
+		AddOriginHeaders(request, fetchSite, origin);
+
+		using var response = await host.Client.SendAsync(request);
+
+		Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+		host.Probe.AssertUntouched();
+	}
+
+	[Fact]
+	public async Task Native_same_origin_submits_the_ordinary_form_without_a_token()
+	{
+		await using var host = await Issue210SecurityHost.StartAsync(tokens: false);
+		using var request = Issue210SecurityHost.Request("POST", "form", form: true, direct: false);
+		request.Headers.Add("Sec-Fetch-Site", "same-origin");
+
+		using var response = await host.Client.SendAsync(request);
+		var html = await response.Content.ReadAsStringAsync();
+
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		Assert.Contains("data-saved=\"True\">submitted", html, StringComparison.Ordinal);
+		Assert.Equal(1, host.Probe.Callbacks);
+	}
+
+	[Fact]
+	public async Task Native_cross_site_rejects_the_ordinary_form_before_application_effects()
+	{
+		await using var host = await Issue210SecurityHost.StartAsync(tokens: false);
+		using var request = Issue210SecurityHost.Request("POST", "form", form: true, direct: false);
+		request.Headers.Add("Sec-Fetch-Site", "cross-site");
+
+		using var response = await host.Client.SendAsync(request);
+
+		Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+		host.Probe.AssertUntouched();
+	}
+
+	[Theory]
+	[InlineData("POST")]
+	[InlineData("PUT")]
+	[InlineData("PATCH")]
+	[InlineData("DELETE")]
+	public async Task Native_denial_stops_actionless_routes_before_lifecycle(string method)
+	{
+		await using var host = await Issue210SecurityHost.StartAsync(tokens: false);
+		using var request = Issue210SecurityHost.Request(method, "actionless", form: true);
+		request.Headers.Add("Sec-Fetch-Site", "cross-site");
+		using var response = await host.Client.SendAsync(request);
+		Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+		host.Probe.AssertUntouched();
+	}
+
+	[Fact]
+	public async Task Native_opt_out_runs_generated_callback_despite_cross_site_headers()
+	{
+		await using var host = await Issue210SecurityHost.StartAsync(tokens: false);
+		using var request = Issue210SecurityHost.Request("DELETE", "exempt");
+		request.Headers.Add("Sec-Fetch-Site", "cross-site");
+		using var response = await host.Client.SendAsync(request);
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		Assert.Equal(1, host.Probe.Callbacks);
+	}
+
+	[Fact]
+	public async Task Native_protection_on_actionless_POST_reaches_named_form_dispatch()
+	{
+		await using var host = await Issue210SecurityHost.StartAsync(tokens: false);
+		using var request = Issue210SecurityHost.Request("POST", "actionless", form: true);
+		request.Headers.Add("Sec-Fetch-Site", "same-origin");
+
+		using var response = await host.Client.SendAsync(request);
+
+		Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+		Assert.Contains("does not specify which form is being submitted", await response.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+		Assert.Equal((1, 1, 0), (host.Probe.Bindings, host.Probe.Initializations, host.Probe.Callbacks));
+	}
+
+	[Theory]
+	[InlineData(false)]
+	[InlineData(true)]
+	public async Task Native_rendering_does_not_issue_an_unused_antiforgery_cookie(bool direct)
+	{
+		await using var host = await Issue210SecurityHost.StartAsync(tokens: false);
+		using var request = Issue210SecurityHost.Request("GET", "form", direct: direct);
+		using var response = await host.Client.SendAsync(request);
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		Assert.False(response.Headers.Contains("Set-Cookie"));
+		Assert.DoesNotContain("__RequestVerificationToken", await response.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+	}
+
+	[Theory]
+	[InlineData(false, false)]
+	[InlineData(true, false)]
+	[InlineData(false, true)]
+	[InlineData(true, true)]
+	public async Task Streaming_token_issuance_matches_the_configured_stock_pipeline(bool htmxor, bool tokens)
+	{
+		await using var host = await Issue210SecurityHost.StartAsync(tokens: tokens, htmxor: htmxor, groupPrefix: "");
+		using var request = Issue210SecurityHost.Request("GET", "streaming", direct: false);
+		request.RequestUri = new Uri("/issue-210/streaming", UriKind.Relative);
+		using var response = await host.Client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead).WaitAsync(TimeSpan.FromSeconds(20));
+		host.StreamGate.Completion.TrySetResult();
+		var html = await response.Content.ReadAsStringAsync();
+		Assert.True(response.StatusCode == HttpStatusCode.OK, html);
+		Assert.Contains("data-stream=\"complete\"", html, StringComparison.Ordinal);
+		Assert.Equal(tokens, response.Headers.Contains("Set-Cookie"));
+	}
+
+	private static void AddOriginHeaders(HttpRequestMessage request, string? fetchSite, string? origin)
+	{
+		if (fetchSite is not null)
+		{
+			request.Headers.Add("Sec-Fetch-Site", fetchSite);
+		}
+
+		if (origin is not null)
+		{
+			request.Headers.Add("Origin", origin);
+		}
+	}
+}
+#endif

--- a/test/Htmxor.AspNetCore10.Tests/Issue210SecurityHost.cs
+++ b/test/Htmxor.AspNetCore10.Tests/Issue210SecurityHost.cs
@@ -1,0 +1,185 @@
+using System.Net;
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Htmxor.AspNetCore10;
+
+internal sealed class Issue210SecurityHost(WebApplication app, HttpClient client) : IAsyncDisposable
+{
+	public WebApplication App { get; } = app;
+	public HttpClient Client { get; } = client;
+	public Issue210Probe Probe => App.Services.GetRequiredService<Issue210Probe>();
+	public Issue210StreamGate StreamGate => App.Services.GetRequiredService<Issue210StreamGate>();
+
+	public static async Task<Issue210SecurityHost> StartAsync(
+		bool tokens = true,
+		bool disableNative = false,
+		string? cors = null,
+		bool groupAuthorization = false,
+		bool htmxor = true,
+		string groupPrefix = "/group")
+	{
+		var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+		{
+			ApplicationName = typeof(Issue210SecurityHost).Assembly.GetName().Name,
+			EnvironmentName = Environments.Development,
+		});
+		builder.Configuration["DisableCsrfProtection"] = disableNative.ToString();
+		builder.WebHost.UseTestServer();
+		builder.Logging.ClearProviders();
+		ConfigureServices(builder.Services, htmxor);
+		var app = builder.Build();
+		app.UseRouting();
+		app.UseCors();
+		app.UseAuthentication();
+		app.UseAuthorization();
+		app.UseRateLimiter();
+		if (tokens)
+		{
+			app.UseAntiforgery();
+		}
+
+		var group = app.MapGroup(groupPrefix).RequireHost("localhost").RequireRateLimiting("bounded");
+		if (cors is not null)
+		{
+			group.RequireCors(cors);
+		}
+
+		if (groupAuthorization)
+		{
+			group.RequireAuthorization("custom");
+		}
+
+		var components = group.MapRazorComponents<Issue78App>();
+		if (htmxor)
+		{
+			components.AddHtmxorEndpoints();
+		}
+
+		await app.StartAsync();
+		var client = app.GetTestClient();
+		client.DefaultRequestHeaders.Add(Issue83AuthenticationHandler.UserHeaderName, Issue83AuthenticationHandler.AuthorizedUser);
+		return new(app, client);
+	}
+
+	private static void ConfigureServices(IServiceCollection services, bool htmxor)
+	{
+		services.AddDataProtection().UseEphemeralDataProtectionProvider();
+		services.AddAuthentication(Issue83AuthenticationHandler.SchemeName)
+			.AddScheme<AuthenticationSchemeOptions, Issue83AuthenticationHandler>(Issue83AuthenticationHandler.SchemeName, _ => { });
+		services.AddAuthorization(options =>
+		{
+			options.FallbackPolicy = new AuthorizationPolicyBuilder().RequireAuthenticatedUser().Build();
+			options.AddPolicy("custom", policy => policy.RequireAuthenticatedUser().AddRequirements(new Issue210Requirement()));
+		});
+		services.AddSingleton<IAuthorizationHandler, Issue210RequirementHandler>();
+		services.AddCors(options =>
+		{
+			options.AddPolicy("trusted", policy => policy.WithOrigins("https://trusted.example").AllowAnyMethod().AllowAnyHeader());
+			options.AddPolicy("wildcard", policy => policy.AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader());
+		});
+		services.AddRateLimiter(options => options.AddFixedWindowLimiter("bounded", limiter =>
+		{
+			limiter.PermitLimit = 100;
+			limiter.Window = TimeSpan.FromMinutes(1);
+		}));
+		var components = services.AddRazorComponents();
+		if (htmxor)
+		{
+			components.AddHtmxor();
+		}
+
+		services.AddSingleton<Issue210Probe>();
+		services.AddSingleton<Issue210StreamGate>();
+	}
+
+	public static HttpRequestMessage Request(string method, string page = "actions", bool form = false, bool direct = true)
+	{
+		var path = page == "actionless" ? "actionless/1" : page;
+		var request = new HttpRequestMessage(new HttpMethod(method), $"/group/issue-210/{path}");
+		if (direct)
+		{
+			request.Headers.Add("HX-Request", "true");
+			request.Headers.Add("HX-Request-Type", "partial");
+		}
+
+		if (form)
+		{
+			var fields = new Dictionary<string, string>
+			{
+				["Value"] = "submitted",
+			};
+			if (page.EndsWith("form", StringComparison.Ordinal))
+			{
+				fields["_handler"] = "save";
+			}
+
+			request.Content = new FormUrlEncodedContent(fields);
+		}
+
+		return request;
+	}
+
+	public async Task AddCredentialsAsync(HttpRequestMessage request)
+	{
+		using var get = Request("GET", "form", direct: false);
+		using var response = await Client.SendAsync(get);
+		var html = await response.Content.ReadAsStringAsync();
+		Assert.True(response.StatusCode == HttpStatusCode.OK, html);
+		var match = Regex.Match(html, "name=\"__RequestVerificationToken\" value=\"([^\"]+)\"", RegexOptions.CultureInvariant);
+		Assert.True(match.Success, html);
+		request.Headers.Add("RequestVerificationToken", WebUtility.HtmlDecode(match.Groups[1].Value));
+		request.Headers.Add("Cookie", Assert.Single(response.Headers.GetValues("Set-Cookie"),
+			value => value.StartsWith(".AspNetCore.Antiforgery.", StringComparison.Ordinal)).Split(';', 2)[0]);
+		Probe.Reset();
+	}
+
+	public async ValueTask DisposeAsync()
+	{
+		StreamGate.Completion.TrySetResult();
+		Client.Dispose();
+		await App.DisposeAsync();
+	}
+}
+
+internal sealed class Issue210Probe
+{
+	public int Bindings { get; private set; }
+	public int Initializations { get; private set; }
+	public int Callbacks { get; private set; }
+	public void Binding() => Bindings++;
+	public void Initialize() => Initializations++;
+	public void Callback() => Callbacks++;
+	public void Reset() => (Bindings, Initializations, Callbacks) = (0, 0, 0);
+	public void AssertUntouched() => Assert.Equal((0, 0, 0), (Bindings, Initializations, Callbacks));
+}
+
+internal sealed class Issue210StreamGate
+{
+	public TaskCompletionSource Completion { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+}
+
+internal sealed class Issue210Requirement : IAuthorizationRequirement;
+
+internal sealed class Issue210RequirementHandler : AuthorizationHandler<Issue210Requirement>
+{
+	protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, Issue210Requirement requirement)
+	{
+		if (context.User.HasClaim("issue-83-access", "granted"))
+		{
+			context.Succeed(requirement);
+		}
+
+		return Task.CompletedTask;
+	}
+}

--- a/test/Htmxor.AspNetCore10.Tests/Issue210StreamingPage.razor
+++ b/test/Htmxor.AspNetCore10.Tests/Issue210StreamingPage.razor
@@ -1,0 +1,14 @@
+@page "/issue-210/streaming"
+@attribute [StreamRendering]
+@inject Issue210StreamGate Gate
+
+<p data-stream="@state">Streaming</p>
+
+@code {
+    private string state = "initial";
+    protected override async Task OnInitializedAsync()
+    {
+        await Gate.Completion.Task.WaitAsync(TimeSpan.FromSeconds(20));
+        state = "complete";
+    }
+}

--- a/test/Htmxor.AspNetCore10.Tests/Issue210TokenSecurityTests.cs
+++ b/test/Htmxor.AspNetCore10.Tests/Issue210TokenSecurityTests.cs
@@ -1,0 +1,188 @@
+using System.Net;
+
+namespace Htmxor.AspNetCore10;
+
+public sealed class Issue210TokenSecurityTests
+{
+	public static TheoryData<string, bool> UnsafeRequests => new()
+	{
+		{ "POST", false }, { "POST", true },
+		{ "PUT", false }, { "PUT", true },
+		{ "PATCH", false }, { "PATCH", true },
+		{ "DELETE", false }, { "DELETE", true },
+	};
+
+	public static TheoryData<string, bool> TokenValidatedRequests => new()
+	{
+		{ "POST", false }, { "POST", true },
+		{ "PUT", false }, { "PUT", true },
+		{ "PATCH", false }, { "PATCH", true },
+#if !NET11_0_OR_GREATER
+		{ "DELETE", false }, { "DELETE", true },
+#endif
+	};
+
+	[Theory]
+	[MemberData(nameof(TokenValidatedRequests))]
+	public async Task Valid_token_runs_the_generated_callback_even_with_cross_site_headers(string method, bool form)
+	{
+		await using var host = await Issue210SecurityHost.StartAsync();
+		using var request = Issue210SecurityHost.Request(method, form: form);
+		await host.AddCredentialsAsync(request);
+		request.Headers.Add("Sec-Fetch-Site", "cross-site");
+		request.Headers.Add("Origin", "https://untrusted.example");
+
+		using var response = await host.Client.SendAsync(request);
+		var html = await response.Content.ReadAsStringAsync();
+
+		Assert.True(response.StatusCode == HttpStatusCode.OK, html);
+		Assert.Contains($"data-action=\"{method}\"", html, StringComparison.Ordinal);
+		Assert.Equal(1, host.Probe.Callbacks);
+	}
+
+	[Theory]
+	[MemberData(nameof(TokenValidatedRequests))]
+	public async Task Missing_token_rejects_before_application_effects_even_for_same_origin(string method, bool form)
+	{
+		await using var host = await Issue210SecurityHost.StartAsync();
+		using var request = Issue210SecurityHost.Request(method, form: form);
+		request.Headers.Add("Sec-Fetch-Site", "same-origin");
+
+		using var response = await host.Client.SendAsync(request);
+
+		Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+		host.Probe.AssertUntouched();
+	}
+
+	[Fact]
+	public async Task Valid_token_submits_the_ordinary_form()
+	{
+		await using var host = await Issue210SecurityHost.StartAsync();
+		using var request = Issue210SecurityHost.Request("POST", "form", form: true, direct: false);
+		await host.AddCredentialsAsync(request);
+
+		using var response = await host.Client.SendAsync(request);
+		var html = await response.Content.ReadAsStringAsync();
+
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		Assert.Contains("data-saved=\"True\">submitted", html, StringComparison.Ordinal);
+		Assert.Equal(1, host.Probe.Callbacks);
+	}
+
+	[Fact]
+	public async Task Missing_token_rejects_the_ordinary_form_before_application_effects()
+	{
+		await using var host = await Issue210SecurityHost.StartAsync();
+		using var request = Issue210SecurityHost.Request("POST", "form", form: true, direct: false);
+
+		using var response = await host.Client.SendAsync(request);
+
+		Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+		host.Probe.AssertUntouched();
+	}
+
+	[Theory]
+	[InlineData("POST")]
+	[InlineData("PUT")]
+	[InlineData("PATCH")]
+#if !NET11_0_OR_GREATER
+	[InlineData("DELETE")]
+#endif
+	public async Task Actionless_unsafe_route_rejects_missing_token_before_lifecycle(string method)
+	{
+		await using var host = await Issue210SecurityHost.StartAsync();
+		using var request = Issue210SecurityHost.Request(method, "actionless", form: true);
+		using var response = await host.Client.SendAsync(request);
+		Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+		host.Probe.AssertUntouched();
+	}
+
+	[Theory]
+	[InlineData(true)]
+	[InlineData(false)]
+	public async Task Explicit_opt_out_allows_generated_callback_without_a_token(bool tokens)
+	{
+		await using var host = await Issue210SecurityHost.StartAsync(tokens: tokens, disableNative: !tokens);
+		using var request = Issue210SecurityHost.Request("DELETE", "exempt");
+		request.Headers.Add("Sec-Fetch-Site", "cross-site");
+		using var response = await host.Client.SendAsync(request);
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		Assert.Equal(1, host.Probe.Callbacks);
+	}
+
+	[Theory]
+	[InlineData(true)]
+	[InlineData(false)]
+	public async Task Ordinary_form_opt_out_preserves_application_choice(bool tokens)
+	{
+		await using var host = await Issue210SecurityHost.StartAsync(tokens: tokens);
+		using var request = Issue210SecurityHost.Request("POST", "exempt-form", form: true, direct: false);
+		request.Headers.Add("Sec-Fetch-Site", "cross-site");
+		using var response = await host.Client.SendAsync(request);
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		Assert.Equal(1, host.Probe.Callbacks);
+	}
+
+	[Theory]
+	[InlineData("POST")]
+	[InlineData("PUT")]
+	[InlineData("PATCH")]
+	public async Task Corrupted_token_rejects_before_binding_lifecycle_or_callback(string method)
+	{
+		await using var host = await Issue210SecurityHost.StartAsync();
+		using var request = Issue210SecurityHost.Request(method, form: true);
+		await host.AddCredentialsAsync(request);
+		request.Headers.Remove("RequestVerificationToken");
+		request.Headers.Add("RequestVerificationToken", "corrupted");
+		request.Headers.Add("Sec-Fetch-Site", "same-origin");
+		using var response = await host.Client.SendAsync(request);
+		Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+		host.Probe.AssertUntouched();
+	}
+
+	[Theory]
+	[InlineData("PUT")]
+	[InlineData("PATCH")]
+	[InlineData("DELETE")]
+	public async Task Valid_protection_renders_actionless_unsafe_routes(string method)
+	{
+		await using var host = await Issue210SecurityHost.StartAsync();
+		using var request = Issue210SecurityHost.Request(method, "actionless", form: true);
+		await host.AddCredentialsAsync(request);
+		request.Headers.Add("Sec-Fetch-Site", "same-origin");
+		using var response = await host.Client.SendAsync(request);
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		Assert.Contains("data-actionless", await response.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+		Assert.Equal(1, host.Probe.Initializations);
+		Assert.Equal(0, host.Probe.Callbacks);
+	}
+
+	[Fact]
+	public async Task Valid_token_on_actionless_POST_reaches_named_form_dispatch()
+	{
+		await using var host = await Issue210SecurityHost.StartAsync();
+		using var request = Issue210SecurityHost.Request("POST", "actionless", form: true);
+		await host.AddCredentialsAsync(request);
+		request.Headers.Add("Sec-Fetch-Site", "cross-site");
+
+		using var response = await host.Client.SendAsync(request);
+
+		Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+		Assert.Contains("does not specify which form is being submitted", await response.Content.ReadAsStringAsync(), StringComparison.Ordinal);
+		Assert.Equal((1, 1, 0), (host.Probe.Bindings, host.Probe.Initializations, host.Probe.Callbacks));
+	}
+
+	[Theory]
+	[InlineData("actions", "DELETE", false)]
+	[InlineData("actionless", "PUT", true)]
+	[InlineData("form", "POST", true)]
+	public async Task Missing_protection_middleware_is_a_configuration_failure_before_effects(string page, string method, bool form)
+	{
+		await using var host = await Issue210SecurityHost.StartAsync(tokens: false, disableNative: true);
+		using var request = Issue210SecurityHost.Request(method, page, form, direct: page != "form");
+		using var response = await host.Client.SendAsync(request);
+		Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+		Assert.Contains("antiforgery", await response.Content.ReadAsStringAsync(), StringComparison.OrdinalIgnoreCase);
+		host.Probe.AssertUntouched();
+	}
+}

--- a/test/Htmxor.Quality.Tests/UpstreamMonitorPolicyTests.cs
+++ b/test/Htmxor.Quality.Tests/UpstreamMonitorPolicyTests.cs
@@ -107,6 +107,7 @@ public sealed class UpstreamMonitorPolicyTests
 				"src/Shared/Components/PrerenderComponentApplicationStore.cs|file|none|reimplements|src/Htmxor/Endpoints/HtmxorEndpointCandidateStateStore.cs",
 				"src/Shared/Components/ProtectedPrerenderComponentApplicationStore.cs|file|none|reimplements|src/Htmxor/Endpoints/HtmxorEndpointCandidateStateStore.cs",
 				"src/Shared/Components/ServerComponentSerializer.cs|file|none|reimplements|src/Htmxor/Endpoints/HtmxorEndpointCandidateRenderModeBoundary.cs",
+				"src/Shared/MiddlewareInvokedKeys.cs|file|none|mirrors|src/Htmxor/Endpoints/HtmxorEndpointCandidate.cs",
 			],
 			ProjectWatches(manifest, root));
 	}

--- a/test/Htmxor.Tests/Builder/HtmxorAttributedRouteCatalogTests.cs
+++ b/test/Htmxor.Tests/Builder/HtmxorAttributedRouteCatalogTests.cs
@@ -449,7 +449,7 @@ public sealed class HtmxorAttributedRouteCatalogTests
 	}
 
 	[Fact]
-	public async Task Unsafe_generated_route_requires_effective_antiforgery_after_prior_disabling_metadata()
+	public async Task Unsafe_generated_route_preserves_effective_antiforgery_opt_out()
 	{
 		await using var app = CreateApplication(out var group, out _, out _);
 		var descriptor = new HtmxorComponentRouteDescriptor(
@@ -464,7 +464,7 @@ public sealed class HtmxorAttributedRouteCatalogTests
 		group.MapHtmxorComponentEndpoint(descriptor, []);
 
 		var endpoint = Assert.Single(GetGeneratedEndpoints(app));
-		Assert.True(endpoint.Metadata.GetRequiredMetadata<IAntiforgeryMetadata>().RequiresValidation);
+		Assert.False(endpoint.Metadata.GetRequiredMetadata<IAntiforgeryMetadata>().RequiresValidation);
 	}
 
 	[Fact]


### PR DESCRIPTION
Closes #210. Parent: #207.

## Behavior

When an application configures ASP.NET Core CSRF or token antiforgery protection, Htmxor honors the framework's effective validation result and rejects invalid unsafe requests before binding, lifecycle work or callbacks.

- Honor effective framework verdicts and metadata opt-outs; preserve validated generated POST callback dispatch and submitted form state.
- Align .NET 11 streaming token generation with configured token middleware and monitor the exact mirrored framework invocation key.
- Preserve the user-approved .NET 11 DELETE verdict without an independent Htmxor token fallback; retain .NET 10 fallback behavior.
- Document that token middleware automatically validates POST/PUT/PATCH only, and applications requiring DELETE token validation must explicitly configure or perform it.

No new Htmxor security mode, origin policy, application authoring API, static callback model or private-access expansion.

## Verification

Candidate: `2e41bf6d28deba410b2329efb21db6b743d5e0bb`; base: `66d9b90b300d121e591b684fb058e79e312cffbd`.

- Meaningful red: 4 of 51 .NET 10 and 10 of 93 .NET 11 security cases failed before repair. All now pass.
- A local Standards finding additionally exposed three valid POST callbacks losing submitted values. A real hosted regression reached200/count1 but failed captured value, then passed after separating form initialization from named-submit dispatch. Focused matrix now52/.NET 10 and95/.NET 11.
- Final unique full hosted runs: 182/.NET 10 and99/.NET 11 passed.
- Repository `fast` and `full` profiles passed, including Release warnings-as-errors, analyzer/style checks, ordinary browser/package checks and fresh coverage. Retained profile counts: fast316 upstream +164 quality +182 hosted +413 Htmxor; full316 +165 +182 +415. Independent unique TRX preserves .NET 11 hosted results omitted by the profile's shared-filename overwrite.
- Assertion sensitivity:609 intended failures across17 original families, all restored green; additional actionless POST assertions and approved expectation corrections have retained independent failure evidence. Four new callback-value checks add12 decisive failures, each restored52/95 green. No Stryker run (0 mutants).
- Coverage characterization:3463/4673 lines and1746/2673 branches in net10 Htmxor.Tests, not coverage of the separate hosted security matrix or a security score.

Exact commands, counts, hashes and retained failure provenance are in the owning worktree's `artifacts/reviews/issue-210/complete-change/2e41bf6d28deba410b2329efb21db6b743d5e0bb/verification.md`; durable final verification checkpoint: https://github.com/egil/Htmxor/issues/210#issuecomment-5650312724.

Fresh independent complete-change review is clean on this exact candidate: Standards0 findings, Spec0 findings. Prior submitted-form-state finding is accepted and resolved, with immutable red/repair/sensitivity/disposition evidence retained.

## Limits

Two isolated diagnostic failures remain disclosed: one unrelated500 during a temporary assertion-inversion run and one existing Issue189 empty-invoker observation in an initial broad run. Neither reproduced in its bounded follow-up or subsequent required gates; original reports are retained and neither cause is claimed fixed.

Evidence uses Ubuntu26.04 x64, SDK11.0.100-rc.1.26425.128 and pinned runtimes10.0.11/11.0.0-rc.1.26425.128. Ordinary browser checks use cached Playwright Chromium and htmx4.0.0. Native/token browser-origin and credential transport security remain #211; other OS, deployment proxies, external identity providers and .NET11 GA are not proved here. No deployment, release or package publication is authorized by this PR.
